### PR TITLE
Es item -- CGAP. NOT READY

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -30,7 +30,7 @@ auto-checkout = snovault
 		dcicutils
 
 [sources]
-snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.3.5
+snovault = git https://github.com/4dn-dcic/snovault.git rev=es_item
 dcicutils = git https://github.com/4dn-dcic/utils.git rev=0.8.1
 jsonschema = git https://github.com/4dn-dcic/jsonschema_serialize_fork.git
 subprocess_middleware = git https://github.com/4dn-dcic/subprocess_middleware.git

--- a/src/encoded/dev_servers.py
+++ b/src/encoded/dev_servers.py
@@ -105,16 +105,21 @@ def main():
 
     app = get_app(args.config_uri, args.app_name)
 
+    # clear queues and initialize indices before loading data. No indexing yet.
+    # this is needed for items with properties stored in ES
     if args.init:
-        create_mapping.run(app, check_first=False, purge_queue=True)
+        create_mapping.run(app, skip_indexing=True, purge_queue=True)
 
-    if args.load:
+    if args.init and args.load:
         from pyramid.path import DottedNameResolver
         load_test_data = app.registry.settings.get('load_test_data')
         load_test_data = DottedNameResolver().resolve(load_test_data)
         load_res = load_test_data(app)
         if load_res:  # None if successful
             raise(load_res)
+
+        # now clear the queues and queue items for indexing
+        create_mapping.run(app, check_first=True, strict=True, purge_queue=True)
 
     print('Started. ^C to exit.')
 

--- a/src/encoded/dev_servers.py
+++ b/src/encoded/dev_servers.py
@@ -105,6 +105,9 @@ def main():
 
     app = get_app(args.config_uri, args.app_name)
 
+    if args.init:
+        create_mapping.run(app, check_first=False, purge_queue=True)
+
     if args.load:
         from pyramid.path import DottedNameResolver
         load_test_data = app.registry.settings.get('load_test_data')
@@ -112,9 +115,6 @@ def main():
         load_res = load_test_data(app)
         if load_res:  # None if successful
             raise(load_res)
-
-    if args.init:
-        create_mapping.run(app, check_first=False, purge_queue=True)
 
     print('Started. ^C to exit.')
 

--- a/src/encoded/root.py
+++ b/src/encoded/root.py
@@ -39,63 +39,29 @@ def item_counts(config):
         response = request.response
         response.content_type = 'application/json; charset=utf-8'
 
-        # how much stuff in database
         db_total = 0
-
-        # how much stuff in elasticsearch (among ALL indexes)
-        es = request.registry['elasticsearch']
         es_total = 0
-        # find db and es counts for each index
-        db_es_counts = OrderedDict()
+        # find db and es counts for each item type
         db_es_compare = OrderedDict()
-        es_counts = {} # keyed by uppercase Item name, such as "ExperimentHic"
-        # need to search for statuses that are hidden from search (deleted, replaced)
-        search_req = make_search_subreq(request, '/search/?type=Item&type=TrackingItem&limit=0')
-        search_resp = request.invoke_subrequest(search_req, True)
-        if search_resp.status_int < 400: # catch errors
-            es_count_facets = [facet for facet in search_resp.json.get('facets', []) if facet.get('field') == 'type']
-            if len(es_count_facets) > 0:
-                es_count_facets = es_count_facets[0]
-                for term in es_count_facets.get('terms'):
-                    es_counts[term['key']] = term['doc_count']
-        search_req_del = make_search_subreq(request, '/search/?type=Item&type=TrackingItem&limit=0&status=replaced&status=deleted')
-        search_resp_del = request.invoke_subrequest(search_req_del, True)
-        if search_resp_del.status_int < 400: # catch errors
-            es_count_facets = [facet for facet in search_resp_del.json.get('facets', []) if facet.get('field') == 'type']
-            if len(es_count_facets) > 0:
-                es_count_facets = es_count_facets[0]
-                for term in es_count_facets.get('terms'):
-                    if term['key'] in es_counts:
-                        es_counts[term['key']] += term['doc_count']
-                    else:
-                        es_counts[term['key']] = term['doc_count']
-        # must do this in two steps: get all ES counts and then subtract
-        # counts from child subtypes, if applicable
         for item_type in request.registry[COLLECTIONS].by_item_type:
             # use the write (DB) storage with only the specific item_type
+            # need to count items with props in ES differently
             db_count = request.registry[STORAGE].write.__len__(item_type)
+            es_count = request.registry[STORAGE].read.__len__(item_type)
+            db_total += db_count
+            es_total += es_count
+            warn_str = build_warn_string(db_count, es_count)
             item_name = request.registry[COLLECTIONS][item_type].type_info.name
-            es_count = es_counts.get(item_name, 0)
-            db_es_counts[item_type] = [db_count, es_count] # order is important
-        for item_type in db_es_counts:
-            item_db_count, item_es_count = db_es_counts[item_type]
-            # check to see if this collection contains child collections
-            other_types = find_collection_subtypes(request.registry, item_type)
-            for sub_type in [other for other in other_types if other != item_type]:
-                item_es_count -= db_es_counts[sub_type][1]
-            db_total += item_db_count
-            es_total += item_es_count
-            warn_str = build_warn_string(item_db_count, item_es_count)
-            db_es_compare[item_type] = ("DB: %s   ES: %s %s" %
-                                         (str(item_db_count), str(item_es_count), warn_str))
+            db_es_compare[item_name] = ("DB: %s   ES: %s %s" %
+                                         (str(db_count), str(es_count), warn_str))
         warn_str = build_warn_string(db_total, es_total)
         db_es_total = ("DB: %s   ES: %s %s" %
                        (str(db_total), str(es_total), warn_str))
         responseDict = {
+            'title': 'Item Counts',
             'db_es_total': db_es_total,
             'db_es_compare': db_es_compare
         }
-
         return responseDict
 
     config.add_view(counts_view, route_name='item-counts')

--- a/src/encoded/tests/data/README.md
+++ b/src/encoded/tests/data/README.md
@@ -66,7 +66,7 @@ Minimal set of inserts used with performance tests that are run with `pytest -m 
 Pared-down set of inserts used with a number of tests, namely those that leverage Elasticsearch to test indexing and searching. They are loaded by tests that use the workbook feature:
 
 ```
-from .features.conftest import workbook
+from .workbook_fixtures import workbook
 ```
 
 Never loaded into fourfront environments.

--- a/src/encoded/tests/test_aggregation.py
+++ b/src/encoded/tests/test_aggregation.py
@@ -1,5 +1,5 @@
 import pytest
-from .features.conftest import app_settings, workbook
+from .workbook_fixtures import app_settings, workbook
 
 # XXX: All need refactor
 pytestmark = [pytest.mark.working, pytest.mark.indexing]

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -1,5 +1,5 @@
 # Use workbook fixture from BDD tests (including elasticsearch)
-from .features.conftest import app_settings, app, workbook
+from .workbook_fixtures import app_settings, app, workbook
 import pytest
 pytestmark = [pytest.mark.indexing]
 

--- a/src/encoded/tests/test_post_put_patch.py
+++ b/src/encoded/tests/test_post_put_patch.py
@@ -174,29 +174,40 @@ def test_put_object_not_touching_children(content_with_child, testapp):
 
 
 def test_put_object_editing_child_does_not_work(content_with_child, testapp):
+    """
+    This will not post a rev link, since editing children through reverse links
+    is no longer done and linkFrom is removed.
+    """
     edit = {
         'reverse': [{
             '@id': content_with_child['child'],
             'status': 'released',
         }]
     }
-    testapp.put_json(content_with_child['@id'], edit, status=200)
-    res = testapp.get(content_with_child['child'] + '?frame=embedded')
-    assert 'status' not in res.json
+    # cannot submit 'reverse' calc property
+    res = testapp.put_json(content_with_child['@id'], edit, status=422).json
+    assert len(res['errors']) ==1
+    assert res['errors'][0]['description'] == 'submission of calculatedProperty disallowed'
+    assert res['errors'][0]['name'] == 'Schema: reverse'
+
+    get_res = testapp.get(content_with_child['child'] + '?frame=embedded').json
+    assert 'status' not in get_res
 
 
 def test_post_object_with_child(content_with_child, testapp):
     """
     This will not post a rev link, since editing children through reverse links
-    is no longer done
+    is no longer done  and linkFrom is removed.
     """
     edit = {
         'reverse': [
             {'status': 'released'}
         ]
     }
-    res = testapp.post_json('/testing-link-targets', edit, status=201)
-    assert len(res.json['@graph'][0]['reverse']) == 0
+    res = testapp.post_json('/testing-link-targets', edit, status=422).json
+    assert len(res['errors']) ==1
+    assert res['errors'][0]['description'] == 'submission of calculatedProperty disallowed'
+    assert res['errors'][0]['name'] == 'Schema: reverse'
 
 
 def test_retry(testapp):

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -1,5 +1,5 @@
 # Use workbook fixture from BDD tests (including elasticsearch)
-from .features.conftest import app_settings, app, workbook
+from .workbook_fixtures import app_settings, app, workbook
 import pytest
 from encoded.commands.run_upgrader_on_inserts import get_inserts
 from snovault.elasticsearch.indexer_utils import get_namespaced_index

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -5,7 +5,7 @@ from encoded.commands.run_upgrader_on_inserts import get_inserts
 from snovault.elasticsearch.indexer_utils import get_namespaced_index
 import json
 import time
-from snovault import TYPES
+from snovault import TYPES, COLLECTIONS
 pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing]
 
 
@@ -451,8 +451,6 @@ def test_search_multiple_types(workbook, testapp):
 ## Tests for collections (search 301s) ##
 #########################################
 
-from .test_views import TYPE_LENGTH
-
 def test_collection_limit(workbook, testapp):
     res = testapp.get('/user/?limit=1', status=301)
     assert len(res.follow().json['@graph']) == 1
@@ -471,50 +469,50 @@ def test_index_data_workbook(app, workbook, testapp, indexer_testapp, htmltestap
     from snovault.elasticsearch import create_mapping
     es = app.registry['elasticsearch']
     # we need to reindex the collections to make sure numbers are correct
-    # TODO: NAMESPACE - here, passed in list to create_mapping
-    # turn of logging for a bit
     create_mapping.run(app, sync_index=True)
     # check counts and ensure they're equal
     testapp_counts = testapp.get('/counts')
-    total_counts = testapp_counts.json['db_es_total']
-    split_counts = total_counts.split()  # 2nd item is db counts, 4th is es
-    assert(int(split_counts[1]) == int(split_counts[3]))
-    for item_type in TYPE_LENGTH.keys():
-        tries = 0
-        item_len = None
+    split_counts = testapp_counts.json['db_es_total'].split()
+    assert(int(split_counts[1]) == int(split_counts[3]))  # 2nd is db, 4th is es
+    for item_name, item_counts in testapp_counts.json['db_es_compare'].items():
+        # make sure counts for each item match ES counts
+        split_item_counts = item_counts.split()
+        db_item_count = int(split_item_counts[1])
+        es_item_count = int(split_item_counts[3])
+        assert db_item_count == es_item_count
+
+        # check ES counts directly. Must skip abstract collections
+        # must change counts result ("ItemName") to item_type format
+        item_type = app.registry[COLLECTIONS][item_name].type_info.item_type
         namespaced_index = get_namespaced_index(app, item_type)
-        while item_len is None or (item_len != TYPE_LENGTH[item_type] and tries < 3):
-            if item_len != None:
-                create_mapping.run(app, collections=[item_type], strict=True, sync_index=True)
-                es.indices.refresh(index=namespaced_index)
-            item_len = es.count(index=namespaced_index, doc_type=item_type).get('count')
-            print('... ES COUNT: %s' % item_len)
-            print('... TYPE COUNT: %s' % TYPE_LENGTH[item_type])
-            tries += 1
-        assert item_len == TYPE_LENGTH[item_type]
-        if item_len > 0:
-            res = testapp.get('/%s?limit=all' % item_type, status=[200, 301, 404])
-            res = res.follow()
-            for item_res in res.json.get('@graph', []):
-                index_view_res = es.get(index=namespaced_index, doc_type=item_type,
-                                        id=item_res['uuid'])['_source']
-                # make sure that the linked_uuids match the embedded data
-                assert 'linked_uuids_embedded' in index_view_res
-                assert 'embedded' in index_view_res
-                found_uuids = recursively_find_uuids(index_view_res['embedded'], set())
-                # all found uuids must be within the linked_uuids
-                assert found_uuids <= set([link['uuid'] for link in index_view_res['linked_uuids_embedded']])
-                # if uuids_rev_linking to me, make sure they show up in @@links
-                if len(index_view_res.get('uuids_rev_linked_to_me', [])) > 0:
-                    links_res = testapp.get('/' + item_res['uuid'] + '/@@links', status=200)
-                    link_uuids = [lnk['uuid'] for lnk in links_res.json.get('uuids_linking_to')]
-                    assert set(index_view_res['uuids_rev_linked_to_me']) <= set(link_uuids)
-                # previously test_html_pages
-                try:
-                    html_res = htmltestapp.get(item_res['@id'])
-                    assert html_res.body.startswith(b'<!DOCTYPE html>')
-                except Exception as e:
-                    pass
+
+        es_direct_count = es.count(index=namespaced_index, doc_type=item_type).get('count')
+        assert es_item_count == es_direct_count
+
+        if es_item_count == 0:
+            continue
+        # check items in search result individually
+        res = testapp.get('/%s?limit=all' % item_type, status=[200, 301]).follow()
+        for item_res in res.json.get('@graph', []):
+            index_view_res = es.get(index=namespaced_index, doc_type=item_type,
+                                    id=item_res['uuid'])['_source']
+            # make sure that the linked_uuids match the embedded data
+            assert 'linked_uuids_embedded' in index_view_res
+            assert 'embedded' in index_view_res
+            found_uuids = recursively_find_uuids(index_view_res['embedded'], set())
+            # all found uuids must be within the linked_uuids
+            assert found_uuids <= set([link['uuid'] for link in index_view_res['linked_uuids_embedded']])
+            # if uuids_rev_linking to me, make sure they show up in @@links
+            if len(index_view_res.get('uuids_rev_linked_to_me', [])) > 0:
+                links_res = testapp.get('/' + item_res['uuid'] + '/@@links', status=200)
+                link_uuids = [lnk['uuid'] for lnk in links_res.json.get('uuids_linking_to')]
+                assert set(index_view_res['uuids_rev_linked_to_me']) <= set(link_uuids)
+            # previously test_html_pages
+            try:
+                html_res = htmltestapp.get(item_res['@id'])
+                assert html_res.body.startswith(b'<!DOCTYPE html>')
+            except Exception as e:
+                pass
 
 
 ######################################

--- a/src/encoded/tests/test_static_page.py
+++ b/src/encoded/tests/test_static_page.py
@@ -1,6 +1,6 @@
 import pytest
 import time
-from .features.conftest import app_settings, app, teardown
+from .workbook_fixtures import app_settings, app
 from webtest import AppError
 
 pytestmark = [pytest.mark.indexing, pytest.mark.working]

--- a/src/encoded/tests/test_types_init_collections.py
+++ b/src/encoded/tests/test_types_init_collections.py
@@ -40,7 +40,7 @@ def test_document_display_title_wo_attachment(testapp, protocol_data):
     from datetime import datetime
     del(protocol_data['protocol_type'])
     res = testapp.post_json('/document', protocol_data).json['@graph'][0]
-    assert res.get('display_title') == 'Document from ' + str(datetime.now())[:10]
+    assert res.get('display_title') == 'Document from ' + str(datetime.utcnow())[:10]
 
 
 @pytest.fixture
@@ -146,7 +146,7 @@ def test_tracking_item_display_title_google_analytic(google_analytics):
 
 def test_tracking_item_display_title_download(download_tracking):
     from datetime import datetime
-    assert download_tracking.get('display_title') == 'Download Tracking Item from ' + str(datetime.now())[:10]
+    assert download_tracking.get('display_title') == 'Download Tracking Item from ' + str(datetime.utcnow())[:10]
 
 
 def test_image_unique_key(registry, image_data):

--- a/src/encoded/tests/test_validation_errors.py
+++ b/src/encoded/tests/test_validation_errors.py
@@ -1,5 +1,5 @@
 import pytest
-from .features.conftest import app_settings, workbook
+from .workbook_fixtures import app_settings, workbook
 
 # XXX: All need refactor
 pytestmark = [pytest.mark.working, pytest.mark.indexing]

--- a/src/encoded/tests/testing_views.py
+++ b/src/encoded/tests/testing_views.py
@@ -148,19 +148,21 @@ class TestingLinkTarget(Item):
         'reverse.*',
     ]
 
+    def rev_link_atids(self, request, rev_name):
+        conn = request.registry[CONNECTION]
+        return [request.resource_path(conn[uuid]) for uuid in
+                self.get_filtered_rev_links(request, rev_name)]
+
     @calculated_property(schema={
         "title": "Sources",
         "type": "array",
         "items": {
             "type": ['string', 'object'],
-            "linkFrom": "TestingLinkSource.target",
+            "linkTo": "TestingLinkSourceSno",
         },
     })
     def reverse(self, request):
-        # was def reverse(self, request, reverse): ... last param needed?
-        conn = request.registry[CONNECTION]
-        return [request.resource_path(conn[uuid]) for uuid in
-                self.get_filtered_rev_links(request, 'reverse')]
+        return self.rev_link_atids(request, "reverse")
 
 
 @collection(

--- a/src/encoded/tests/workbook_fixtures.py
+++ b/src/encoded/tests/workbook_fixtures.py
@@ -2,7 +2,7 @@ import pytest
 
 # this file was previously used to setup the test fixtures for the BDD tests.
 # now, it holds the app_settings / app / workbook needed to test a full
-# app, including elasticsearch and loaded workbook inserts
+# app with indexing, including elasticsearch and loaded workbook inserts
 
 @pytest.fixture
 def external_tx():
@@ -11,7 +11,7 @@ def external_tx():
 
 @pytest.fixture(scope='session')
 def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server, aws_auth):
-    from ..conftest import _app_settings
+    from .conftest import _app_settings
     import os
     settings = _app_settings.copy()
     settings['create_tables'] = True
@@ -21,8 +21,7 @@ def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server,
     settings['collection_datastore'] = 'elasticsearch'
     settings['item_datastore'] = 'elasticsearch'
     settings['indexer'] = True
-    settings['indexer.processes'] = 2
-    settings['indexer.namespace'] = os.environ.get('TRAVIS_JOB_ID', '')
+    settings['indexer.namespace'] = os.environ.get('TRAVIS_JOB_ID', '') # set namespace for tests
 
     # use aws auth to access elasticsearch
     if aws_auth:
@@ -48,29 +47,17 @@ def app(app_settings, **kwargs):
     DBSession.bind.pool.dispose()
 
 
-@pytest.fixture(autouse=True)
-def teardown(app):
-    """
-    Alternative to ..test_indexing.teardown
-    Simply call /index to clear out the indexing queue after each test
-    """
-    from ..conftest import indexer_testapp
-    indexer_testapp(app).post_json('/index', {'record': True})
-
-
 @pytest.mark.fixture_cost(500)
 @pytest.yield_fixture(scope='session')
 def workbook(app):
     from webtest import TestApp
-    from ..test_indexing import teardown
-    teardown(app, use_collections=None)  # recreate all indices
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'REMOTE_USER': 'TEST',
     }
     testapp = TestApp(app, environ)
 
-    from ...loadxl import load_all
+    from ..loadxl import load_all
     from pkg_resources import resource_filename
     # just load the workbook inserts
     load_res = load_all(testapp, resource_filename('encoded', 'tests/data/workbook-inserts/'), [])


### PR DESCRIPTION
**DO NOT FORGET TO UPDATE SNOVAULT BRANCH IN BUILDOUT.CFG**

This branch is the CGAP complement to https://github.com/4dn-dcic/snovault/pull/111. It adds some functionality specific to the new Elasticsearch items and a few other misc things.

**Summary**
- dev_servers.py changed to run `create_mapping` before and after loading test data. This is done to initialize any ES-item indices before loading, as well as deduplicate the queue before serving the application (and thus indexing)
- `/counts` refactored a bit. May be slightly less performant, but is now much more maintainable
- Refactored some indexing-related test features. This previously in `.features.conftest` have been moved to `workbook_fixtures`
- Removed last reference to `linkFrom` in the testing types
- Other random test fix