### PR TITLE
Snovault 1.3.5 Compatibility

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -30,7 +30,7 @@ auto-checkout = snovault
 		dcicutils
 
 [sources]
-snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.3.4
+snovault = git https://github.com/4dn-dcic/snovault.git rev=keys
 dcicutils = git https://github.com/4dn-dcic/utils.git rev=0.8.1
 jsonschema = git https://github.com/4dn-dcic/jsonschema_serialize_fork.git
 subprocess_middleware = git https://github.com/4dn-dcic/subprocess_middleware.git

--- a/src/encoded/tests/testing_views.py
+++ b/src/encoded/tests/testing_views.py
@@ -75,7 +75,7 @@ class TestingDownload(ItemWithAttachment):
         'title': 'Test keys',
         'description': 'Testing. Testing. 1, 2, 3.',
     },
-    unique_key='testing_accession',
+    traversal_key='testing_accession',
 )
 class TestingKey(Item):
     item_type = 'testing_key'
@@ -94,7 +94,7 @@ class TestingKey(Item):
     }
 
 
-@collection('testing-link-sources', unique_key='testing_link_sources:name')
+@collection('testing-link-sources', traversal_key='testing_link_sources:name')
 class TestingLinkSource(Item):
     item_type = 'testing_link_source'
     schema = {
@@ -120,7 +120,7 @@ class TestingLinkSource(Item):
     }
 
 
-@collection('testing-link-targets', unique_key='testing_link_target:name')
+@collection('testing-link-targets', traversal_key='testing_link_target:name')
 class TestingLinkTarget(Item):
     item_type = 'testing_link_target'
     name_key = 'name'

--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -31,7 +31,7 @@ def includeme(config):
 
 @collection(
     name='individuals',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Individuals',
         'description': 'Listing of Individuals',
@@ -97,7 +97,7 @@ class Individual(Item):
 
 @collection(
     name='samples',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Samples',
         'description': 'Listing of Samples',
@@ -125,7 +125,7 @@ class SampleProcessing(Item):
 
 @collection(
     name='disorders',
-    unique_key='disorder:disorder_id',
+    traversal_key='disorder:disorder_id',
     properties={
         'title': 'Disorders',
         'description': 'Listing of Disorders',
@@ -151,7 +151,7 @@ class Disorder(Item):
 
 @collection(
     name='genes',
-    unique_key='gene:gene_id',
+    traversal_key='gene:gene_id',
     lookup_key='preferred_symbol',
     properties={
         'title': 'Genes',
@@ -202,7 +202,7 @@ class Document(ItemWithAttachment, Item):
 
 @collection(
     name='file-formats',
-    unique_key='file_format:file_format',
+    traversal_key='file_format:file_format',
     lookup_key='file_format',
     properties={
         'title': 'File Formats',

--- a/src/encoded/types/access_key.py
+++ b/src/encoded/types/access_key.py
@@ -33,7 +33,7 @@ from snovault.validators import (
 
 @collection(
     name='access-keys',
-    unique_key='access_key:access_key_id',
+    traversal_key='access_key:access_key_id',
     properties={
         'title': 'Access keys',
         'description': 'Programmatic access keys',

--- a/src/encoded/types/cohort.py
+++ b/src/encoded/types/cohort.py
@@ -22,7 +22,7 @@ log = structlog.getLogger(__name__)
 
 @collection(
     name='cohorts',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Cohorts',
         'description': 'Listing of Cohorts',

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -142,7 +142,7 @@ def property_closure(request, propname, root_uuid):
 
 @abstract_collection(
     name='files',
-    unique_key='accession',
+    traversal_key='accession',
     acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': 'Files',
@@ -478,7 +478,7 @@ class File(Item):
 
 @collection(
     name='files-fastq',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'FASTQ Files',
         'description': 'Listing of FASTQ Files',
@@ -528,7 +528,7 @@ class FileFastq(File):
 
 @collection(
     name='files-processed',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Processed Files',
         'description': 'Listing of Processed Files',
@@ -593,7 +593,7 @@ class FileProcessed(File):
 
 @collection(
     name='files-reference',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Reference Files',
         'description': 'Listing of Reference Files',

--- a/src/encoded/types/image.py
+++ b/src/encoded/types/image.py
@@ -13,7 +13,7 @@ from snovault.attachment import ItemWithAttachment
 
 @collection(
     name='images',
-    unique_key='image:filename',
+    traversal_key='image:filename',
     properties={
         'title': 'Image',
         'description': 'Listing of portal images',

--- a/src/encoded/types/institution.py
+++ b/src/encoded/types/institution.py
@@ -41,7 +41,7 @@ ALLOW_EVERYONE_VIEW_AND_SUBMITTER_EDIT = [
 
 @collection(
     name='institutions',
-    unique_key='institution:name',
+    traversal_key='institution:name',
     properties={
         'title': 'Institutions',
         'description': 'Listing of Institutions',

--- a/src/encoded/types/phenotype.py
+++ b/src/encoded/types/phenotype.py
@@ -11,7 +11,7 @@ from .base import (
 
 @collection(
     name='phenotypes',
-    unique_key='phenotype:hpo_id',
+    traversal_key='phenotype:hpo_id',
     lookup_key='phenotype_name',
     properties={
         'title': 'Phenotypes',

--- a/src/encoded/types/project.py
+++ b/src/encoded/types/project.py
@@ -20,7 +20,7 @@ import re
 
 @collection(
     name='projects',
-    unique_key='project:name',
+    traversal_key='project:name',
     properties={
         'title': 'Projects',
         'description': 'Listing of projects',

--- a/src/encoded/types/user.py
+++ b/src/encoded/types/user.py
@@ -58,7 +58,7 @@ USER_DELETED = [
 
 @collection(
     name='users',
-    unique_key='user:email',
+    traversal_key='user:email',
     properties={
         'title': '4D Nucleome Users',
         'description': 'Listing of current 4D Nucleome DCIC users',

--- a/src/encoded/types/user_content.py
+++ b/src/encoded/types/user_content.py
@@ -21,7 +21,7 @@ import requests
 
 @abstract_collection(
     name='user-contents',
-    unique_key='user_content:name',
+    traversal_key='user_content:name',
     properties={
         'title': "User Content Listing",
         'description': 'Listing of all types of content which may be created by people.',
@@ -92,7 +92,7 @@ class UserContent(Item):
 
 @collection(
     name='static-sections',
-    unique_key='user_content:name',
+    traversal_key='user_content:name',
     properties={
         'title': 'Static Sections',
         'description': 'Static Sections for the Portal',


### PR DESCRIPTION
- Snovault 1.3.5 renames the collection decorator argument unique_key to traversal_key
- This change must be propagated across all item types in CGAP to be compatible.