### PR TITLE
Load keys

### DIFF
--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -38,8 +38,11 @@ container_commands:
   07_elastic_search_mapping:
     command: "bin/create-mapping-on-deploy production.ini --app-name app &> /var/log/create_mapping.log"
     leader_only: true
-  09_load_dummy_data:
+  08_load_dummy_data:
     command: "bin/load-data production.ini --app-name app --access-key s3 --drop-db-on-mt  >> /var/log/deploy.log"
+    leader_only: true
+  09_load_access_keys:
+    command: "bin/load-access-keys production.ini --app-name app >> /var/log/deploy.log"
     leader_only: true
 
 option_settings:

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -39,7 +39,7 @@ container_commands:
     command: "bin/create-mapping-on-deploy production.ini --app-name app &> /var/log/create_mapping.log"
     leader_only: true
   08_load_dummy_data:
-    command: "bin/load-data production.ini --app-name app --access-key s3 --drop-db-on-mt  >> /var/log/deploy.log"
+    command: "bin/load-data production.ini --app-name app --drop-db-on-mt  >> /var/log/deploy.log"
     leader_only: true
   09_load_access_keys:
     command: "bin/load-access-keys production.ini --app-name app >> /var/log/deploy.log"

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -30,8 +30,8 @@ auto-checkout = snovault
 		dcicutils
 
 [sources]
-snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.2.1
-dcicutils = git https://github.com/4dn-dcic/utils.git rev=0.7.7
+snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.2.3
+dcicutils = git https://github.com/4dn-dcic/utils.git rev=0.8.1
 jsonschema = git https://github.com/4dn-dcic/jsonschema_serialize_fork.git
 rubygemsrecipe = hg https://bitbucket.org/lrowe/rubygemsrecipe
 subprocess_middleware = git https://github.com/4dn-dcic/subprocess_middleware.git

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         migrate-attachments-aws = encoded.commands.migrate_attachments_aws:main
         migrate-dataset-type = encoded.commands.migrate_dataset_type:main
         load-data = encoded.commands.load_data:main
+        load-access-keys = encoded.commands.load_access_keys:main
         dropdb = encoded.commands.dropdb:main
         verify-item = encoded.commands.verify_item:main
         clone-beanstalk = encoded.commands.clone_beanstalk_env:main

--- a/src/encoded/commands/load_access_keys.py
+++ b/src/encoded/commands/load_access_keys.py
@@ -1,0 +1,132 @@
+import argparse
+import logging
+import structlog
+import json
+import os
+import boto3
+from pyramid.paster import get_app
+from webtest import TestApp
+from dcicutils.beanstalk_utils import get_beanstalk_real_url
+
+log = structlog.getLogger(__name__)
+EPILOG = __doc__
+
+
+def get_existing_key_ids(testapp, user_uuid, key_desc):
+    """
+    Search for an access key with given description and user uuid.
+    If successful return list of @id values of all found access keys.
+    This is expected to fail if the current server is not up.
+    Logs information on errors.
+
+    Args:
+        testapp (webtest.TestApp): current TestApp
+        user_uuid (str): uuid of the user used to generate the key
+        key_desc (str): description of the access key to find
+
+    Return:
+        list: of str access keys ids
+    """
+    try:
+        search_res = testapp.get('/search/?type=AccessKey&description=%s&user.uuid=%s'
+                                 % (key_desc, user_uuid)).json
+    except Exception as exc:
+        log.error('load_access_keys: search failed for access key with desc'
+                  ' %s. Exception: %s' % (key_desc, exc))
+        return []
+    if len(search_res['@graph']) > 1:
+        log.warning('load_access_keys: %s access keys found with '
+                    'description %s and user.uuid %s.'
+                    % (len(search_res['@graph']), key_name, user_uuid))
+    return [res['@id'] for res in search_res['@graph']]
+
+
+def generate_access_key(testapp, env, user_uuid, description):
+    """
+    Generate an access key for given user on given environment.
+
+    Args:
+        testapp (webtest.TestApp): current TestApp
+        env (str): application environment used to find server
+        user_uuid (str): uuid of the user to gener
+        description (str): description to add to access key
+
+    Returns:
+        dict: access key contents with server
+    """
+    server = get_beanstalk_real_url(env)
+    access_key_req = {'user': user_uuid, 'description': description}
+    res = testapp.post_json('/access_key', access_key_req).json
+    return {'secret': res['secret_access_key'],
+            'key': res['access_key_id'],
+            'server': server}
+
+
+def main():
+    """
+    Function to create and load access keys for multiple users to the system s3
+    bucket. The description of the key is set to the s3 object name. Before
+    creating the keys, will attempt to delete pre-existing keys with the given
+    descriptions. This command is not meant to be run locally.
+
+    Provide required `config_uri` and `--app-name` to the command.
+    Example usage:
+    `bin/load_access_keys production.ini --app-name app`
+    """
+    logging.basicConfig()
+    # Loading app will have configured from config file. Reconfigure here:
+    logging.getLogger('encoded').setLevel(logging.INFO)
+
+    parser = argparse.ArgumentParser(
+        description="Load Access Keys", epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('config_uri', help='path to configfile')
+    parser.add_argument('--app-name', help='Pyramid app name in configfile')
+    args = parser.parse_args()
+
+    app = get_app(args.config_uri, args.app_name)
+    environ = {
+        'HTTP_ACCEPT': 'application/json',
+        'REMOTE_USER': 'TEST',
+    }
+    testapp = TestApp(app, environ)
+
+    env = app.registry.settings.get('env.name')
+    if not env:
+        raise RuntimeError('load_access_keys: cannot find env.name in settings')
+
+    encrypt_key = os.environ.get('S3_ENCRYPT_KEY')
+    if not encrypt_key:
+        raise RuntimeError('load_access_keys: must define S3_ENCRYPT_KEY in env')
+
+    # will need to use a dynamic region at some point (not just here)
+    s3 = boto3.client('s3', region_name='us-east-1')
+    s3_bucket = app.registry.settings['system_bucket']
+
+    # we generate keys for the following accounts w/ corresponding descriptions
+    to_generate = [('cgap.platform@gmail.com', 'access_key_admin'),
+                   ('tibanna.app@gmail.com', 'access_key_tibanna'),
+                   ('foursight.app@gmail.com', 'access_key_foursight')]
+    for email, key_name in to_generate:
+        try:
+            user_props = testapp.get('/users/%s?datastore=database' % (email)).follow().json
+        except Exception as exc:
+            log.error('load_access_keys: could not get user %s. Exception: %s' % (email, exc))
+            continue
+
+        key_ids = get_existing_key_ids(testapp,  user_props['uuid'], key_name)
+        for key_id in key_ids:
+            testapp.patch_json(key_id, {'status': 'deleted'})
+
+        key = generate_access_key(testapp, env, user_props['uuid'], key_name)
+        s3.put_object(Bucket=s3_bucket,
+                      Key=key_name,
+                      Body=json.dumps(key),
+                      SSECustomerKey=encrypt_key,
+                      SSECustomerAlgorithm='AES256')
+        log.info('load_access_keys: successfully generated access key %s' % key_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/encoded/commands/load_data.py
+++ b/src/encoded/commands/load_data.py
@@ -20,8 +20,6 @@ def main():
     )
     parser.add_argument('--app-name', help="Pyramid app name in configfile")
     parser.add_argument('config_uri', help="path to configfile")
-    parser.add_argument('--access-key', default='s3',
-                        help="store local or copy to s3, will generate and store access key for admin user")
     parser.add_argument('--drop-db-on-mt', action='store_true',  help="path to configfile")
     parser.add_argument('--prod', action='store_true',
                         help="must be set to run on webprod/webprod2")
@@ -49,7 +47,7 @@ def main():
         log.info('load_data: skipping, since we are on webprod/webprod2 and --prod not used')
         return
 
-    load_test_data(app, args.access_key, clear_tables, args.overwrite)
+    load_test_data(app, clear_tables, args.overwrite)
 
 if __name__ == "__main__":
     main()

--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -2,8 +2,6 @@
 """Load collections and determine the order."""
 import mimetypes
 import structlog
-import os.path
-import boto3
 import magic
 import json
 import os
@@ -439,76 +437,12 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
     return None
 
 
-def generate_access_key(testapp, store_access_key, email='cgap.platform@gmail.com'):
-    # get admin user and generate access keys
-    if store_access_key:
-        # we probably don't have elasticsearch index updated yet
-        admin = testapp.get('/users/%s?datastore=database' % (email)).follow().json
-
-        access_key_req = {
-            'user': admin['@id'],
-            'description': 'key for submit4dn',
-        }
-        res = testapp.post_json('/access_key', access_key_req).json
-        if store_access_key == 'local':
-            # for local storing we always connecting to local server
-            server = 'http://localhost:8000'
-        else:
-            health = testapp.get('/health?format=json').json
-            env = health.get('beanstalk_env')
-            server = get_beanstalk_real_url(env)
-            print("server is %s" % server)
-
-        akey = {'default':
-                {'secret': res['secret_access_key'],
-                 'key': res['access_key_id'],
-                 'server': server,
-                 }
-                }
-        return json.dumps(akey)
-
-
-def store_keys(app, store_access_key, keys, s3_file_name='illnevertell'):
-        if (not keys):
-            return
-        # write to ~/keypairs.json
-        if store_access_key == 'local':
-            home_dir = os.path.expanduser('~')
-            keypairs_filename = os.path.join(home_dir, 'keypairs.json')
-
-            print("Storing access keys to %s", keypairs_filename)
-            with open(keypairs_filename, 'w') as keypairs:
-                    # write to file for local
-                    keypairs.write(keys)
-
-        elif store_access_key == 's3':
-            # if access_key_loc == 's3', always generate new keys
-            s3bucket = app.registry.settings['system_bucket']
-            secret = os.environ.get('AWS_SECRET_KEY')
-            if not secret:
-                print("no secrets for s3 upload, you probably shouldn't be doing"
-                      "this from your local machine")
-                print("halt and catch fire")
-                return
-
-            s3 = boto3.client('s3', region_name='us-east-1')
-            secret = secret[:32]
-
-            print("Uploading S3 object with SSE-C")
-            s3.put_object(Bucket=s3bucket,
-                          Key=s3_file_name,
-                          Body=keys,
-                          SSECustomerKey=secret,
-                          SSECustomerAlgorithm='AES256')
-
-
-def load_data(app, access_key_loc=None, indir='inserts', docsdir=None,
-              clear_tables=False, overwrite=False, use_master_inserts=True):
+def load_data(app, indir='inserts', docsdir=None, clear_tables=False,
+              overwrite=False, use_master_inserts=True):
     '''
     This function will take the inserts folder as input, and place them to the given environment.
     args:
         app:
-        access_key_loc (None):
         indir (inserts): inserts folder, should be relative to tests/data/
         docsdir (None): folder with attachment documents, relative to tests/data
         clear_tables (False): Not sure- clear existing database before loading inserts
@@ -561,23 +495,21 @@ def load_data(app, access_key_loc=None, indir='inserts', docsdir=None,
         print(LOAD_ERROR_MESSAGE)
         logger.error('load_data: failed to load from %s' % docsdir, error=res)
         return res
-    keys = generate_access_key(testapp, access_key_loc)
-    store_keys(app, access_key_loc, keys)
     return None  # unnecessary, but makes it more clear that no error was encountered
 
 
-def load_test_data(app, access_key_loc=None, clear_tables=False, overwrite=False):
+def load_test_data(app, clear_tables=False, overwrite=False):
     """
     Load inserts and master-inserts
 
     Returns:
         None if successful, otherwise Exception encountered
     """
-    return load_data(app, access_key_loc, docsdir='documents', indir='inserts',
+    return load_data(app, docsdir='documents', indir='inserts',
                      clear_tables=clear_tables, overwrite=overwrite)
 
 
-def load_local_data(app, access_key_loc=None, clear_tables=False, overwrite=False):
+def load_local_data(app, clear_tables=False, overwrite=False):
     """
     Load temp-local-inserts. If not present, load inserts and master-inserts
 
@@ -592,19 +524,19 @@ def load_local_data(app, access_key_loc=None, clear_tables=False, overwrite=Fals
         use_temp_local = any([fn for fn in filenames if fn.endswith('.json')])
 
     if use_temp_local:
-        return load_data(app, access_key_loc, docsdir='documents', indir='temp-local-inserts',
+        return load_data(app, docsdir='documents', indir='temp-local-inserts',
                          clear_tables=clear_tables, use_master_inserts=False, overwrite=overwrite)
     else:
-        return load_data(app, access_key_loc, docsdir='documents', indir='inserts',
+        return load_data(app, docsdir='documents', indir='inserts',
                          clear_tables=clear_tables, overwrite=overwrite)
 
 
-def load_prod_data(app, access_key_loc=None, clear_tables=False, overwrite=False):
+def load_prod_data(app, clear_tables=False, overwrite=False):
     """
     Load master-inserts
 
     Returns:
         None if successful, otherwise Exception encountered
     """
-    return load_data(app, access_key_loc, indir='master-inserts',
-                     clear_tables=clear_tables, overwrite=overwrite)
+    return load_data(app, indir='master-inserts', clear_tables=clear_tables,
+                     overwrite=overwrite)

--- a/src/encoded/schemas/disorder.json
+++ b/src/encoded/schemas/disorder.json
@@ -76,8 +76,8 @@
                         "type": "string",
                         "linkTo": "Phenotype"
                     },
-                    "sex": {
-                        "title": "SEX",
+                    "affected_sex": {
+                        "title": "Affected Sex",
                         "description": "Used if the annotation in question is limited to males or females. This field refers to the phenotypic (and not the chromosomal) sex",
                         "type": "string",
                         "enum": ["M", "F"]
@@ -90,21 +90,12 @@
                     },
                     "aspect": {
                         "title": "Aspect",
-                        "description": "one of P (Phenotypic abnormality), I (inheritance), C (onset and clinical course).",
+                        "description": "one of P (Phenotypic abnormality), I (inheritance), C (onset and clinical course) or M (modifier).",
                         "type": "string",
-                        "enum": ["phenotypic abnormality", "inheritance", "onset and clinical course"]
+                        "enum": ["P", "I", "C", "M"]
                     },
-                    "date_curated": {
-                       "title": "Date added",
-                       "description": "The date YYYY-MM-DD that the association was made",
-                       "type": "string",
-                       "anyOf": [
-                           {"format": "date-time"},
-                           {"format": "date"}
-                       ]
-                    },
-                    "curated_by": {
-                        "title": "Curated by",
+                    "curattion_history": {
+                        "title": "Curation History",
                         "description": "History of curation with format 'HPO:Joseph[2012-07-05];HPO:Suzanna[2015-12-07]'",
                         "type": "string"
                     }

--- a/src/encoded/tests/test_load_access_key.py
+++ b/src/encoded/tests/test_load_access_key.py
@@ -1,0 +1,16 @@
+import pytest
+from unittest import mock
+from encoded.commands.load_access_keys import generate_access_key
+
+pytestmark = [pytest.mark.setone, pytest.mark.working]
+
+# TODO: test load_access_keys.get_existing_key_ids, which would use ES
+
+def test_gen_access_keys(testapp, admin):
+    with mock.patch('encoded.commands.load_access_keys.get_beanstalk_real_url') as mocked_url:
+        mocked_url.return_value = 'http://fourfront-hotseat'
+        res = generate_access_key(testapp, 'test_env', admin['uuid'], 'test_desc')
+        assert res['server'] == 'http://fourfront-hotseat'
+        assert res['secret']
+        assert res['key']
+        assert mocked_url.called_once()


### PR DESCRIPTION
Small PR that does the following:
- Add `load_access_keys` command and use it as part of the elasticbeanstalk deployment (tested + working)
- Revise loadxl to no longer handle access keys
- Test tweaks
- Incorporate one extra commit from a merged branch, `pheno2dis`