### PR TITLE
Use relative imports for encoded

### DIFF
--- a/src/encoded/commands/clear_db_es_contents.py
+++ b/src/encoded/commands/clear_db_es_contents.py
@@ -1,12 +1,19 @@
 import argparse
 import logging
 import structlog
+import transaction
+
 from pyramid.paster import get_app
-from encoded import configure_dbsession
-from snovault.elasticsearch.create_mapping import run as run_create_mapping
 from snovault import DBSESSION
+from snovault.elasticsearch.create_mapping import run as run_create_mapping
+from sqlalchemy import MetaData
+from zope.sqlalchemy import mark_changed
+from .. import configure_dbsession
+
 
 log = structlog.getLogger(__name__)
+
+
 EPILOG = __doc__
 
 
@@ -21,9 +28,6 @@ def clear_db_tables(app):
     Returns:
         bool: True if successful, False if error encountered
     """
-    import transaction
-    from sqlalchemy import MetaData
-    from zope.sqlalchemy import mark_changed
     success = False
     session = app.registry[DBSESSION]
     meta = MetaData(bind=session.connection(), reflect=True)

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -1,14 +1,23 @@
-import os
-import json
-import sys
 import argparse
 import datetime
 import logging
 import logging.config
-from uuid import uuid4
+import json
+import os
+import sys
+
 from collections import Counter
+from dcicutils.ff_utils import (
+    get_authentication_with_server,
+    get_metadata,
+    search_metadata,
+    unified_authentication,
+    post_metadata
+)
 from rdflib.collection import Collection
-from encoded.commands.owltools import (
+from uuid import uuid4
+from ..commands.load_items import load_items
+from ..commands.owltools import (
     Namespace,
     Owler,
     splitNameFromNamespace,
@@ -21,14 +30,7 @@ from encoded.commands.owltools import (
     hasDbXref,
     hasAltId
 )
-from encoded.commands.load_items import load_items
-from dcicutils.ff_utils import (
-    get_authentication_with_server,
-    get_metadata,
-    search_metadata,
-    unified_authentication,
-    post_metadata
-)
+
 
 EPILOG = __doc__
 

--- a/src/encoded/commands/load_data.py
+++ b/src/encoded/commands/load_data.py
@@ -1,9 +1,11 @@
 import argparse
 import logging
 import structlog
+
 from pyramid.path import DottedNameResolver
 from pyramid.paster import get_app
-from encoded import configure_dbsession
+from .. import configure_dbsession
+
 
 log = structlog.getLogger(__name__)
 EPILOG = __doc__

--- a/src/encoded/commands/parse_hpoa.py
+++ b/src/encoded/commands/parse_hpoa.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-import sys
-import os
 import argparse
 import json
-import re
-import requests
 import logging
 import logging.config
+import os
+import re
+import requests
+import sys
+
 from datetime import datetime
-from uuid import uuid4
 from dcicutils.ff_utils import (
     get_authentication_with_server,
     get_metadata,
@@ -17,13 +17,15 @@ from dcicutils.ff_utils import (
     post_metadata,
     search_metadata,
 )
-from encoded.commands.load_items import load_items
-from encoded.commands.generate_items_from_owl import (
+from uuid import uuid4
+from ..commands.generate_items_from_owl import (
     connect2server,
     get_raw_form,
     prompt_check_for_output_options,
     post_report_document_to_portal,
 )
+from ..commands.load_items import load_items
+
 
 '''logging setup
    logging config - to be moved to file at some point

--- a/src/encoded/commands/verify_item.py
+++ b/src/encoded/commands/verify_item.py
@@ -1,7 +1,10 @@
-from pyramid.paster import get_app
+import argparse
 import logging
+
+from pyramid.paster import get_app
 from webtest import TestApp
-from encoded.verifier import verify_item
+from ..verifier import verify_item
+
 
 EPILOG = __doc__
 
@@ -27,7 +30,6 @@ def run(app, uuids=None):
 def main():
     ''' Verifies and item against database / ES and checks embeds '''
 
-    import argparse
     parser = argparse.ArgumentParser(
         description="Verifies and item against database / ES and checks embeds", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -5,14 +5,18 @@ import structlog
 import magic
 import json
 import os
+
+from base64 import b64encode
 from past.builtins import basestring
-from pyramid.view import view_config
+from PIL import Image
+from pkg_resources import resource_filename
 from pyramid.paster import get_app
 from pyramid.response import Response
+from pyramid.view import view_config
 from snovault.util import debug_log
-from encoded.server_defaults import add_last_modified
-from base64 import b64encode
-from PIL import Image
+from webtest import TestApp
+from .server_defaults import add_last_modified
+
 
 text = type(u'')
 logger = structlog.getLogger(__name__)
@@ -98,7 +102,6 @@ def load_data_view(context, request):
     patch_only = request.json.get('patch_only', False)
     post_only = request.json.get('post_only', False)
     app = get_app(config_uri, 'app')
-    from webtest import TestApp
     environ = {'HTTP_ACCEPT': 'application/json', 'REMOTE_USER': 'TEST'}
     testapp = TestApp(app, environ)
     # expected response
@@ -107,7 +110,6 @@ def load_data_view(context, request):
         'status': 'success',
         '@type': ['result'],
     }
-    from pkg_resources import resource_filename
     store = request.json.get('store', {})
     local_path = request.json.get('local_path')
     fdn_dir = request.json.get('fdn_dir')
@@ -471,13 +473,11 @@ def load_data(app, indir='inserts', docsdir=None, overwrite=False,
         indir (inserts): inserts folder, should be relative to tests/data/
         docsdir (None): folder with attachment documents, relative to tests/data
     '''
-    from webtest import TestApp
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'REMOTE_USER': 'TEST',
     }
     testapp = TestApp(app, environ)
-    from pkg_resources import resource_filename
     # load master-inserts by default
     if indir != 'master-inserts' and use_master_inserts:
         master_inserts = resource_filename('encoded', 'tests/data/master-inserts/')
@@ -522,7 +522,6 @@ def load_local_data(app, overwrite=False):
     Returns:
         None if successful, otherwise Exception encountered
     """
-    from pkg_resources import resource_filename
     # if we have any json files in temp-local-inserts, use those
     chk_dir = resource_filename('encoded', 'tests/data/temp-local-inserts')
     use_temp_local = False

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -2,21 +2,18 @@
 
 http://pyramid.readthedocs.org/en/latest/narr/testing.html
 '''
+
 import logging
 import pkg_resources
 import pytest
 import webtest
 
-from encoded import main
-
 from pyramid.request import apply_request_extensions
 from pyramid.testing import DummyRequest, setUp, tearDown
 from pyramid.threadlocal import get_current_registry, manager as threadlocal_manager
-
 from snovault import DBSESSION, ROOT, UPGRADER
-
 from snovault.elasticsearch import ELASTIC_SEARCH
-
+from .. import main
 from .conftest_settings import make_app_settings_dictionary
 
 

--- a/src/encoded/tests/test_access_key.py
+++ b/src/encoded/tests/test_access_key.py
@@ -1,10 +1,15 @@
 import pytest
+
+from base64 import b64encode
+from pyramid.compat import ascii_native_
+from snovault import COLLECTIONS
+from ..edw_hash import EDWHash
+
+
 pytestmark = [pytest.mark.working, pytest.mark.setone]
 
 
 def basic_auth(username, password):
-    from base64 import b64encode
-    from pyramid.compat import ascii_native_
     return 'Basic ' + ascii_native_(b64encode(('%s:%s' % (username, password)).encode('utf-8')))
 
 
@@ -163,8 +168,6 @@ def test_access_key_view_hides_secret_access_key_hash(testapp, access_key, frame
 
 
 def test_access_key_uses_edw_hash(app, access_key):
-    from encoded.edw_hash import EDWHash
-    from snovault import COLLECTIONS
     root = app.registry[COLLECTIONS]
     obj = root.by_item_type['access_key'][access_key['access_key_id']]
     pwhash = obj.properties['secret_access_key_hash']

--- a/src/encoded/tests/test_auth0.py
+++ b/src/encoded/tests/test_auth0.py
@@ -1,8 +1,11 @@
+import os
 import pytest
 import requests
-import os
+
+from ..authentication import get_jwt
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
-from encoded.authentication import get_jwt
 
 
 @pytest.fixture(scope='session')

--- a/src/encoded/tests/test_authentication.py
+++ b/src/encoded/tests/test_authentication.py
@@ -1,6 +1,13 @@
-import unittest
-from pyramid.testing import DummyRequest
 import pytest
+import unittest
+
+from pyramid.interfaces import IAuthenticationPolicy
+from pyramid.security import Authenticated, Everyone
+from pyramid.testing import DummyRequest
+from zope.interface.verify import verifyClass, verifyObject
+from ..authentication import NamespacedAuthenticationPolicy
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
@@ -8,7 +15,6 @@ class TestNamespacedAuthenticationPolicy(unittest.TestCase):
     """ This is a modified version of TestRemoteUserAuthenticationPolicy
     """
     def _getTargetClass(self):
-        from encoded.authentication import NamespacedAuthenticationPolicy
         return NamespacedAuthenticationPolicy
 
     def _makeOne(self, namespace='user',
@@ -17,14 +23,10 @@ class TestNamespacedAuthenticationPolicy(unittest.TestCase):
         return self._getTargetClass()(namespace, base, *args, **kw)
 
     def test_class_implements_IAuthenticationPolicy(self):
-        from zope.interface.verify import verifyClass
-        from pyramid.interfaces import IAuthenticationPolicy
         klass = self._makeOne().__class__
         verifyClass(IAuthenticationPolicy, klass)
 
     def test_instance_implements_IAuthenticationPolicy(self):
-        from zope.interface.verify import verifyObject
-        from pyramid.interfaces import IAuthenticationPolicy
         verifyObject(IAuthenticationPolicy, self._makeOne())
 
     def test_unauthenticated_userid_returns_None(self):
@@ -48,14 +50,11 @@ class TestNamespacedAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.authenticated_userid(request), 'user.fred')
 
     def test_effective_principals_None(self):
-        from pyramid.security import Everyone
         request = DummyRequest(environ={})
         policy = self._makeOne()
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
         request = DummyRequest(environ={'REMOTE_USER':'fred'})
         policy = self._makeOne()
         self.assertEqual(policy.effective_principals(request),

--- a/src/encoded/tests/test_clear_es_db_contents.py
+++ b/src/encoded/tests/test_clear_es_db_contents.py
@@ -1,8 +1,10 @@
 import pytest
-from encoded.commands.clear_db_es_contents import (
+
+from ..commands.clear_db_es_contents import (
     clear_db_tables,
     run_clear_db_es
 )
+
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 

--- a/src/encoded/tests/test_create_mapping.py
+++ b/src/encoded/tests/test_create_mapping.py
@@ -1,8 +1,13 @@
 import pytest
+
+from snovault import COLLECTIONS, TYPES
+from snovault.elasticsearch.create_mapping import type_mapping
+from snovault.util import add_default_embeds
 from unittest.mock import patch, MagicMock
 from .datafixtures import ORDER
-from snovault import COLLECTIONS
-from encoded.commands.create_mapping_on_deploy import ITEM_INDEX_ORDER, get_deployment_config
+from ..commands.create_mapping_on_deploy import ITEM_INDEX_ORDER, get_deployment_config
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
@@ -13,9 +18,6 @@ def test_create_mapping(registry, item_type):
     This test does not actually use elasticsearch
     Only tests the mappings generated from schemas
     """
-    from snovault.elasticsearch.create_mapping import type_mapping
-    from snovault.util import add_default_embeds
-    from snovault import TYPES
     mapping = type_mapping(registry[TYPES], item_type)
     assert mapping
     type_info = registry[TYPES].by_item_type[item_type]

--- a/src/encoded/tests/test_edw_hash.py
+++ b/src/encoded/tests/test_edw_hash.py
@@ -1,4 +1,8 @@
 import pytest
+
+from ..edw_hash import EDWHash
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
@@ -11,5 +15,4 @@ TEST_HASHES = {
 
 @pytest.mark.parametrize(('password', 'pwhash'), TEST_HASHES.items())
 def test_edw_hash(password, pwhash):
-    from encoded.edw_hash import EDWHash
     assert EDWHash.encrypt(password) == pwhash

--- a/src/encoded/tests/test_embedding.py
+++ b/src/encoded/tests/test_embedding.py
@@ -1,7 +1,13 @@
 import pytest
+
 from .datafixtures import ORDER
+from snovault import TYPES
+from snovault.util import add_default_embeds, crawl_schemas_by_embeds
+from ..types.base import get_item_if_you_can
+
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
+
 
 targets = [
     {'name': 'one', 'uuid': '775795d3-4410-4114-836b-8eeecf1d0c2f'},
@@ -89,8 +95,6 @@ def test_add_default_embeds(registry, item_type):
     """
     Ensure default embedding matches the schema for each object
     """
-    from snovault.util import add_default_embeds, crawl_schemas_by_embeds
-    from snovault import TYPES
     type_info = registry[TYPES].by_item_type[item_type]
     schema = type_info.schema
     embeds = add_default_embeds(item_type, registry[TYPES], type_info.embedded_list, schema)
@@ -110,8 +114,6 @@ def test_manual_embeds(registry, item_type):
     """
     Ensure manual embedding in the types files are valid
     """
-    from snovault.util import crawl_schemas_by_embeds
-    from snovault import TYPES
     type_info = registry[TYPES].by_item_type[item_type]
     schema = type_info.schema
     embeds = type_info.embedded_list
@@ -130,8 +132,6 @@ def test_fictitous_embed(registry):
     the organism subpath should be in the added_embeds even though it is
     not a terminal object
     """
-    from snovault.util import crawl_schemas_by_embeds
-    from snovault import TYPES
     type_info = registry[TYPES].by_item_type['biosample']
     schema = type_info.schema
     embed = 'biosource.individual.organism.name'
@@ -148,7 +148,6 @@ def test_get_item_if_you_can(content, dummy_request, threadlocals):
     Not necessarily the best place for this test, but test that the
     `get_item_if_you_can` function works with multiple inputs
     """
-    from encoded.types.base import get_item_if_you_can
     used_item = sources[0]
     # all of these should get the full item
     res1 = get_item_if_you_can(dummy_request, used_item)

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -3,15 +3,32 @@
 The fixtures in this module setup a full system with postgresql and
 elasticsearch running as subprocesses.
 """
-import pytest
 import json
+import os
+import pytest
 import time
-from encoded.verifier import verify_item
+import transaction
+import uuid
+
+from pkg_resources import resource_filename
 from snovault import DBSESSION, TYPES
 from snovault.elasticsearch import create_mapping, ELASTIC_SEARCH
+from snovault.elasticsearch.create_mapping import (
+    type_mapping,
+    create_mapping_by_type,
+    build_index_record,
+    compare_against_existing_mapping
+)
 from snovault.elasticsearch.interfaces import INDEXER_QUEUE
 from snovault.elasticsearch.indexer_utils import get_namespaced_index
+from sqlalchemy import MetaData
+from timeit import default_timer as timer
+from unittest import mock
+from zope.sqlalchemy import mark_changed
+from .. import main
+from ..verifier import verify_item
 from .workbook_fixtures import app_settings
+
 
 pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky]
 
@@ -21,7 +38,6 @@ TEST_COLLECTIONS = ['testing_post_put_patch', 'file_processed']
 
 @pytest.yield_fixture(scope='session', params=[False])
 def app(app_settings, request):
-    from encoded import main
     # for now, don't run with mpindexer. Add `True` to params above to do so
     if request.param:
         app_settings['mpindexer'] = True
@@ -40,10 +56,6 @@ def setup_and_teardown(app):
     Run create mapping and purge queue before tests and clear out the
     DB tables after the test
     """
-    import transaction
-    from sqlalchemy import MetaData
-    from zope.sqlalchemy import mark_changed
-
     # BEFORE THE TEST - run create mapping for tests types and clear queues
     create_mapping.run(app, collections=TEST_COLLECTIONS, skip_indexing=True)
     app.registry[INDEXER_QUEUE].clear_queue()
@@ -115,12 +127,6 @@ def test_create_mapping_on_indexing(app, testapp, registry, elasticsearch):
     Do this by checking es directly before and after running mapping.
     Delete an index directly, run again to see if it recovers.
     """
-    from snovault.elasticsearch.create_mapping import (
-        type_mapping,
-        create_mapping_by_type,
-        build_index_record,
-        compare_against_existing_mapping
-    )
     es = registry[ELASTIC_SEARCH]
     item_types = TEST_COLLECTIONS
     # check that mappings and settings are in index
@@ -209,7 +215,6 @@ def test_real_validation_error(app, indexer_testapp, testapp, institution,
     Create an item (file-processed) with a validation error and index,
     to ensure that validation errors work
     """
-    import uuid
     es = app.registry[ELASTIC_SEARCH]
     fp_body = {
         'schema_version': '3',
@@ -255,13 +260,8 @@ def test_load_and_index_perf_data(testapp, indexer_testapp):
     Note: run with bin/test -s -m performance to see the prints from the test
     '''
 
-    from os import listdir
-    from os.path import isfile, join
-    from unittest import mock
-    from timeit import default_timer as timer
-    from pkg_resources import resource_filename
     insert_dir = resource_filename('encoded', 'tests/data/perf-testing/')
-    inserts = [f for f in listdir(insert_dir) if isfile(join(insert_dir, f))]
+    inserts = [f for f in os.listdir(insert_dir) if os.path.isfile(os.path.join(insert_dir, f))]
     json_inserts = {}
 
     # pluck a few uuids for testing

--- a/src/encoded/tests/test_load_access_key.py
+++ b/src/encoded/tests/test_load_access_key.py
@@ -1,8 +1,10 @@
 import pytest
 from unittest import mock
-from encoded.commands.load_access_keys import generate_access_key
+from ..commands.load_access_keys import generate_access_key
+
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
+
 
 # TODO: test load_access_keys.get_existing_key_ids, which would use ES
 

--- a/src/encoded/tests/test_loadxl.py
+++ b/src/encoded/tests/test_loadxl.py
@@ -1,10 +1,12 @@
-import pytest
-from encoded import loadxl
 import json
-from unittest import mock
+import pytest
+
 from past.builtins import basestring
 from pkg_resources import resource_filename
-from encoded.commands.run_upgrader_on_inserts import get_inserts
+from unittest import mock
+from .. import loadxl
+from ..commands.run_upgrader_on_inserts import get_inserts
+
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 

--- a/src/encoded/tests/test_owltools.py
+++ b/src/encoded/tests/test_owltools.py
@@ -1,7 +1,10 @@
 import pytest
+
+from rdflib import RDFS, BNode, URIRef, Literal
+from ..commands import owltools as ot
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
-from rdflib import RDFS, BNode, URIRef
-from encoded.commands import owltools as ot
 
 
 @pytest.fixture
@@ -11,21 +14,18 @@ def owler(mocker):
 
 @pytest.fixture
 def rdf_objects():
-    from rdflib import Literal
     rdfobjs = ['testrdfobj1', 'testrdfobj2']
     return [Literal(rdfobj) for rdfobj in rdfobjs]
 
 
 @pytest.fixture
 def rdf_objects_2_1():
-    from rdflib import Literal
     rdfobjs = ['testrdfobj1']
     return [Literal(rdfobj) for rdfobj in rdfobjs]
 
 
 @pytest.fixture
 def rdf_objects_2_3():
-    from rdflib import Literal
     rdfobjs = ['testrdfobj1', 'testrdfobj2', 'testrdfobj3']
     return [Literal(rdfobj) for rdfobj in rdfobjs]
 

--- a/src/encoded/tests/test_permissions.py
+++ b/src/encoded/tests/test_permissions.py
@@ -1,8 +1,13 @@
 import pytest
-pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
+import webtest
 
 from datetime import date
 from urllib.parse import urlencode
+from ..types.institution import Institution
+
+
+pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
+
 
 # XXX: There are a lot of testing holes here. New datafixtures will need to be
 # developed to adequately test the permissions.
@@ -152,12 +157,11 @@ def remc_submitter(testapp, remc_institution, remc_project):
 
 
 def remote_user_testapp(app, remote_user):
-    from webtest import TestApp
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'REMOTE_USER': str(remote_user),
     }
-    return TestApp(app, environ)
+    return webtest.TestApp(app, environ)
 
 
 @pytest.fixture
@@ -477,7 +481,6 @@ def test_wrangler_can_edit_institution_name_or_title(institution, submitter_test
 
 
 def test_ac_local_roles_for_institution(registry):
-    from encoded.types.institution import Institution
     institution_data = {
         'status': 'in review',
         'project': 'b0b9c607-bbbb-4f02-93f4-9895baa1334b',

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -1,11 +1,18 @@
+import json
+import pytest
+import time
+
+from datetime import (datetime, timedelta)
+from snovault import TYPES, COLLECTIONS
+from snovault.elasticsearch import create_mapping
+from snovault.elasticsearch.create_mapping import MAX_NGRAM
+from snovault.elasticsearch.indexer_utils import get_namespaced_index
+from snovault.util import add_default_embeds
+from ..commands.run_upgrader_on_inserts import get_inserts
 # Use workbook fixture from BDD tests (including elasticsearch)
 from .workbook_fixtures import app_settings, app, workbook
-import pytest
-from encoded.commands.run_upgrader_on_inserts import get_inserts
-from snovault.elasticsearch.indexer_utils import get_namespaced_index
-import json
-import time
-from snovault import TYPES, COLLECTIONS
+
+
 pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing]
 
 
@@ -127,7 +134,6 @@ def test_search_ngram(workbook, testapp):
     """
     Tests edge-ngram related behavior with simple query string
     """
-    from snovault.elasticsearch.create_mapping import MAX_NGRAM
     # test search beyond max-ngram, should still give one result
     res = testapp.get('/search/?type=Item&q=Second+Dummy+Sub+Disorder').json
     assert len(res['@graph']) == 1
@@ -197,7 +203,6 @@ def test_search_embedded_file_by_accession(workbook, testapp):
 def dd_dts(testapp, workbook):
     # returns a dictionary of strings of various date and datetimes
     # relative to the creation date of the mboI one object in test inserts
-    from datetime import (datetime, timedelta)
     enz = testapp.get('/search/?type=Disorder&disorder_name=Dummy+Disorder').json['@graph'][0]
 
     cdate = enz['date_created']
@@ -378,8 +383,6 @@ def test_metadata_tsv_view(workbook, htmltestapp):
 
 
 def test_default_schema_and_non_schema_facets(workbook, testapp, registry):
-    from snovault import TYPES
-    from snovault.util import add_default_embeds
     test_type = 'user'
     type_info = registry[TYPES].by_item_type[test_type]
     schema = type_info.schema
@@ -506,7 +509,6 @@ def test_collection_actions_filtered_by_permission(workbook, testapp, anontestap
 
 
 def test_index_data_workbook(app, workbook, testapp, indexer_testapp, htmltestapp):
-    from snovault.elasticsearch import create_mapping
     es = app.registry['elasticsearch']
     # we need to reindex the collections to make sure numbers are correct
     create_mapping.run(app, sync_index=True)

--- a/src/encoded/tests/test_server_defaults.py
+++ b/src/encoded/tests/test_server_defaults.py
@@ -1,5 +1,10 @@
-from pytest import fixture
 import pytest
+import webtest
+
+from pytest import fixture
+from .. import main
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 def test_server_defaults(admin, anontestapp):
@@ -22,7 +27,6 @@ def test_server_defaults(admin, anontestapp):
 
 @fixture(scope='session')
 def test_accession_app(request, check_constraints, zsa_savepoints, app_settings):
-    from encoded import main
     app_settings = app_settings.copy()
     app_settings['accession_factory'] = 'encoded.server_defaults.test_accession'
     return main({}, **app_settings)
@@ -32,11 +36,10 @@ def test_accession_app(request, check_constraints, zsa_savepoints, app_settings)
 def test_accession_anontestapp(request, test_accession_app, external_tx, zsa_savepoints):
     '''TestApp with JSON accept header.
     '''
-    from webtest import TestApp
     environ = {
         'HTTP_ACCEPT': 'application/json',
     }
-    return TestApp(test_accession_app, environ)
+    return webtest.TestApp(test_accession_app, environ)
 
 
 def test_test_accession_server_defaults(admin, test_accession_anontestapp):

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -1,9 +1,15 @@
-import pytest
-from encoded.types.file import FileFastq, post_upload
-from pyramid.httpexceptions import HTTPForbidden
-import os
 import boto3
+import os
+import pytest
+import tempfile
+
+from pyramid.httpexceptions import HTTPForbidden
+from .. import source_beanstalk_env_vars
+from ..types.file import FileFastq, post_upload, external_creds
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
+
 
 # XXX: There are a lot of testing holes here. New datafixtures need to be implemented
 # so that the stuff tested in Fourfront can also be tested in CGAP
@@ -27,7 +33,6 @@ def file(testapp, project, experiment, institution, file_formats):
 def test_external_creds(mocker):
     mocker.patch('encoded.types.file.boto3', autospec=True)
 
-    from encoded.types.file import external_creds
     ret = external_creds('test-wfout-bucket', 'test-key', 'name')
     assert ret['key'] == 'test-key'
     assert ret['bucket'] == 'test-wfout-bucket'
@@ -40,8 +45,6 @@ def test_force_beanstalk_env(mocker):
     This test is a bit outdated, since env variable loading has moved to
     application __init__ from file.py. But let's keep the test...
     """
-    import tempfile
-    from encoded import source_beanstalk_env_vars
     secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
     key = os.environ.get("AWS_ACCESS_KEY_ID")
     os.environ.pop("AWS_SECRET_ACCESS_KEY")

--- a/src/encoded/tests/test_types_init_collections.py
+++ b/src/encoded/tests/test_types_init_collections.py
@@ -1,4 +1,9 @@
 import pytest
+
+from datetime import datetime
+from ..types.image import Image
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
 
@@ -37,7 +42,6 @@ def test_document_display_title_w_attachment(testapp, protocol_data, attachment)
 
 
 def test_document_display_title_wo_attachment(testapp, protocol_data):
-    from datetime import datetime
     del(protocol_data['protocol_type'])
     res = testapp.post_json('/document', protocol_data).json['@graph'][0]
     assert res.get('display_title') == 'Document from ' + str(datetime.utcnow())[:10]
@@ -145,12 +149,10 @@ def test_tracking_item_display_title_google_analytic(google_analytics):
 
 
 def test_tracking_item_display_title_download(download_tracking):
-    from datetime import datetime
     assert download_tracking.get('display_title') == 'Download Tracking Item from ' + str(datetime.utcnow())[:10]
 
 
 def test_image_unique_key(registry, image_data):
-    from encoded.types.image import Image
     uuid = "0afb6080-1c08-11e4-8c21-0800200c9a44"
     image = Image.create(registry, uuid, image_data)
     keys = image.unique_keys(image.properties)

--- a/src/encoded/tests/test_types_tracking_item.py
+++ b/src/encoded/tests/test_types_tracking_item.py
@@ -1,5 +1,9 @@
 import pytest
-from encoded.types import TrackingItem
+
+# Supports commented-out code below.
+# from ..types import TrackingItem
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
 

--- a/src/encoded/tests/workbook_fixtures.py
+++ b/src/encoded/tests/workbook_fixtures.py
@@ -3,13 +3,10 @@ import pkg_resources
 import pytest
 import webtest
 
-from encoded import main
-
 from snovault import DBSESSION
 from snovault.elasticsearch import create_mapping
-
+from .. import main
 from ..loadxl import load_all
-
 from .conftest_settings import make_app_settings_dictionary
 
 

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -1,8 +1,11 @@
 """base class creation for all the schemas that exist."""
+import re
+import snovault
+import string
+
+from datetime import date
 from functools import lru_cache
-from pyramid.view import (
-    view_config,
-)
+from jsonschema_serialize_fork import NO_DEFAULT
 from pyramid.security import (
     # ALL_PERMISSIONS,
     Allow,
@@ -12,21 +15,18 @@ from pyramid.security import (
     Everyone,
 )
 from pyramid.traversal import find_root
-import snovault
-# from ..schema_formats import is_accession
-# import snovalut default post / patch stuff so we can overwrite it in this file
+from pyramid.view import (
+    view_config,
+)
+# import snovault default post / patch stuff so we can overwrite it in this file
 from snovault.validators import (
     validate_item_content_post,
     validate_item_content_put,
     validate_item_content_patch
 )
 from snovault.interfaces import CONNECTION
-from encoded.server_defaults import get_userid, add_last_modified
-from jsonschema_serialize_fork import NO_DEFAULT
-
-from datetime import date
-import string
-import re
+# from ..schema_formats import is_accession
+from ..server_defaults import get_userid, add_last_modified
 
 
 # Item acls

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -1,3 +1,22 @@
+import boto3
+import datetime
+import json
+import logging
+import pytz
+import os
+import structlog
+
+from botocore.exceptions import ClientError
+from copy import deepcopy
+from pyramid.httpexceptions import (
+    HTTPForbidden,
+    HTTPTemporaryRedirect,
+    HTTPNotFound,
+)
+from pyramid.response import Response
+from pyramid.settings import asbool
+from pyramid.traversal import resource_path
+from pyramid.view import view_config
 from snovault import (
     AfterModified,
     BeforeModified,
@@ -7,7 +26,14 @@ from snovault import (
     load_schema,
     abstract_collection,
 )
+from snovault.attachment import ItemWithAttachment
+from snovault.crud_views import (
+    collection_add,
+    item_edit,
+)
+from snovault.elasticsearch import ELASTIC_SEARCH
 from snovault.schema_utils import schema_validator
+from snovault.util import debug_log
 from snovault.validators import (
     validate_item_content_post,
     validate_item_content_put,
@@ -17,45 +43,24 @@ from snovault.validators import (
     no_validate_item_content_put,
     no_validate_item_content_patch
 )
-from snovault.crud_views import (
-    collection_add,
-    item_edit,
+from urllib.parse import (
+    parse_qs,
+    urlparse,
 )
-from snovault.attachment import ItemWithAttachment
-from snovault.util import debug_log
+from ..authentication import session_properties
+from ..search import make_search_subreq
+from . import TrackingItem
 from .base import (
     Item,
     ALLOW_SUBMITTER_ADD,
     get_item_if_you_can,
     # lab_award_attribution_embed_list
 )
-from pyramid.httpexceptions import (
-    HTTPForbidden,
-    HTTPTemporaryRedirect,
-    HTTPNotFound,
-)
-from pyramid.response import Response
-from pyramid.settings import asbool
-from pyramid.view import view_config
-from urllib.parse import (
-    parse_qs,
-    urlparse,
-)
-import boto3
-from botocore.exceptions import ClientError
-import datetime
-import json
-import pytz
-import os
-from pyramid.traversal import resource_path
-from encoded.search import make_search_subreq
-from snovault.elasticsearch import ELASTIC_SEARCH
-from copy import deepcopy
-from . import TrackingItem
-from ..authentication import session_properties
-import structlog
-import logging
+
+
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
+
+
 log = structlog.getLogger(__name__)
 
 file_workflow_run_embeds = [

--- a/src/encoded/types/page.py
+++ b/src/encoded/types/page.py
@@ -1,10 +1,7 @@
 """
 The type file for the collection Pages.  Which is used for static pages on the portal
 """
-from urllib.parse import (
-    urlparse,
-    urlencode
-)
+
 from pyramid.httpexceptions import ( # 301-307 redirect code response
     HTTPMovedPermanently,
     HTTPFound,
@@ -20,10 +17,9 @@ from snovault import (
     COLLECTIONS,
     CONNECTION
 )
-from encoded.search import get_iterable_search_results
-from .base import Item
-from .user_content import (
-    StaticSection
+from snovault.crud_views import (
+    collection_add,
+    item_edit,
 )
 from snovault.resource_views import item_view_page
 from snovault.validators import (
@@ -35,11 +31,16 @@ from snovault.validators import (
     no_validate_item_content_put,
     no_validate_item_content_patch
 )
-from snovault.crud_views import (
-    collection_add,
-    item_edit,
-)
 from snovault.util import debug_log
+from urllib.parse import (
+    urlparse,
+    urlencode
+)
+from ..search import get_iterable_search_results
+from .base import Item
+from .user_content import (
+    StaticSection
+)
 
 
 def get_pyramid_http_exception_for_redirect_code(code):

--- a/src/encoded/verifier.py
+++ b/src/encoded/verifier.py
@@ -1,4 +1,9 @@
 from functools import wraps
+from snovault import TYPES
+# TODO: Production code should not rely on tests.
+from .tests.test_create_mapping import test_create_mapping
+from .tests.test_embedding import test_add_default_embeds, test_manual_embeds
+from .tests.test_schemas import master_mixins, test_load_schema
 
 
 def verifier(func):
@@ -52,13 +57,11 @@ def verify_profile(item_type, indexer_testapp):
 @verifier
 def verify_schema(item_type_camel, registry):
     # test schema
-    from encoded.tests.test_schemas import master_mixins, test_load_schema
     test_load_schema(item_type_camel + ".json", master_mixins(), registry)
 
 
 @verifier
 def verify_can_embed(item_type_camel, es_item, indexer_testapp, registry):
-    from snovault import TYPES
     # get the embedds
     pyr_item_type = registry[TYPES].by_item_type[item_type_camel]
     embeds = pyr_item_type.embedded
@@ -77,14 +80,12 @@ def verify_indexing(item_uuid, indexer_testapp):
 
 @verifier
 def verify_embeds(registry, item_type):
-    from encoded.tests.test_embedding import test_add_default_embeds, test_manual_embeds
     test_add_default_embeds(registry, item_type)
     test_manual_embeds(registry, item_type)
 
 
 @verifier
 def verify_mapping(registry, item_type):
-    from encoded.tests.test_create_mapping import test_create_mapping
     test_create_mapping(registry, item_type)
 
 


### PR DESCRIPTION
This changes absolute references to the repo (which calls itself 'encoded') into relative references.