### PR TITLE
Add missing data to cohort table; remove variant column

### DIFF
--- a/src/encoded/static/components/item-pages/CohortView/CohortSummaryTable.js
+++ b/src/encoded/static/components/item-pages/CohortView/CohortSummaryTable.js
@@ -6,6 +6,7 @@ import memoize from 'memoize-one';
 import _ from 'underscore';
 import { Schemas } from './../../util';
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
+import { flattenSchemaPropertyToColumnDefinition } from '@hms-dbmi-bgm/shared-portal-components/src/components/util/schema-transforms';
 
 
 /** @param {Object} props - Contents of a family sub-embedded object. */
@@ -34,7 +35,6 @@ export const CohortSummaryTable = React.memo(function CohortSummaryTable(props){
         "rawFiles",
         "processingType",
         "processedFiles",
-        "variants"
     ];
 
     const columnTitles = {
@@ -52,7 +52,7 @@ export const CohortSummaryTable = React.memo(function CohortSummaryTable(props){
         ),
         'visitInfo' : (
             <React.Fragment>
-                <i className="icon icon-fw icon-clinic-medical fas mr-05 align-middle"/>
+                <i className="icon icon-fw icon-notes-medical fas mr-05 align-middle"/>
                 Visit Info
             </React.Fragment>
         ),
@@ -71,12 +71,6 @@ export const CohortSummaryTable = React.memo(function CohortSummaryTable(props){
                 Processed File(s)
             </React.Fragment>
         ),
-        'variants' : (
-            <React.Fragment>
-                <i className="icon icon-fw icon-file-upload fas align-middle" />
-                <span className="d-none d-lg-inline ml-05">Variants (single)</span>
-            </React.Fragment>
-        )
     };
 
 
@@ -223,8 +217,12 @@ export const CohortSummaryTable = React.memo(function CohortSummaryTable(props){
                 error: sampleErr = null,
                 files = [],
                 processed_files = [],
+                protocol,
                 status: sampleStatus,
                 specimen_type: sampleInfo = null,
+                specimen_collection_date = null,
+                specimen_notes = null,
+                workup_type
             } = sample;
 
             if (!sampleTitle || !sampleID){
@@ -258,7 +256,16 @@ export const CohortSummaryTable = React.memo(function CohortSummaryTable(props){
                             <i className="item-status-indicator-dot mr-05" data-status={sampleStatus}/>
                             { Schemas.Term.toName("status", sampleStatus) }
                         </span>
-                    )
+                    ),
+                    visitInfo: (
+                        specimen_collection_date ?
+                            <span> { specimen_collection_date } { specimen_notes ?
+                                <i className="icon icon-faw far icon-clipboard text-primary" data-tip={ specimen_notes }/>
+                                : "" }
+                            </span>: null
+                    ),
+                    processingType: protocol,
+                    workupType: workup_type
                 });
             }
             sampleGroup++;

--- a/src/encoded/static/components/item-pages/CohortView/CohortSummaryTable.js
+++ b/src/encoded/static/components/item-pages/CohortView/CohortSummaryTable.js
@@ -217,7 +217,7 @@ export const CohortSummaryTable = React.memo(function CohortSummaryTable(props){
                 error: sampleErr = null,
                 files = [],
                 processed_files = [],
-                protocol,
+                completed_processes = [],
                 status: sampleStatus,
                 specimen_type: sampleInfo = null,
                 specimen_collection_date = null,
@@ -264,7 +264,7 @@ export const CohortSummaryTable = React.memo(function CohortSummaryTable(props){
                                 : "" }
                             </span>: null
                     ),
-                    processingType: protocol,
+                    processingType: completed_processes[0] || null,
                     workupType: workup_type
                 });
             }

--- a/src/encoded/static/components/item-pages/CohortView/CohortSummaryTable.js
+++ b/src/encoded/static/components/item-pages/CohortView/CohortSummaryTable.js
@@ -6,7 +6,6 @@ import memoize from 'memoize-one';
 import _ from 'underscore';
 import { Schemas } from './../../util';
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
-import { flattenSchemaPropertyToColumnDefinition } from '@hms-dbmi-bgm/shared-portal-components/src/components/util/schema-transforms';
 
 
 /** @param {Object} props - Contents of a family sub-embedded object. */

--- a/src/encoded/types/cohort.py
+++ b/src/encoded/types/cohort.py
@@ -61,7 +61,6 @@ class Cohort(Item):
         "families.members.samples.specimen_notes",
         "families.members.samples.specimen_collection_date",
         "families.members.samples.workup_type",
-        "families.members.samples.protocol",
         "families.members.samples.processed_files",
         "families.members.samples.processed_files.workflow_run_outputs",
         "families.members.samples.processed_files.quality_metric",

--- a/src/encoded/types/cohort.py
+++ b/src/encoded/types/cohort.py
@@ -58,6 +58,10 @@ class Cohort(Item):
         "families.members.phenotypic_features.onset_age_units",
         "families.members.samples.status",
         "families.members.samples.specimen_type",
+        "families.members.samples.specimen_notes",
+        "families.members.samples.specimen_collection_date",
+        "families.members.samples.workup_type",
+        "families.members.samples.protocol",
         "families.members.samples.processed_files",
         "families.members.samples.processed_files.workflow_run_outputs",
         "families.members.samples.processed_files.quality_metric",
@@ -75,7 +79,8 @@ class Cohort(Item):
         "families.members.samples.files.quality_metric.qc_list.value.status",
         "families.members.samples.files.quality_metric.overall_quality_status",
         "families.members.samples.files.quality_metric.url",
-        "families.members.samples.files.quality_metric.status"
+        "families.members.samples.files.quality_metric.status",
+        "families.members.samples.completed_processes"
     ]
 
     @calculated_property(schema={


### PR DESCRIPTION
Columns updated to take advantage of new schemas:
- workup_type
- specimen_notes (w/specimen_collection_date)
- completed_processes (processing type is just the first item in this array)

Pretty light changes for demo. Wanted to add a fixed-width to the Individual column to keep them aligned regardless of current family selection... haven't gotten around to it.