### PR TITLE
Health page

### DIFF
--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -209,7 +209,7 @@ def main(global_config, **local_config):
     settings['g.recaptcha.key'] = os.environ.get('reCaptchaKey')
     settings['g.recaptcha.secret'] = os.environ.get('reCaptchaSecret')
     # set mirrored Elasticsearch location (for webprod/webprod2)
-    settings['mirror.env.es'] = os.environ.get('mirrorEnvEs')
+    settings['mirror.env.name'] = os.environ.get('mirrorEnvEs')
     config = Configurator(settings=settings)
 
     from snovault.elasticsearch import APP_FACTORY

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -209,7 +209,7 @@ def main(global_config, **local_config):
     settings['g.recaptcha.key'] = os.environ.get('reCaptchaKey')
     settings['g.recaptcha.secret'] = os.environ.get('reCaptchaSecret')
     # set mirrored Elasticsearch location (for webprod/webprod2)
-    settings['mirror.env.name'] = os.environ.get('mirrorEnvEs')
+    settings['mirror.env.name'] = os.environ.get('MIRROR_ENV_NAME')
     config = Configurator(settings=settings)
 
     from snovault.elasticsearch import APP_FACTORY

--- a/src/encoded/root.py
+++ b/src/encoded/root.py
@@ -129,6 +129,7 @@ def health_check(config):
             "database": settings.get('sqlalchemy.url').split('@')[1],  # don't show user /password
             "load_data": settings.get('load_test_data'),
             "beanstalk_env": settings.get('env.name'),
+            "namespace": settings.get('indexer.namespace'),
             "@type": ["Health", "Portal"],
             "@context": "/health",
             "@id": "/health",

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -43,6 +43,7 @@ _app_settings = {
     'production': True,
     'pyramid.debug_authorization': True,
     'postgresql.statement_timeout': 20,
+    'sqlalchemy.url': 'dummy@dummy',
     'retry.attempts': 3,
     # some file specific stuff for testing
     'file_upload_bucket': 'test-wfout-bucket',

--- a/src/encoded/tests/test_views.py
+++ b/src/encoded/tests/test_views.py
@@ -62,6 +62,16 @@ def test_vary_json(anontestapp):
     assert 'Accept' in res.vary
 
 
+def test_get_health_page(testapp):
+    """
+    Tests that we can get the health page and various fields we expect are there
+    """
+    res = testapp.get('/health', status=200).json
+    assert 'namespace' in res
+    assert 'blob_bucket' in res
+    assert 'elasticsearch' in res
+
+
 @pytest.mark.parametrize('item_type', [k for k in TYPE_LENGTH if k not in ['user', 'access_key']])
 def test_collections_anon(anontestapp, item_type):
     res = anontestapp.get('/' + item_type).follow(status=200)


### PR DESCRIPTION
- Add `indexer.namespace` option to the health page under `namespace`
- Change `mirror.env.es` to `mirror.env.name`, since now we can acquire the ES endpoint and the namespace from the health page