### PR TITLE
mimetypes_are_equal override in class Document

### DIFF
--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -81,6 +81,18 @@ class Document(ItemWithAttachment, Item):
     embedded_list = []
     mimetype_map = {'application/proband+xml': ['text/plain']}
 
+    def mimetypes_are_equal(self, m1, m2):
+        """ Checks that mime_type m1 and m2 are equal """
+        major1 = m1.split('/')[0]
+        major2 = m2.split('/')[0]
+        if major1 == 'text' and major2 == 'text':
+            return True
+        if m1 in self.mimetype_map:
+            m1 = self.mimetype_map[m1][0]
+        if m2 in self.mimetype_map:
+            m2 = self.mimetype_map[m2][0]
+        return m1 == m2
+
     @calculated_property(schema={
         "title": "Display Title",
         "description": "A calculated title for every object in 4DN",

--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -89,9 +89,6 @@ class Document(ItemWithAttachment, Item):
             return True
         if m1 in self.mimetype_map and m2 in self.mimetype_map[m1]:
             return True
-        #     m1 = self.mimetype_map[m1][0]
-        # if m2 in self.mimetype_map:
-        #     m2 = self.mimetype_map[m2][0]
         return m1 == m2
 
     @calculated_property(schema={

--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -87,10 +87,11 @@ class Document(ItemWithAttachment, Item):
         major2 = m2.split('/')[0]
         if major1 == 'text' and major2 == 'text':
             return True
-        if m1 in self.mimetype_map:
-            m1 = self.mimetype_map[m1][0]
-        if m2 in self.mimetype_map:
-            m2 = self.mimetype_map[m2][0]
+        if m1 in self.mimetype_map and m2 in self.mimetype_map[m1]:
+            return True
+        #     m1 = self.mimetype_map[m1][0]
+        # if m2 in self.mimetype_map:
+        #     m2 = self.mimetype_map[m2][0]
         return m1 == m2
 
     @calculated_property(schema={


### PR DESCRIPTION
Problem: currently can't upload any pedigrees, problem due to mimetype mismatch issue

In this PR:
- overrides mimetypes_are_equal method in Document class (inherited from ItemWithAttachment class in snovault) to avoid pbxml problems (avoids changes in snovault)

[Note: building locally won't work without "fix inserts" branch merged in]