### PR TITLE
Logging pde

### DIFF
--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -414,9 +414,6 @@ def id_post_and_patch(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=Tr
             # new term
             uid = str(uuid4())
             term['uuid'] = uid
-            if tid in tid2uuid:
-                logger.warn("HAVE SEEN {} BEFORE!".format(tid))
-                logger.warn("PREVIOUS={}; NEW={}".format(tid2uuid[tid], uid))
             to_update.append(term)
             tid2uuid[tid] = uid
             to_post.append(tid)
@@ -424,9 +421,6 @@ def id_post_and_patch(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=Tr
             # add uuid to mapping and existing term
             dbterm = dbterms[tid]
             uuid = dbterm['uuid']
-            if tid in tid2uuid:
-                logger.warn("HAVE SEEN {} BEFORE!".format(tid))
-                logger.warn("PREVIOUS={}; NEW={}".format(tid2uuid[tid], uid))
             tid2uuid[tid] = uuid
             term['uuid'] = uuid
 

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -32,44 +32,6 @@ from ..commands.owltools import (
 
 EPILOG = __doc__
 
-# '''logging setup
-#    logging config - to be moved to file at some point
-# '''
-# logfile = 'process_dp_upd.log'
-# logger = logging.getLogger(__name__)
-#
-# logging.config.dictConfig({
-#     'version': 1,
-#     'disable_existing_loggers': False,
-#     'formatters': {
-#         'standard': {
-#             'format': '%(levelname)s:\t%(message)s'
-#         },
-#         'verbose': {
-#             'format': '%(levelname)s:\t%(message)s\tFROM: %(name)s'
-#         }
-#     },
-#     'handlers': {
-#         'stdout': {
-#             'level': 'WARN',
-#             'formatter': 'verbose',
-#             'class': 'logging.StreamHandler'
-#         },
-#         'logfile': {
-#             'level': 'INFO',
-#             'formatter': 'standard',
-#             'class': 'logging.FileHandler',
-#             'filename': logfile
-#         }
-#     },
-#     'loggers': {
-#         '': {
-#             'handlers': ['stdout', 'logfile'],
-#             'level': 'INFO',
-#             'propagate': True
-#         }
-#     }
-# })
 
 ''' global config '''
 ITEM2OWL = {
@@ -174,18 +136,6 @@ def get_all_ancestors(term, terms, field, itype):
     return term  # is this necessary
 
 
-def _has_human(cols):
-    '''True if human taxon is part of the collection'''
-    ans = False
-    human = HUMAN_TAXON
-    if cols:
-        if isURIRef(cols[0]):
-            human = convert2URIRef(human)
-        if human in cols:
-            ans = True
-    return ans
-
-
 def get_termid_from_uri(uri):
     '''Given a uri - takes the last part (name) and converts _ to :
         eg. http://www.ebi.ac.uk/efo/EFO_0002784 => EFO:0002784
@@ -219,15 +169,11 @@ def create_term_dict(class_, termid, data, itype):
 
 
 def process_parents(class_, data, terms):
-    '''Gets the parents of the class - direct and those linked via
-        specified relationship types
+    '''Gets the direct parents of the class
     '''
     termid = get_termid_from_uri(class_)
-    for parent in data.get_classDirectSupers(class_, excludeBnodes=False):
-        if isBlankNode(parent):
-            continue
-        else:
-            terms[termid].setdefault('parents', []).append(get_termid_from_uri(parent))
+    for parent in data.get_classDirectSupers(class_):
+        terms[termid].setdefault('parents', []).append(get_termid_from_uri(parent))
     return terms
 
 
@@ -273,9 +219,6 @@ def _cleanup_non_fields(terms):
 def add_slim_to_term(term, slim_terms, itype):
     '''Checks the list of ancestor terms to see if any are slim_terms
         and if so adds the slim_term to the term in slim_term slot
-
-        for now checking both closure and closure_with_develops_from
-        but consider having only single 'ancestor' list
     '''
     id_field = ITEM2OWL[itype].get('id_field')
     if not id_field:

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -626,7 +626,7 @@ def post_report_document_to_portal(connection, itype, logfile):
     meta = {'institution': inst, 'project': proj}
     mimetype = "text/plain"
     rtype = 'document'
-    date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    date = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%SZ")
     attach_fn = None
     if os.path.isfile(logfile):
         attach_fn = '{}_update_report_{}.txt'.format(itype, date)
@@ -671,11 +671,10 @@ def main():
 
         logging/tracking info
     '''
-    start = datetime.now()
-    dt = start.strftime("%y-%m-%d-%H-%M-%S")
+    start = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     args = parse_args(sys.argv[1:])
     itype = args.item_type
-    logfile = '{}_{}_item_upd.log'.format(dt, itype)
+    logfile = '{}_{}_item_upd.log'.format(start.replace(':', '-'), itype)  # avoids colons in filename
     logger = get_logger(__name__, logfile)
     logger.info('Processing {} on {}'.format(itype, start))
     connection = connect2server(args.env, args.key, args.keyfile)
@@ -720,9 +719,8 @@ def main():
             res = load_items(items2upd, itypes=[itype], auth=connection, logger=logger)
             logger.info(res)
             logger.info(json.dumps(items2upd, indent=4))
-    stop = datetime.now()
-    logger.info('STARTED: {}'.format(str(start)))
-    logger.info('END: {}'.format(str(stop)))
+    logger.info('STARTED: {}'.format(start))
+    logger.info('END: {}'.format(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")))
     if args.post_report:
         post_report_document_to_portal(connection, itype, logfile)
 

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -399,10 +399,16 @@ def id_fields2patch(term, dbterm, rm_unch):
         return term
 
 
-def id_post_and_patch(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=True, logger=None):
-    '''compares terms to terms that are already in db - if no change
-        removes them from the list of updates, if new adds to post dict,
-        if changed adds uuid and add to patch dict
+def identify_item_updates(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=True, logger=None):
+    ''' compares items generated from the owl file to items of that type that are already in db
+        - if item is in the db and has not changed and rm_unchanged is True items are removed
+          from the items to be updated
+        - if rm_unchanged is False all items are added to the updates
+        - if an item is not in the db it is added to the updates
+        - if there are values of fields that are obtained from the owl file that are different from the values
+          in the same fields in the item from the db those fields are added as a patch to the updates
+        - if set_obsoletes is True (the default) then an item that exists in the db that is not present
+          in the items created from the owl is added as a patch to obsolete status to the updates
     '''
     to_update = []
     to_post = []
@@ -709,7 +715,7 @@ def main():
         filter_unchanged = True
         if args.full:
             filter_unchanged = False
-        items2upd = id_post_and_patch(terms, db_terms, itype, filter_unchanged, logger=logger)
+        items2upd = identify_item_updates(terms, db_terms, itype, filter_unchanged, logger=logger)
         pretty = False
         if args.pretty:
             pretty = True

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -334,12 +334,14 @@ def _format_as_raw(val):
 
 
 def get_raw_form(term):
-    ''' takes a term dict that could be in embedded or object format
+    ''' takes a term dict that is in embedded frame format
         and transforms to raw (so uuids) are used for linked items
+        WARNING: DOES NOT work for object frame - won't convert @ids
+        and should not change an already raw frame json
     '''
     raw_term = {}
     for field, val in term.items():
-        if isinstance(val, str):
+        if isinstance(val, (str, int, float, bool)):
             raw_term[field] = val
         else:
             rawval = _format_as_raw(val)
@@ -350,15 +352,19 @@ def get_raw_form(term):
 
 
 def compare_terms(t1, t2):
-    '''check that all the fields in the first term t1 are in t2 and
-        have the same values
+    ''' compare t1 to t2 and if a key is not in t2 or
+        the key is there but the value is different
+        returns a dict of the new key:val of t1
+
+        NOTE: could be false positives if the order of fields in a subembedded object differ
+        consider revisting (though we don't have that use case at this time)
     '''
     diff = {}
     for k, val in t1.items():
         if k not in t2:
             diff[k] = val
         elif isinstance(val, list):
-            if (len(val) != len(t2[k])) or (Counter(val) != Counter(t2[k])):
+            if (len(val) != len(t2[k])) or (Counter(str(val)) != Counter(str(t2[k]))):
                 diff[k] = val
         elif val != t2[k]:
             diff[k] = val

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -1,5 +1,5 @@
 import argparse
-import datetime
+from datetime import datetime
 import logging
 import logging.config
 import json
@@ -14,7 +14,6 @@ from dcicutils.ff_utils import (
     unified_authentication,
     post_metadata
 )
-from rdflib.collection import Collection
 from uuid import uuid4
 from ..commands.load_items import load_items
 from ..commands.owltools import (
@@ -25,7 +24,6 @@ from ..commands.owltools import (
     isURIRef,
     isBlankNode,
     getObjectLiteralsOfType,
-    subClassOf,
     Deprecated,
     hasDbXref,
     hasAltId
@@ -34,44 +32,44 @@ from ..commands.owltools import (
 
 EPILOG = __doc__
 
-'''logging setup
-   logging config - to be moved to file at some point
-'''
-logfile = 'process_dp_upd.log'
-logger = logging.getLogger(__name__)
-
-logging.config.dictConfig({
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'standard': {
-            'format': '%(levelname)s:\t%(message)s'
-        },
-        'verbose': {
-            'format': '%(levelname)s:\t%(message)s\tFROM: %(name)s'
-        }
-    },
-    'handlers': {
-        'stdout': {
-            'level': 'WARN',
-            'formatter': 'verbose',
-            'class': 'logging.StreamHandler'
-        },
-        'logfile': {
-            'level': 'INFO',
-            'formatter': 'standard',
-            'class': 'logging.FileHandler',
-            'filename': logfile
-        }
-    },
-    'loggers': {
-        '': {
-            'handlers': ['stdout', 'logfile'],
-            'level': 'INFO',
-            'propagate': True
-        }
-    }
-})
+# '''logging setup
+#    logging config - to be moved to file at some point
+# '''
+# logfile = 'process_dp_upd.log'
+# logger = logging.getLogger(__name__)
+#
+# logging.config.dictConfig({
+#     'version': 1,
+#     'disable_existing_loggers': False,
+#     'formatters': {
+#         'standard': {
+#             'format': '%(levelname)s:\t%(message)s'
+#         },
+#         'verbose': {
+#             'format': '%(levelname)s:\t%(message)s\tFROM: %(name)s'
+#         }
+#     },
+#     'handlers': {
+#         'stdout': {
+#             'level': 'WARN',
+#             'formatter': 'verbose',
+#             'class': 'logging.StreamHandler'
+#         },
+#         'logfile': {
+#             'level': 'INFO',
+#             'formatter': 'standard',
+#             'class': 'logging.FileHandler',
+#             'filename': logfile
+#         }
+#     },
+#     'loggers': {
+#         '': {
+#             'handlers': ['stdout', 'logfile'],
+#             'level': 'INFO',
+#             'propagate': True
+#         }
+#     }
+# })
 
 ''' global config '''
 ITEM2OWL = {
@@ -98,6 +96,45 @@ ITEM2OWL = {
         'url_field': 'hpo_url'
     },
 }
+
+
+def get_logger(lname, logfile):
+    """logging setup"""
+    logger = logging.getLogger(lname)
+
+    logging.config.dictConfig({
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'standard': {
+                'format': '%(levelname)s:\t%(message)s'
+            },
+            'verbose': {
+                'format': '%(levelname)s:\t%(message)s\tFROM: %(name)s'
+            }
+        },
+        'handlers': {
+            'stdout': {
+                'level': 'WARN',
+                'formatter': 'verbose',
+                'class': 'logging.StreamHandler'
+            },
+            'logfile': {
+                'level': 'INFO',
+                'formatter': 'standard',
+                'class': 'logging.FileHandler',
+                'filename': logfile
+            }
+        },
+        'loggers': {
+            '': {
+                'handlers': ['stdout', 'logfile'],
+                'level': 'INFO',
+                'propagate': True
+            }
+        }
+    })
+    return logger
 
 
 def iterative_parents(nodes, terms, data):
@@ -303,7 +340,7 @@ def get_existing_items(connection, itype, include_obs_n_del=True):
     return terms
 
 
-def connect2server(env=None, key=None, keyfile=None):
+def connect2server(env=None, key=None, keyfile=None, logger=None):
     '''Sets up credentials for accessing the server.  Generates a key using info
        from the named keyname in the keyfile and checks that the server can be
        reached with that key.
@@ -413,7 +450,7 @@ def id_fields2patch(term, dbterm, rm_unch):
         return term
 
 
-def id_post_and_patch(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=True):
+def id_post_and_patch(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=True, logger=None):
     '''compares terms to terms that are already in db - if no change
         removes them from the list of updates, if new adds to post dict,
         if changed adds uuid and add to patch dict
@@ -446,7 +483,7 @@ def id_post_and_patch(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=Tr
 
     # all terms have uuid - now add uuids to linked terms
     for term in terms.values():
-        puuids = _get_uuids_for_linked(term, tid2uuid, itype)
+        puuids = _get_uuids_for_linked(term, tid2uuid, itype, logger)
         for rt, uuids in puuids.items():
             term[rt] = list(set(uuids))  # to avoid redundant terms
 
@@ -488,7 +525,7 @@ def id_post_and_patch(terms, dbterms, itype, rm_unchanged=True, set_obsoletes=Tr
     return to_update
 
 
-def _get_uuids_for_linked(term, idmap, itype):
+def _get_uuids_for_linked(term, idmap, itype, logger=None):
     puuids = {}
     for rt in ['parents', 'slim_terms']:
         tlist = term.get(rt)
@@ -646,7 +683,7 @@ def post_report_document_to_portal(connection, itype, logfile):
     meta = {'institution': inst, 'project': proj}
     mimetype = "text/plain"
     rtype = 'document'
-    date = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     attach_fn = None
     if os.path.isfile(logfile):
         attach_fn = '{}_update_report_{}.txt'.format(itype, date)
@@ -664,7 +701,7 @@ def post_report_document_to_portal(connection, itype, logfile):
     return
 
 
-def prompt_check_for_output_options(load, outfile, itype, server):
+def prompt_check_for_output_options(load, outfile, itype, server, logger=None):
     if load:
         choice1 = str(input("load is True - are you sure you want to directly load the output to {} (y/n)?: ".format(server)))
         if choice1.lower() == 'y':
@@ -691,13 +728,16 @@ def main():
 
         logging/tracking info
     '''
-    start = datetime.datetime.now()
+    start = datetime.now()
+    dt = start.strftime("%y-%m-%d-%H-%M-%S")
     args = parse_args(sys.argv[1:])
     itype = args.item_type
+    logfile = '{}_{}_item_upd.log'.format(dt, itype)
+    logger = get_logger(__name__, logfile)
     logger.info('Processing {} on {}'.format(itype, start))
     connection = connect2server(args.env, args.key, args.keyfile)
     logger.info('Running on {}'.format(connection.get('server')))
-    postfile, loaddb = prompt_check_for_output_options(args.load, args.outfile, itype, connection.get('server'))
+    postfile, loaddb = prompt_check_for_output_options(args.load, args.outfile, itype, connection.get('server'), logger)
 
     logger.debug('Getting existing items from ', args.env)
     db_terms = get_existing_items(connection, itype)
@@ -727,23 +767,21 @@ def main():
         filter_unchanged = True
         if args.full:
             filter_unchanged = False
-        items2upd = id_post_and_patch(terms, db_terms, itype, filter_unchanged)
+        items2upd = id_post_and_patch(terms, db_terms, itype, filter_unchanged, logger=logger)
         pretty = False
         if args.pretty:
             pretty = True
         if postfile:
             write_outfile(items2upd, postfile, pretty)
         if loaddb:
-            res = load_items(items2upd, itypes=[itype], auth=connection)
+            res = load_items(items2upd, itypes=[itype], auth=connection, logger=logger)
             logger.info(res)
             logger.info(json.dumps(items2upd, indent=4))
-    stop = datetime.datetime.now()
+    stop = datetime.now()
     logger.info('STARTED: {}'.format(str(start)))
     logger.info('END: {}'.format(str(stop)))
     if args.post_report:
         post_report_document_to_portal(connection, itype, logfile)
-    dt = end.strftime("%y-%m-%d-%H-%M-%S")
-    os.rename(logfile, dt + logfile)
 
 
 if __name__ == '__main__':

--- a/src/encoded/commands/load_items.py
+++ b/src/encoded/commands/load_items.py
@@ -7,44 +7,6 @@ import json
 from datetime import datetime
 from dcicutils import ff_utils
 
-# '''logging setup
-#    logging config - to be moved to file at some point
-# '''
-# date = datetime.now().strftime("%y-%m-%d-%H-%M-%S")
-# logfile = 'load_items.log'
-# logger = logging.getLogger(__name__)
-# logging.config.dictConfig({
-#     'version': 1,
-#     'disable_existing_loggers': False,
-#     'formatters': {
-#         'standard': {
-#             'format': '%(levelname)s:\t%(message)s'
-#         },
-#         'verbose': {
-#             'format': '%(levelname)s:\t%(message)s\tFROM: %(name)s'
-#         }
-#     },
-#     'handlers': {
-#         'stdout': {
-#             'level': 'INFO',
-#             'formatter': 'verbose',
-#             'class': 'logging.StreamHandler'
-#         },
-#         'logfile': {
-#             'level': 'INFO',
-#             'formatter': 'standard',
-#             'class': 'logging.FileHandler',
-#             'filename': logfile
-#         }
-#     },
-#     'loggers': {
-#         '': {
-#             'handlers': ['stdout', 'logfile'],
-#             'level': 'INFO',
-#             'propagate': True
-#         }
-#     }
-# })
 
 EPILOG = __doc__
 
@@ -202,7 +164,7 @@ def load_items(json_input, itypes=None, env=None, auth=None, patch_only=False, p
         num_items = len(idata)
         logger.info('{} {}'.format(num_items, iname))
         num_to_load += num_items
-    start = datetime.now()
+    start = datetime.utcnow()
     if not json_data.get('store'):
         logger.error("No DATA to LOAD!")
         return
@@ -235,7 +197,8 @@ def load_items(json_input, itypes=None, env=None, auth=None, patch_only=False, p
         if not post_only and (len(load_res['POST']) + len(load_res['SKIP'])) > len(load_res['PATCH']):
             missed = set(load_res['POST'] + load_res['SKIP']) - set(load_res['PATCH'])
             logger.error("The following {} items passed round I (POST/skip) but not round II (PATCH): {}".format(len(missed), missed))
-    logger.info("Finished request in %s" % str(datetime.now() - start))
+    request_time = datetime.utcnow() - start
+    logger.info("Finished request in {}".format(str(request_time)))
 
 
 def main():
@@ -243,18 +206,16 @@ def main():
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.INFO)
     args = parse_args()
-    start = datetime.now()
-    dt = start.strftime("%y-%m-%d-%H-%M-%S")
-    logfile = '{}_load_items.log'.format(dt)
+    start = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    logfile = '{}_load_items.log'.format(start.replace(':', '-'))
     logger = get_logger(__name__, logfile)
     auth = None
     if not args.env and args.key:
         auth = get_auth(args.key, args.keyfile)
     load_items(args.json_input, args.item_types, args.env, auth, args.patch_only, args.post_only, logger)
     end = datetime.now()
-    et = end.strftime("%y-%m-%d-%H-%M-%S")
+    et = utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     logger.info("DONE! {}".format(et))
-
 
 
 if __name__ == "__main__":

--- a/src/encoded/commands/parse_hpoa.py
+++ b/src/encoded/commands/parse_hpoa.py
@@ -5,6 +5,7 @@ import json
 import logging
 import logging.config
 import os
+import pdb
 import re
 import requests
 import sys
@@ -18,6 +19,9 @@ from dcicutils.ff_utils import (
     search_metadata,
 )
 from uuid import uuid4
+
+from typing import List, Any
+
 from ..commands.generate_items_from_owl import (
     connect2server,
     get_raw_form,
@@ -25,45 +29,6 @@ from ..commands.generate_items_from_owl import (
     post_report_document_to_portal,
 )
 from ..commands.load_items import load_items
-
-
-'''logging setup
-   logging config - to be moved to file at some point
-'''
-logfile = 'upd_dis2pheno_annot.log'
-logger = logging.getLogger(__name__)
-logging.config.dictConfig({
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'standard': {
-            'format': '%(levelname)s:\t%(message)s'
-        },
-        'verbose': {
-            'format': '%(levelname)s:\t%(message)s\tFROM: %(name)s'
-        }
-    },
-    'handlers': {
-        'stdout': {
-            'level': 'INFO',
-            'formatter': 'verbose',
-            'class': 'logging.StreamHandler'
-        },
-        'logfile': {
-            'level': 'INFO',
-            'formatter': 'standard',
-            'class': 'logging.FileHandler',
-            'filename': logfile
-        }
-    },
-    'loggers': {
-        '': {
-            'handlers': ['stdout', 'logfile'],
-            'level': 'INFO',
-            'propagate': True
-        }
-    }
-})
 
 
 ''' Dictionary for field mapping between hpoa file and cgap disorder schema
@@ -86,32 +51,52 @@ FIELD_MAPPING = {
 RELATION = 'associated with'
 
 
-def convert2raw(item):
-    # need to remove properties not generated from file eg. calc props and others
-    fields2remove = ['uuid', '@id', '@type', 'display_title', 'status', 'principals_allowed', 'date_created']
-    stripped_item = {k: v for k, v in item.items() if k not in fields2remove}
-    return get_raw_form(stripped_item)
+def get_logger(lname, logfile):
+    """logging setup
+       logging config - to be moved to file at some point
+    """
+    logger = logging.getLogger(lname)
+    logging.config.dictConfig({
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'standard': {
+                'format': '%(levelname)s:\t%(message)s'
+            },
+            'verbose': {
+                'format': '%(levelname)s:\t%(message)s\tFROM: %(name)s'
+            }
+        },
+        'handlers': {
+            'stdout': {
+                'level': 'INFO',
+                'formatter': 'verbose',
+                'class': 'logging.StreamHandler'
+            },
+            'logfile': {
+                'level': 'INFO',
+                'formatter': 'standard',
+                'class': 'logging.FileHandler',
+                'filename': logfile
+            }
+        },
+        'loggers': {
+            '': {
+                'handlers': ['stdout', 'logfile'],
+                'level': 'INFO',
+                'propagate': True
+            }
+        }
+    })
+    return logger
 
 
-def check_fields(data):
-    return [f for f in data if (f != 'DiseaseName' and f not in FIELD_MAPPING)]
-
-
-def get_disorders_from_db(connection):
-    q = 'search/?type=Disorder'
-    return {d.get('uuid'): d for d in search_metadata(q, connection, page_limit=200, is_generator=True)}
-
-
-def get_existing_phenotype_uuids(connection):
-    q = 'search/?type=Phenotype'
-    result = search_metadata(q, connection, page_limit=200, is_generator=True)
-    return {r.get('hpo_id'): r.get('uuid') for r in result}
-
-
-def get_phenotypes_from_db(connection):
-    q = 'search/?type=Phenotype'
-    result = search_metadata(q, connection, page_limit=200, is_generator=True)
-    return {r.get('hpo_id'): r for r in result}
+def get_items_from_db_keyed_by_field(connection, itype, keyfield):
+    """ Returns all the items of the given type in the db as a dictionary
+        keyed by the given field
+    """
+    q = 'search/?type={}'.format(itype)
+    return {i.get(keyfield): i for i in search_metadata(q, connection, page_limit=200, is_generator=True)}
 
 
 def get_dbxref2disorder_map(disorders):
@@ -126,6 +111,78 @@ def get_dbxref2disorder_map(disorders):
                     if x.startswith('OMIM:') or x.lower().startswith('orpha') or x.lower().startswith('decip'):
                         xref2dis[x] = duid
     return xref2dis
+
+
+def get_input_gen(input):
+    """ depending on what is passed as input will create a generator
+        that returns lines from a web request or lines of a file
+    """
+    if input.startswith('http'):
+        try:
+            with requests.get(input, timeout=5) as r:
+                if r.encoding is None:
+                    r.encoding = 'utf-8'
+                res = r.text
+                for l in res.split('\n'):
+                    yield l
+        except Exception as e:
+            print(e)
+            return []
+    elif os.path.isfile(input):
+        try:
+            with open(input) as r:
+                for line in r:
+                    line = line.strip()
+                    yield line
+        except Exception as e:
+            print(e)
+            return []
+    r.close()
+
+
+def line2list(line):
+    return [d.strip() for d in line.split('\t')]
+
+
+def check_fields(data):
+    return [f for f in data if (f != 'DiseaseName' and f not in FIELD_MAPPING)]
+
+
+def get_header_info_and_field_names(lines, logger):
+    fields = []
+    dtag = 'date: '
+    fdtag = 'description: '
+    date = 'unknown'
+    fdesc = 'unknown'
+    while True:
+        line = next(lines)
+        if not line.startswith("#"):
+            break
+        elif dtag in line:
+            # get the date that the file was generated
+            _, date = line.split(dtag)
+        elif fdtag in line:
+            _, fdesc = line.split(fdtag)
+    logger.info("Annotation file info:\n\tdate: {}\n\tdescription: {}".format(date, fdesc))
+    fields = line2list(line)
+    bad_fields = check_fields(fields)
+    if bad_fields:
+        logger.error("UNKNOWN FIELDS FOUND: {}".format(', '.join(bad_fields)))
+        sys.exit()
+    return fields, lines
+
+
+def find_disorder_uid_using_file_id(data, xref2disorder):
+    """ gets the database ID used in annotation file and maps to existing disorder uuid
+    """
+    using_id = data.get('DatabaseID')
+    if not using_id:
+        return
+    if using_id.startswith('ORPHA'):
+        map_id = using_id.replace('ORPHA', 'Orphanet')
+    else:
+        map_id = using_id
+    return xref2disorder.get(map_id)
 
 
 def check_hpo_id_and_note_problems(fname, hpoid, hpoid2uuid, problems):
@@ -143,8 +200,67 @@ def check_hpo_id_and_note_problems(fname, hpoid, hpoid2uuid, problems):
     return None
 
 
-def line2list(line):
-    return [d.strip() for d in line.split('\t')]
+def create_evi_annotation(data, hpoid2uuid, problems):
+    """ Looks at all the fields in the annotation line and
+        transforms to EvidenceDisPheno format
+    """
+    HP_REGEX = re.compile('^HP:[0-9]{7}')
+    pheno_annot = {}
+    for f, v in data.items():
+        if not v or (f == 'DiseaseName'):
+            continue
+        if f in ['subject_item', 'object_item']:
+            cgf = f
+        elif f == 'Frequency':
+            if v.startswith('HP:'):
+                cgf = FIELD_MAPPING[f][0]
+            else:
+                cgf = FIELD_MAPPING[f][1]
+        else:
+            cgf = FIELD_MAPPING[f]
+
+        if f == 'Qualifier':
+            v = True
+        elif f == 'Sex':
+            v = v[0:1].upper()
+
+        if isinstance(v, str) and HP_REGEX.match(v):
+            hpuid = check_hpo_id_and_note_problems(f, v, hpoid2uuid, problems)
+            if not hpuid:
+                continue
+            else:
+                v = hpuid
+        pheno_annot[cgf] = v
+    return pheno_annot
+
+
+def compare_existing_to_newly_generated(logger, connection, evidence_items, itype):
+    """ gets all the existing evidence items from database and compares to all the newly
+        generated ones from annotations and if found removes from list
+    """
+    sq = 'search/?type={}&status!=obsolete'.format(itype)
+    logger.info("COMPARING FILE ITEMS WITH CURRENT DB CONTENT")
+    logger.info("searching: {}".format(str(datetime.now())))
+    dbitems = search_metadata(sq, connection, is_generator=True, page_limit=500)
+    existing = 0
+    uids2obsolete = []
+    logger.info("comparing: {}".format(str(datetime.now())))
+    for db_evi in dbitems:
+        tochk = convert2raw(db_evi)
+        if tochk in evidence_items:
+            existing += 1
+            evidence_items.remove(tochk)
+        else:
+            uids2obsolete.append(db_evi.get('uuid'))
+    logger.info("result: {}".format(str(datetime.now())))
+    return evidence_items, existing, uids2obsolete
+
+
+def convert2raw(item):
+    # need to remove properties not generated from file eg. calc props and others
+    fields2remove = ['uuid', '@id', '@type', 'display_title', 'status', 'principals_allowed', 'date_created']
+    stripped_item = {k: v for k, v in item.items() if k not in fields2remove}
+    return get_raw_form(stripped_item)
 
 
 def write_outfile(terms, filename, pretty=False):
@@ -159,32 +275,21 @@ def write_outfile(terms, filename, pretty=False):
             json.dump(terms, outfile)
 
 
-def get_input_gen(input):
-    ''' depending on what is passed as input will create a generator
-        that returns lines from a webrequest or lines of a file
-    '''
-    if input.startswith('http'):
-        try:
-            with requests.get(input, timeout=5) as r:
-                if r.encoding is None:
-                    r.encoding = 'utf-8'
-                # res = r.iter_lines(decode_unicode=True)
-                res = r.text
-                for l in res.split('\n'):
-                    yield l
-        except Exception as e:
-            print(e)
-            return []
-    elif os.path.isfile(input):
-        try:
-            with open(input) as r:
-                for line in r:
-                    line = line.strip()
-                    yield line
-        except Exception as e:
-            print(e)
-            return []
-    r.close()
+def log_problems(logger, problems):
+    missing_phenos = problems.get('hpo_not_found')
+    if missing_phenos:
+        logger.info("{} missing HPO terms used in hpoa file".format(len(missing_phenos)))
+        for hpoid, fields in missing_phenos.items():
+            logger.info("{}\t{}".format(hpoid, fields))
+    dup_annots = problems.get('redundant_annot')
+    if dup_annots:
+        logger.info("{} redundant annotations found".format(len(dup_annots)))
+    unmapped_dis = problems.get('no_map')
+    if unmapped_dis:
+        udis = {u.get('DatabaseID'): u.get('DiseaseName') for u in unmapped_dis}
+        logger.info("{} disorders from {} annotation lines not found by xref".format(len(udis), len(unmapped_dis)))
+        for d in sorted(list(udis.keys())):
+            logger.info('{}\t{}'.format(d, udis[d]))
 
 
 def get_args():  # pragma: no cover
@@ -223,68 +328,56 @@ def get_args():  # pragma: no cover
 
 
 def main():  # pragma: no cover
+    ITEMTYPE = 'EvidenceDisPheno'
+
     start = datetime.now()
+    dt = start.strftime("%y-%m-%d-%H-%M-%S")
+    logfile = '{}_upd_dis2pheno_annot.log'.format(dt)
+    logger = get_logger(__name__, logfile)
     logger.info('Processing disorder to phenotype annotations - START:{}'.format(str(start)))
+
     args = get_args()
-    itype = 'EvidenceDisPheno'
 
     connection = connect2server(args.env, args.key, args.keyfile)
     logger.info('Working with {}'.format(connection.get('server')))
-    postfile, loaddb = prompt_check_for_output_options(args.load, args.outfile, itype, connection.get('server'))
-    logger.info('Getting existing Items')
-    logger.info('Disorders')
-    disorders = get_disorders_from_db(connection)
-    logger.info('Phenotypes')
-    phenotypes = get_phenotypes_from_db(connection)
 
-    hp_regex = re.compile('^HP:[0-9]{7}')
+    postfile, loaddb = prompt_check_for_output_options(args.load, args.outfile, ITEMTYPE, connection.get('server'))
+
+    logger.info('Getting existing Items from Database')
+    logger.info('Disorders')
+    disorders = get_items_from_db_keyed_by_field(connection, 'Disorder', 'uuid')
+    logger.info('Phenotypes')
+    phenotypes = get_items_from_db_keyed_by_field(connection, 'Phenotype', 'hpo_id')
+
+
     hpoid2uuid = {hid: pheno.get('uuid') for hid, pheno in phenotypes.items()}
     xref2disorder = get_dbxref2disorder_map(disorders)
-    evidence_items = []  # {}
+
+    evidence_items = []
     problems = {}
+
     # figure out input and if to save the file
     insrc = args.input
     logger.info("Getting annotation data using: {}".format(insrc))
+
+    # this a generator for all the lines of annotation data
     lines = get_input_gen(insrc)
-    fields = []
-    dtag = 'date: '
-    fdtag = 'description: '
-    date = 'unknown'
-    fdesc = 'unknown'
-    while True:
-        line = next(lines)
-        if not line.startswith("#"):
-            break
-        elif dtag in line:
-            # get the date that the file was generated
-            _, date = line.split(dtag)
-        elif fdtag in line:
-            _, fdesc = line.split(fdtag)
-    logger.info("Annotation file info:\n\tdate: {}\n\tdescription: {}".format(date, fdesc))
-    fields = line2list(line)
-    bad_fields = check_fields(fields)
-    if bad_fields:
-        logger.error("UNKNOWN FIELDS FOUND: {}".format(', '.join(bad_fields)))
-        sys.exit()
+
+    fields, lines = get_header_info_and_field_names(lines, logger)
 
     for line in lines:
         if line.startswith("#"):
             continue
         data_list = line2list(line)
         data = dict(zip(fields, data_list))
+
         # find the  disorder_uuid to refer to subject_item
-        using_id = data.get('DatabaseID')
-        if not using_id:
-            continue
-        if using_id.startswith('ORPHA'):
-            map_id = using_id.replace('ORPHA', 'Orphanet')
-        else:
-            map_id = using_id
-        if map_id not in xref2disorder:
+        disorder_id = find_disorder_uid_using_file_id(data, xref2disorder)
+        if not disorder_id:
             problems.setdefault('no_map', []).append(data)
             continue
-        disorder_id = xref2disorder.get(map_id)
         data['subject_item'] = disorder_id
+
         # and the HPO_ID to refer to object_item
         hpo_id = data.get('HPO_ID')
         phenotype_id = check_hpo_id_and_note_problems('HPO_ID', hpo_id, hpoid2uuid, problems)
@@ -293,32 +386,8 @@ def main():  # pragma: no cover
             continue
         data['object_item'] = phenotype_id
         del data['HPO_ID']
-        pheno_annot = {}
-        for f, v in data.items():
-            if not v or (f == 'DiseaseName'):
-                continue
-            if f in ['subject_item', 'object_item']:
-                cgf = f
-            elif f == 'Frequency':
-                if v.startswith('HP:'):
-                    cgf = FIELD_MAPPING[f][0]
-                else:
-                    cgf = FIELD_MAPPING[f][1]
-            else:
-                cgf = FIELD_MAPPING[f]
 
-            if f == 'Qualifier':
-                v = True
-            elif f == 'Sex':
-                v = v[0:1].upper()
-
-            if isinstance(v, str) and hp_regex.match(v):
-                hpuid = check_hpo_id_and_note_problems(f, v, hpoid2uuid, problems)
-                if not hpuid:
-                    continue
-                else:
-                    v = hpuid
-            pheno_annot[cgf] = v
+        pheno_annot = create_evi_annotation(data, hpoid2uuid, problems)
 
         if pheno_annot:
             pheno_annot['relationship_name'] = RELATION
@@ -326,30 +395,16 @@ def main():  # pragma: no cover
                 problems.setdefault('redundant_annot', []).append(pheno_annot)  # (data, dis2pheno[ppos]))
                 continue
             evidence_items.append(pheno_annot)
+
     logger.info("after parsing annotation file we have {} evidence items".format(len(evidence_items)))
 
-    # at this point we've gone through all the lines in the file
-    # here we want to compare with what already exists in db
-    patches = []
-    sq = 'search/?type={}&status!=obsolete'.format(itype)
-    logger.info("COMPARING FILE ITEMS WITH CURRENT DB CONTENT")
-    logger.info("searching: {}".format(str(datetime.now())))
-    res = search_metadata(sq, connection, is_generator=True, page_limit=500)
-    existing = 0
-    uids2obsolete = []
-    logger.info("comparing: {}".format(str(datetime.now())))
-    for db_evi in res:
-        tochk = convert2raw(db_evi)
-        if tochk in evidence_items:
-            existing += 1
-            evidence_items.remove(tochk)
-        else:
-            uids2obsolete.append(db_evi.get('uuid'))
-    logger.info("result: {}".format(str(datetime.now())))
+    evidence_items, existing, uids2obsolete = compare_existing_to_newly_generated(logger, connection, evidence_items, ITEMTYPE)
+
     logger.info('{} EXISTING DB ITEMS WILL NOT BE CHANGED'.format(existing))
     logger.info('{} EXISTING DB ITEMS WILL BE SET TO OBSOLETE'.format(len(uids2obsolete)))
     logger.info('{} NEW ITEMS TO BE LOADED TO DB'.format(len(evidence_items)))
-    # let's add uuids to new items so second round will work
+
+    # let's add uuids to new items
     [evi.update({'uuid': str(uuid4())}) for evi in evidence_items]
     obs_patch = [{'uuid': uid, 'status': 'obsolete'} for uid in uids2obsolete]
 
@@ -358,34 +413,19 @@ def main():  # pragma: no cover
             write_outfile([evidence_items, obs_patch], postfile, args.pretty)
         if loaddb:
             if evidence_items:
-                res = load_items(evidence_items, itypes=[itype], auth=connection, post_only=True)
+                res = load_items(evidence_items, itypes=[ITEMTYPE], auth=connection, post_only=True)
                 logger.info(res)
             if obs_patch:
-                res2 = load_items(obs_patch, itypes=[itype], auth=connection, patch_only=True)
+                res2 = load_items(obs_patch, itypes=[ITEMTYPE], auth=connection, patch_only=True)
                 logger.info(res2)
             # logger.info(json.dumps(res, indent=4))
     if problems:
-        # log problems
-        missing_phenos = problems.get('hpo_not_found')
-        if missing_phenos:
-            logger.info("{} missing HPO terms used in hpoa file".format(len(missing_phenos)))
-            for hpoid, fields in missing_phenos.items():
-                logger.info("{}\t{}".format(hpoid, fields))
-        dup_annots = problems.get('redundant_annot')
-        if dup_annots:
-            logger.info("{} redundant annotations found".format(len(dup_annots)))
-        unmapped_dis = problems.get('no_map')
-        if unmapped_dis:
-            udis = {u.get('DatabaseID'): u.get('DiseaseName') for u in unmapped_dis}
-            logger.info("{} disorders from {} annotation lines not found by xref".format(len(udis), len(unmapped_dis)))
-            for d in sorted(list(udis.keys())):
-                logger.info('{}\t{}'.format(d, udis[d]))
+        log_problems(logger, problems)
+           
     end = datetime.now()
     logger.info("FINISHED - START: {}\tEND: {}".format(start, str(end)))
     if args.post_report:
         post_report_document_to_portal(connection, itype, logfile)
-    dt = end.strftime("%y-%m-%d-%H-%M-%S")
-    os.rename(logfile, dt + logfile)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/src/encoded/commands/parse_hpoa.py
+++ b/src/encoded/commands/parse_hpoa.py
@@ -239,11 +239,11 @@ def compare_existing_to_newly_generated(logger, connection, evidence_items, ityp
     """
     sq = 'search/?type={}&status!=obsolete'.format(itype)
     logger.info("COMPARING FILE ITEMS WITH CURRENT DB CONTENT")
-    logger.info("searching: {}".format(str(datetime.now())))
+    logger.info("searching: {}".format(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")))
     dbitems = search_metadata(sq, connection, is_generator=True, page_limit=500)
     existing = 0
     uids2obsolete = []
-    logger.info("comparing: {}".format(str(datetime.now())))
+    logger.info("comparing: {}".format(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")))
     for db_evi in dbitems:
         tochk = convert2raw(db_evi)
         if tochk in evidence_items:
@@ -251,7 +251,7 @@ def compare_existing_to_newly_generated(logger, connection, evidence_items, ityp
             evidence_items.remove(tochk)
         else:
             uids2obsolete.append(db_evi.get('uuid'))
-    logger.info("result: {}".format(str(datetime.now())))
+    logger.info("result: {}".format(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")))
     return evidence_items, existing, uids2obsolete
 
 
@@ -329,11 +329,10 @@ def get_args():  # pragma: no cover
 def main():  # pragma: no cover
     ITEMTYPE = 'EvidenceDisPheno'
 
-    start = datetime.now()
-    dt = start.strftime("%y-%m-%d-%H-%M-%S")
-    logfile = '{}_upd_dis2pheno_annot.log'.format(dt)
+    start = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    logfile = '{}_upd_dis2pheno_annot.log'.format(start.replace(':', '-'))
     logger = get_logger(__name__, logfile)
-    logger.info('Processing disorder to phenotype annotations - START:{}'.format(str(start)))
+    logger.info('Processing disorder to phenotype annotations - START:{}'.format(start))
 
     args = get_args()
 
@@ -347,7 +346,6 @@ def main():  # pragma: no cover
     disorders = get_items_from_db_keyed_by_field(connection, 'Disorder', 'uuid')
     logger.info('Phenotypes')
     phenotypes = get_items_from_db_keyed_by_field(connection, 'Phenotype', 'hpo_id')
-
 
     hpoid2uuid = {hid: pheno.get('uuid') for hid, pheno in phenotypes.items()}
     xref2disorder = get_dbxref2disorder_map(disorders)
@@ -421,8 +419,8 @@ def main():  # pragma: no cover
     if problems:
         log_problems(logger, problems)
 
-    end = datetime.now()
-    logger.info("FINISHED - START: {}\tEND: {}".format(start, str(end)))
+    end = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    logger.info("FINISHED - START: {}\tEND: {}".format(start, end))
     if args.post_report:
         post_report_document_to_portal(connection, itype, logfile)
 

--- a/src/encoded/commands/parse_hpoa.py
+++ b/src/encoded/commands/parse_hpoa.py
@@ -5,7 +5,6 @@ import json
 import logging
 import logging.config
 import os
-import pdb
 import re
 import requests
 import sys
@@ -338,10 +337,10 @@ def main():  # pragma: no cover
 
     args = get_args()
 
-    connection = connect2server(args.env, args.key, args.keyfile)
+    connection = connect2server(args.env, args.key, args.keyfile, logger)
     logger.info('Working with {}'.format(connection.get('server')))
 
-    postfile, loaddb = prompt_check_for_output_options(args.load, args.outfile, ITEMTYPE, connection.get('server'))
+    postfile, loaddb = prompt_check_for_output_options(args.load, args.outfile, ITEMTYPE, connection.get('server'), logger)
 
     logger.info('Getting existing Items from Database')
     logger.info('Disorders')
@@ -413,15 +412,15 @@ def main():  # pragma: no cover
             write_outfile([evidence_items, obs_patch], postfile, args.pretty)
         if loaddb:
             if evidence_items:
-                res = load_items(evidence_items, itypes=[ITEMTYPE], auth=connection, post_only=True)
+                res = load_items(evidence_items, itypes=[ITEMTYPE], auth=connection, post_only=True, logger=logger)
                 logger.info(res)
             if obs_patch:
-                res2 = load_items(obs_patch, itypes=[ITEMTYPE], auth=connection, patch_only=True)
+                res2 = load_items(obs_patch, itypes=[ITEMTYPE], auth=connection, patch_only=True, logger=logger)
                 logger.info(res2)
             # logger.info(json.dumps(res, indent=4))
     if problems:
         log_problems(logger, problems)
-           
+
     end = datetime.now()
     logger.info("FINISHED - START: {}\tEND: {}".format(start, str(end)))
     if args.post_report:

--- a/src/encoded/tests/data/documents/test_uberon4.owl
+++ b/src/encoded/tests/data/documents/test_uberon4.owl
@@ -1,41 +1,65 @@
 <?xml version="1.0"?>
-  <rdf:RDF xmlns="http://purl.obolibrary.org/obo/uberon/ext.owl#"
-       xml:base="http://purl.obolibrary.org/obo/uberon/ext.owl"
-       xmlns:owl="http://www.w3.org/2002/07/owl#"
-       xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-      <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/uberon/ext.owl">
-      </owl:Ontology>
-  <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
-  <!-- http://purl.obolibrary.org/obo/CL_0002553 -->
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/hp.owl#"
+     xml:base="http://purl.obolibrary.org/obo/hp.owl"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+     xmlns:hsapdv="http://purl.obolibrary.org/obo/hsapdv#"
+     xmlns:hp="http://purl.obolibrary.org/obo/hp#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:nbo="http://purl.obolibrary.org/obo/nbo.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:hp2="http://purl.obolibrary.org/obo/hp.owl#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/hp.owl">
+    </owl:Ontology>
 
-     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0002553">
-         <rdfs:subClassOf>
-             <owl:Restriction>
-                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002048"/>
-             </owl:Restriction>
-         </rdfs:subClassOf>
-         <rdfs:subClassOf>
-             <owl:Restriction>
-                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
-                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000133"/>
-             </owl:Restriction>
-         </rdfs:subClassOf>
-         <rdfs:subClassOf>
-             <owl:Restriction>
-                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000058"/>
-             </owl:Restriction>
-         </rdfs:subClassOf>
-         <rdfs:subClassOf>
-             <owl:Restriction>
-                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000417"/><!-- achieves_planned_objective -->
-                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000456"/><!-- material transformation objective -->
-             </owl:Restriction>
-         </rdfs:subClassOf>
-         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010313"/>
-         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fibroblast of lung</rdfs:label>
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000811 -->
+
+     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000811">
+         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormal external genitalia</rdfs:label>
+         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormal external genitalia</oboInOwl:hasExactSynonym>
+         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0000811</oboInOwl:id>
+         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C4025825</oboInOwl:hasDbXref>
+         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
      </owl:Class>
+
+     <!-- http://purl.obolibrary.org/obo/HP_0010460 -->
+
+     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0010460">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of the female genitalia</rdfs:label>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2009-09-15T08:32:09Z</oboInOwl:creation_date>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of the female genital system.</obo:IAO_0000115>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of the female internal or external genitalia.</rdfs:comment>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0010460</oboInOwl:id>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C4023820</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+    </owl:Class>
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000055 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000055">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of female external genitalia</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0000811"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0010460"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An abnormality of the female external genitalia.</obo:IAO_0000115>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0000055</oboInOwl:id>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C4021822</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasExactSynonym>Abnormal female external genitalia</oboInOwl:hasExactSynonym>
+    </owl:Class>
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000058 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000058">
+      <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of the labia</rdfs:label>
+      <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0000055"/>
+      <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anomaly of the labia, the externally visible portions of the vulva.</obo:IAO_0000115>
+      <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0000058</oboInOwl:id>
+      <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C4025892</oboInOwl:hasDbXref>
+      <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+    </owl:Class>
 
 </rdf:RDF>

--- a/src/encoded/tests/data/documents/test_uberon5.owl
+++ b/src/encoded/tests/data/documents/test_uberon5.owl
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/hp.owl#"
+     xml:base="http://purl.obolibrary.org/obo/hp.owl"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+     xmlns:hsapdv="http://purl.obolibrary.org/obo/hsapdv#"
+     xmlns:hp="http://purl.obolibrary.org/obo/hp#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:nbo="http://purl.obolibrary.org/obo/nbo.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:hp2="http://purl.obolibrary.org/obo/hp.owl#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/hp.owl">
+    </owl:Ontology>
+
+
+<!-- http://purl.obolibrary.org/obo/HP_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000001">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">All</rdfs:label>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0000001</oboInOwl:id>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Root of all terms in the Human Phenotype Ontology.</rdfs:comment>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0444868</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+    </owl:Class>
+
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000002">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of body height</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000119"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000052"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002573"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000460"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0001507"/>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2008-02-27T02:20:00Z</oboInOwl:creation_date>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of body height</oboInOwl:hasExactSynonym>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deviation from the norm of height with respect to that which is expected according to age and gender norms.</obo:IAO_0000115>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0000002</oboInOwl:id>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C4025901</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peter</oboInOwl:created_by>
+    </owl:Class>
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000003">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multicystic kidney dysplasia</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0000107"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0000003</oboInOwl:id>
+        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0004715</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MSH:D021782</oboInOwl:hasDbXref>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multicystic dysplasia of the kidney is characterized by multiple cysts of varying size in the kidney and the absence of a normal pelvicaliceal system. The condition is associated with ureteral or ureteropelvic atresia, and the affected kidney is nonfunctional.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multicystic dysplastic kidney</oboInOwl:hasExactSynonym>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multicystic kidney dysplasia is the result of abnormal fetal renal development in which the affected kidney is replaced by multiple cysts and has little or no residual function. The vast majority of multicystic kidneys are unilateral. Multicystic kidney can be diagnosed on prenatal ultrasound.</rdfs:comment>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multicystic kidneys</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multicystic renal dysplasia</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SNOMEDCT_US:204962002</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SNOMEDCT_US:82525005</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C3714581</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+    </owl:Class>
+
+ <!-- http://purl.obolibrary.org/obo/HP_0000057 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000057">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete Clitoromegaly</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <obo:IAO_0100001>HP:0008665</obo:IAO_0100001>
+    </owl:Class>
+</rdf:RDF>

--- a/src/encoded/tests/test_generate_item_from_owl.py
+++ b/src/encoded/tests/test_generate_item_from_owl.py
@@ -835,8 +835,9 @@ def test_id_post_and_patch_set_obsolete_true_obsolete(mocker, terms, mock_logger
     dbterms = copy.deepcopy(terms)
     added_obs = {'hpo_id': 'hp:10', 'definition': 'soon to be obsolete'}
     dbterms.update({added_obs['hpo_id']: added_obs})
-    for i, tid in enumerate(dbterms.keys()):
-        dbterms[tid].update({'uuid': 'uuid' + str(i + 1)})
+    for tid in dbterms.keys():
+        uid = tid.replace('hp:', 'uuid')
+        dbterms[tid].update({'uuid': uid})
     mocker.patch('encoded.commands.generate_items_from_owl._get_uuids_for_linked', return_value={})
     mocker.patch('encoded.commands.generate_items_from_owl.id_fields2patch', return_value=None)
     to_update = gifo.id_post_and_patch(terms, dbterms, 'Phenotype', logger=mock_logger)

--- a/src/encoded/tests/test_generate_item_from_owl.py
+++ b/src/encoded/tests/test_generate_item_from_owl.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+import copy
 from io import StringIO
 
 from collections import OrderedDict
@@ -789,7 +790,6 @@ def test_id_post_and_patch_no_changes(mocker, terms, mock_logger):
 
 
 def test_id_post_and_patch_w_new_term(mocker, terms, mock_logger):
-    import copy
     dbterms = copy.deepcopy(terms)
     for i, tid in enumerate(dbterms.keys()):
         dbterms[tid].update({'uuid': 'uuid' + str(i + 1)})
@@ -806,7 +806,6 @@ def test_id_post_and_patch_w_new_term(mocker, terms, mock_logger):
 
 
 def test_id_post_and_patch_w_patch_term(mocker, terms, mock_logger):
-    import copy
     dbterms = copy.deepcopy(terms)
     added_field = {'definition': 'this is what it means'}
     for i, tid in enumerate(dbterms.keys()):
@@ -831,7 +830,6 @@ def test_id_post_and_patch_set_obsolete_true_obsolete(mocker, terms, mock_logger
     """ if set_obsolete is true (the default) then the extra dbterm should be added
         to patches as a term to set to obsolete
     """
-    import copy
     dbterms = copy.deepcopy(terms)
     added_obs = {'hpo_id': 'hp:10', 'definition': 'soon to be obsolete'}
     dbterms.update({added_obs['hpo_id']: added_obs})
@@ -851,7 +849,6 @@ def test_id_post_and_patch_set_obsolete_false_do_not_obsolete_live_term(mocker, 
     """ if set_obsolete is false then the extra dbterm should not be added to patches
         as a term to set to obsolete as long as it's status is not obsolete or deleted
     """
-    import copy
     dbterms = copy.deepcopy(terms)
     added_obs = {'hpo_id': 'hp:10', 'definition': 'soon to be obsolete'}
     dbterms.update({added_obs['hpo_id']: added_obs})
@@ -867,7 +864,6 @@ def test_id_post_and_patch_set_obsolete_true_do_not_patch_obsolete_term(mocker, 
     """ if set_obsolete is True then the extra dbterm should not be added to patches
         if it's already status = obsolete
     """
-    import copy
     dbterms = copy.deepcopy(terms)
     added_obs = {'hpo_id': 'hp:10', 'definition': 'already obsolete', 'status': 'obsolete'}
     dbterms.update({added_obs['hpo_id']: added_obs})
@@ -891,7 +887,6 @@ def test_write_outfile_pretty(simple_terms):
 
 
 def test_write_outfile_notpretty(simple_terms):
-    # import pdb; pdb.set_trace()
     print(simple_terms)
     filename = 'tmp_test_file'
     gifo.write_outfile(list(simple_terms.values()), filename)

--- a/src/encoded/tests/test_generate_item_from_owl.py
+++ b/src/encoded/tests/test_generate_item_from_owl.py
@@ -780,16 +780,16 @@ def test_get_uuids_for_linked_one_missing(term_w_slims_and_parents, mock_logger,
     assert out == 'WARNING: HP0000002 - MISSING FROM IDMAP\n'
 
 
-def test_id_post_and_patch_no_changes(mocker, terms, mock_logger):
+def test_identify_item_updates_no_changes(mocker, terms, mock_logger):
     dbterms = terms.copy()
     for i, tid in enumerate(dbterms.keys()):
         dbterms[tid].update({'uuid': 'uuid' + str(i + 1)})
     mocker.patch('encoded.commands.generate_items_from_owl._get_uuids_for_linked', return_value={})
     mocker.patch('encoded.commands.generate_items_from_owl.id_fields2patch', return_value=None)
-    assert not gifo.id_post_and_patch(terms, dbterms, 'Phenotype', logger=mock_logger)
+    assert not gifo.identify_item_updates(terms, dbterms, 'Phenotype', logger=mock_logger)
 
 
-def test_id_post_and_patch_w_new_term(mocker, terms, mock_logger):
+def test_identify_item_updates_w_new_term(mocker, terms, mock_logger):
     dbterms = copy.deepcopy(terms)
     for i, tid in enumerate(dbterms.keys()):
         dbterms[tid].update({'uuid': 'uuid' + str(i + 1)})
@@ -800,12 +800,12 @@ def test_id_post_and_patch_w_new_term(mocker, terms, mock_logger):
     mocker.patch('encoded.commands.generate_items_from_owl.uuid4', return_value='uuid11')
     mocker.patch('encoded.commands.generate_items_from_owl._get_uuids_for_linked', return_value={})
     mocker.patch('encoded.commands.generate_items_from_owl.id_fields2patch', side_effect=side_effect)
-    to_update = gifo.id_post_and_patch(terms, dbterms, 'Phenotype', logger=mock_logger)
+    to_update = gifo.identify_item_updates(terms, dbterms, 'Phenotype', logger=mock_logger)
     new_term.update({'uuid': 'uuid11'})
     assert to_update[0] == new_term
 
 
-def test_id_post_and_patch_w_patch_term(mocker, terms, mock_logger):
+def test_identify_item_updates_w_patch_term(mocker, terms, mock_logger):
     dbterms = copy.deepcopy(terms)
     added_field = {'definition': 'this is what it means'}
     for i, tid in enumerate(dbterms.keys()):
@@ -819,14 +819,14 @@ def test_id_post_and_patch_w_patch_term(mocker, terms, mock_logger):
         side_effect.append(se)
     mocker.patch('encoded.commands.generate_items_from_owl._get_uuids_for_linked', return_value={})
     mocker.patch('encoded.commands.generate_items_from_owl.id_fields2patch', side_effect=side_effect)
-    to_update = gifo.id_post_and_patch(terms, dbterms, 'Phenotype', logger=mock_logger)
+    to_update = gifo.identify_item_updates(terms, dbterms, 'Phenotype', logger=mock_logger)
     assert len(to_update) == 2
     for upd in to_update:
         assert 'uuid' in upd
         assert upd['definition'] == 'this is what it means'
 
 
-def test_id_post_and_patch_set_obsolete_true_obsolete(mocker, terms, mock_logger):
+def test_identify_item_updates_set_obsolete_true_obsolete(mocker, terms, mock_logger):
     """ if set_obsolete is true (the default) then the extra dbterm should be added
         to patches as a term to set to obsolete
     """
@@ -838,14 +838,14 @@ def test_id_post_and_patch_set_obsolete_true_obsolete(mocker, terms, mock_logger
         dbterms[tid].update({'uuid': uid})
     mocker.patch('encoded.commands.generate_items_from_owl._get_uuids_for_linked', return_value={})
     mocker.patch('encoded.commands.generate_items_from_owl.id_fields2patch', return_value=None)
-    to_update = gifo.id_post_and_patch(terms, dbterms, 'Phenotype', logger=mock_logger)
+    to_update = gifo.identify_item_updates(terms, dbterms, 'Phenotype', logger=mock_logger)
     assert len(to_update) == 1
     obsterm = to_update[0]
     assert obsterm['uuid'] == 'uuid10'
     assert obsterm['status'] == 'obsolete'
 
 
-def test_id_post_and_patch_set_obsolete_false_do_not_obsolete_live_term(mocker, terms, mock_logger):
+def test_identify_item_updates_set_obsolete_false_do_not_obsolete_live_term(mocker, terms, mock_logger):
     """ if set_obsolete is false then the extra dbterm should not be added to patches
         as a term to set to obsolete as long as it's status is not obsolete or deleted
     """
@@ -856,11 +856,11 @@ def test_id_post_and_patch_set_obsolete_false_do_not_obsolete_live_term(mocker, 
         dbterms[tid].update({'uuid': 'uuid' + str(i + 1)})
     mocker.patch('encoded.commands.generate_items_from_owl._get_uuids_for_linked', return_value={})
     mocker.patch('encoded.commands.generate_items_from_owl.id_fields2patch', return_value=None)
-    to_update = gifo.id_post_and_patch(terms, dbterms, 'Phenotype', set_obsoletes=False, logger=mock_logger)
+    to_update = gifo.identify_item_updates(terms, dbterms, 'Phenotype', set_obsoletes=False, logger=mock_logger)
     assert not to_update
 
 
-def test_id_post_and_patch_set_obsolete_true_do_not_patch_obsolete_term(mocker, terms, mock_logger):
+def test_identify_item_updates_set_obsolete_true_do_not_patch_obsolete_term(mocker, terms, mock_logger):
     """ if set_obsolete is True then the extra dbterm should not be added to patches
         if it's already status = obsolete
     """
@@ -871,7 +871,7 @@ def test_id_post_and_patch_set_obsolete_true_do_not_patch_obsolete_term(mocker, 
         dbterms[tid].update({'uuid': 'uuid' + str(i + 1)})
     mocker.patch('encoded.commands.generate_items_from_owl._get_uuids_for_linked', return_value={})
     mocker.patch('encoded.commands.generate_items_from_owl.id_fields2patch', return_value=None)
-    to_update = gifo.id_post_and_patch(terms, dbterms, 'Phenotype', logger=mock_logger)
+    to_update = gifo.identify_item_updates(terms, dbterms, 'Phenotype', logger=mock_logger)
     assert not to_update
 
 

--- a/src/encoded/tests/test_generate_item_from_owl.py
+++ b/src/encoded/tests/test_generate_item_from_owl.py
@@ -1,0 +1,1421 @@
+import json
+import os
+import pytest
+from io import StringIO
+
+from collections import OrderedDict
+from rdflib import URIRef
+from ..commands import generate_items_from_owl as gifo
+from ..commands.owltools import Owler
+
+
+pytestmark = [pytest.mark.setone, pytest.mark.working]
+
+
+class MockedLogger(object):
+    def info(self, msg):
+        return 'INFO: ' + msg
+
+    def warning(self, msg):
+        return 'WARNING: ' + msg
+
+    def error(self, msg):
+        return 'ERROR: ' + msg
+
+
+@pytest.fixture
+def mock_logger():
+    return MockedLogger()
+
+
+def test_parse_args_defaults():
+    args = ['Disorder']
+    args = gifo.parse_args(args)
+    assert args.env == 'local'
+    assert args.keyfile == os.path.expanduser("~/keypairs.json")
+    assert args.load is False
+    assert args.post_report is False
+    assert args.pretty is False
+    assert args.full is False
+
+
+@pytest.fixture
+def connection():
+    return {
+        "server": "https://cgap.hms.harvard.edu/",
+        "key": "testkey",
+        "secret": "testsecret"
+    }
+
+
+@pytest.fixture
+def owler(mocker):
+    return mocker.patch.object(gifo, 'Owler')
+
+
+@pytest.fixture
+def rel_disorders():
+    return [
+        {
+            'disorder_id': 'MONDO:0400005',
+            'status': 'released',
+            'disorder_name': 'refeeding syndrome',
+            'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_0400005'
+        },
+        {
+            'disorder_id': 'MONDO:0400004',
+            'status': 'released',
+            'disorder_name': 'phrynoderma',
+            'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_0400004'
+        },
+        {
+            'disorder_id': 'MONDO:0300000',
+            'status': 'released',
+            'disorder_name': 'SSR3-CDG',
+            'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_0300000'
+        },
+        {
+            'disorder_id': 'MONDO:0200000',
+            'status': 'released',
+            'disorder_name': 'uterine ligament adenosarcoma',
+            'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_0200000'
+        }
+    ]
+
+
+@pytest.fixture
+def delobs_disorders():
+    return [
+        {
+            'disorder_id': 'MONDO:9999998',
+            'status': 'deleted',
+            'disorder_name': 'colored thumbs',
+            'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_9999998'
+        },
+        {
+            'disorder_id': 'MONDO:9999999',
+            'status': 'obsolete',
+            'disorder_name': 'green thumbs',
+            'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_9999999'
+        }
+    ]
+
+
+@pytest.fixture
+def phenotypes():
+    return [
+        {
+            'hpo_id': 'HP:0001507',
+            'status': 'released',
+            'phenotype_name': 'growth abnormality',
+            'hpo_url': 'http://purl.obolibrary.org/obo/HP_00001507',
+            'is_slim_for': 'Phenotype abnormality'
+        },
+        {
+            'hpo_id': 'HP:0040064',
+            'status': 'released',
+            'phenotype_name': 'Abnormality of limbs',
+            'hpo_url': 'http://purl.obolibrary.org/obo/HP_0040064',
+            'is_slim_for': 'Phenotype abnormality'
+        },
+        {
+            'hpo_id': 'HP:3000008',
+            'status': 'released',
+            'phenotype_name': 'Abnormality of mylohyoid muscle',
+            'hpo_url': 'http://purl.obolibrary.org/obo/HP_3000008'
+        },
+        {
+            'hpo_id': 'HP:0010708',
+            'status': 'released',
+            'phenotype_name': '1-5 finger syndactyly',
+            'hpo_url': 'http://purl.obolibrary.org/obo/HP_0010708'
+        }
+    ]
+
+
+@pytest.fixture
+def uberon_owler():
+    return Owler('src/encoded/tests/data/documents/test_uberon.owl')
+
+
+@pytest.fixture
+def uberon_owler2():
+    return Owler('src/encoded/tests/data/documents/test_uberon2.owl')
+
+
+@pytest.fixture
+def uberon_owler3():
+    return Owler('src/encoded/tests/data/documents/test_uberon3.owl')
+
+
+@pytest.fixture
+def uberon_owler4():
+    return Owler('src/encoded/tests/data/documents/test_uberon4.owl')
+
+
+@pytest.fixture
+def uberon_owler5():
+    return Owler('src/encoded/tests/data/documents/test_uberon5.owl')
+
+
+@pytest.fixture
+def ll_class():
+    return gifo.convert2URIRef('http://purl.obolibrary.org/obo/UBERON_0000101')
+
+
+@pytest.fixture
+def mkd_class():
+    return gifo.convert2URIRef('http://purl.obolibrary.org/obo/HP_0000003')
+
+
+def test_connect2server_w_env(mocker, connection):
+    # parameters we pass in don't really matter
+    key = "{'server': 'https://cgap.hms.harvard.edu/', 'key': 'testkey', 'secret': 'testsecret'}"
+    mocker.patch('encoded.commands.generate_items_from_owl.get_authentication_with_server', return_value=connection)
+    retval = gifo.connect2server('fourfront-cgap')
+    assert retval == connection
+
+
+def test_connect2server_w_key(mocker, connection):
+    # TODO need to mock file open read etc to get this to work
+    mocker.patch('encoded.commands.generate_items_from_owl.os.path.isfile', return_value=True)
+    pass
+
+
+def test_prompt_check_for_output_options_w_load_y_and_file(monkeypatch, mock_logger):
+    monkeypatch.setattr('builtins.input', lambda _: 'y')
+    ofile, loadit = gifo.prompt_check_for_output_options(True, 'test.out', 'Disorder', 'test_server', mock_logger)
+    assert ofile == 'test.out'
+    assert loadit
+
+
+def test_prompt_check_for_output_options_w_load_y_and_no_file(monkeypatch, mock_logger):
+    monkeypatch.setattr('builtins.input', lambda _: 'y')
+    ofile, loadit = gifo.prompt_check_for_output_options(True, None, 'Disorder', 'test_server', mock_logger)
+    assert not ofile
+    assert loadit
+
+
+def test_prompt_check_for_output_options_w_load_y_and_no_file_but_wantit(mocker, mock_logger):
+    mocker.patch('builtins.input', side_effect=['y', 'n'])
+    ofile, loadit = gifo.prompt_check_for_output_options(True, None, 'Disorder', 'test_server', mock_logger)
+    assert ofile == 'Disorder.json'
+    assert loadit
+
+
+def test_prompt_check_for_output_options_wo_load_nofile(mock_logger):
+    ofile, loadit = gifo.prompt_check_for_output_options(None, None, 'Disorder', 'test_server', mock_logger)
+    assert ofile == 'Disorder.json'
+    assert not loadit
+
+
+def test_prompt_check_for_output_options_wo_load_w_file(mock_logger):
+    ofile, loadit = gifo.prompt_check_for_output_options(None, 'test.out', 'Disorder', 'test_server', mock_logger)
+    assert ofile == 'test.out'
+    assert not loadit
+
+
+def test_get_existing_items(mocker, connection, rel_disorders, delobs_disorders):
+    disorder_ids = [d.get('disorder_id') for d in rel_disorders + delobs_disorders]
+    mocker.patch('encoded.commands.generate_items_from_owl.search_metadata', side_effect=[rel_disorders, delobs_disorders])
+    dbdiseases = gifo.get_existing_items(connection, 'Disorder')
+    assert len(dbdiseases) == len(rel_disorders) + len(delobs_disorders)
+    assert all([d in dbdiseases for d in disorder_ids])
+
+
+def test_get_existing_items_wo_obsdel(mocker, connection, rel_disorders):
+    disorder_ids = [d.get('disorder_id') for d in rel_disorders]
+    mocker.patch('encoded.commands.generate_items_from_owl.search_metadata', return_value=rel_disorders)
+    dbdiseases = gifo.get_existing_items(connection, 'Disorder', False)
+    assert len(dbdiseases) == len(rel_disorders)
+    assert all([d in dbdiseases for d in disorder_ids])
+
+
+def test_remove_obsoletes_and_unnamed_obsoletes(rel_disorders):
+    # add a couple of terms that should be removed - can use existing fixture
+    # though in real case won't have status property so ignore
+    okids = [d.get('disorder_id') for d in rel_disorders]
+    obsoletes_or_unamed = [
+        {'disorder_id': 'MONDO:9999997', 'disorder_name': 'Obsolete: defunct', 'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_9999997'},
+        {'disorder_id': 'MONDO:9999996', 'disorder_name': 'whoopy', 'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_9999996', 'parents': ['ObsoleteClass']},
+        {'disorder_id': 'MONDO:9999995', 'disorder_url': 'http://purl.obolibrary.org/obo/MONDO_9999995'}
+    ]
+    badids = [d.get('disorder_id') for d in obsoletes_or_unamed]
+    rel_disorders.extend(obsoletes_or_unamed)
+    # now convert to a dict as expected by the function
+    terms = {d.get('disorder_id'): d for d in rel_disorders}
+    assert len(terms) == len(okids + badids)
+    terms = gifo.remove_obsoletes_and_unnamed(terms, 'Disorder')
+    assert len(terms) == len(okids)
+    assert all([d in okids for d in terms.keys()])
+    assert not any([d in badids for d in terms.keys()])
+
+
+def test_get_slim_term_ids_from_db_terms(phenotypes):
+    okslimids = ['HP:0001507', 'HP:0040064']
+    phenos = {p.get('hpo_id'): p for p in phenotypes}
+    slimterms = gifo.get_slim_term_ids_from_db_terms(phenos, 'Phenotype')
+    assert len(slimterms) == 2
+    assert all([st in okslimids for st in slimterms])
+
+
+def test_get_slim_term_ids_from_db_terms_no_slims(rel_disorders):
+    disorders = {p.get('disorder_id'): p for p in rel_disorders}
+    slimterms = gifo.get_slim_term_ids_from_db_terms(disorders, 'Disorder')
+    assert not slimterms
+
+
+def test_get_term_uris_as_ns_from_conf():
+    # this test getting shared info - we don't yet have a case
+    # where there is a specific URI for an item_type
+    # also not really unit as depending on convert2namespace function
+    uri_cases = {
+        'definition_uris': ['http://purl.obolibrary.org/obo/IAO_0000115'],
+        'synonym_uris': [
+            'http://www.geneontology.org/formats/oboInOwl#hasExactSynonym',
+            'http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym',
+            'http://www.geneontology.org/formats/oboInOwl#RelatedSynonym',
+        ]
+    }
+    itype = 'Disorder'  # doesn't matter
+    for case in uri_cases.keys():
+        uris = gifo.get_term_uris_as_ns(itype, case)
+        assert all([str(u) in uri_cases[case] for u in uris])
+
+
+def test_get_termid_from_uri_no_uri():
+    uri = ''
+    assert not gifo.get_termid_from_uri(uri)
+
+
+def test_get_termid_from_uri_valid_uri():
+    uri = 'http://www.ebi.ac.uk/efo/EFO_0002784'
+    tid = gifo.get_termid_from_uri(uri)
+    assert tid == 'EFO:0002784'
+
+
+def test_get_termid_from_uri_funky_uri1():
+    uri = 'http://www.ebi.ac.uk/efo/EFO_UFO_0002784'
+    tid = gifo.get_termid_from_uri(uri)
+    assert tid == 'EFO:UFO:0002784'
+
+
+def test_get_termid_from_uri_funky_uri2():
+    uri = 'http://www.ebi.ac.uk/efo/EFO0002784'
+    tid = gifo.get_termid_from_uri(uri)
+    assert tid == 'EFO0002784'
+
+
+def test_get_term_name_from_rdf_no_name(uberon_owler):
+    name = gifo.get_term_name_from_rdf('pickle', uberon_owler)
+    assert not name
+
+
+def test_get_term_name_from_rdf_has_name(uberon_owler, ll_class):
+    name = gifo.get_term_name_from_rdf(ll_class, uberon_owler)
+    assert name == 'lobe of lung'
+
+
+def test_get_term_name_from_rdf_no_term(uberon_owler):
+    class_ = gifo.convert2URIRef('http://purl.obolibrary.org/obo/UBERON_0000001')
+    name = gifo.get_term_name_from_rdf(class_, uberon_owler)
+    assert not name
+
+
+def test_is_deprecated_deprecated(uberon_owler5):
+    class_ = gifo.convert2URIRef('http://purl.obolibrary.org/obo/HP_0000057')
+    assert gifo._is_deprecated(class_, uberon_owler5)
+
+
+def test_is_deprecated_not_deprecated(uberon_owler5):
+    class_ = gifo.convert2URIRef('http://purl.obolibrary.org/obo/HP_0000003')
+    assert not gifo._is_deprecated(class_, uberon_owler5)
+
+
+def test_create_term_dict(mocker, mkd_class, uberon_owler5):
+    mocker.patch('encoded.commands.generate_items_from_owl.get_term_name_from_rdf',
+                 return_value='Multicystic kidney dysplasia')
+    term = gifo.create_term_dict(mkd_class, 'HP:0000003', uberon_owler5, 'Phenotype')
+    assert term == {'hpo_id': 'HP:0000003', 'hpo_url': 'http://purl.obolibrary.org/obo/HP_0000003', 'phenotype_name': 'Multicystic kidney dysplasia'}
+
+
+def test_process_parents(uberon_owler4):
+    tids = ['HP:0000811', 'HP:0010460', 'HP:0000055', 'HP:0000058']
+    terms2parents = {
+        'HP:0000055': ['HP:0000811', 'HP:0010460'],
+        'HP:0000058': ['HP:0000055']
+    }
+    terms = {t: {'hpo_id': t} for t in tids}
+    for c in uberon_owler4.allclasses:
+        terms = gifo.process_parents(c, uberon_owler4, terms)
+    print(terms)
+    for tid, term in terms.items():
+        if tid in terms2parents:
+            assert sorted(term.get('parents')) == sorted(terms2parents.get(tid))
+        else:
+            assert 'parents' not in term
+
+
+@pytest.fixture
+def simple_terms():
+    terms = {'t1': {'hpo_id': 't1', 'hpo_url': 'term1'},
+             't2': {'hpo_id': 't2', 'hpo_url': 'term2'},
+             't3': {'hpo_id': 't3', 'hpo_url': 'term3'}}
+    return OrderedDict(sorted(terms.items(), key=lambda t: t[0]))
+
+
+def test_add_additional_term_info(mocker, simple_terms):
+    val_lists = [[], ['val1'], ['val1', 'val2']]
+    fields = ['definition', 'synonyms', 'dbxrefs', 'alternative_ids']
+    mocker.patch('encoded.commands.generate_items_from_owl.convert2URIRef', return_value='blah')
+    mocker.patch('encoded.commands.generate_items_from_owl.get_synonyms', side_effect=val_lists)
+    mocker.patch('encoded.commands.generate_items_from_owl.get_definitions', side_effect=val_lists)
+    mocker.patch('encoded.commands.generate_items_from_owl.get_dbxrefs', side_effect=val_lists)
+    mocker.patch('encoded.commands.generate_items_from_owl.get_alternative_ids', side_effect=val_lists)
+    result = gifo.add_additional_term_info(simple_terms, 'data', 'synterms', 'defterms', 'Phenotype')
+    for tid, term in result.items():
+        for f in fields:
+            if tid == 't1':
+                assert f not in term
+            else:
+                if f == 'definition':  # only one added
+                    assert term[f] == 'val1'
+                elif tid == 't2':
+                    assert term[f] == val_lists[1]
+                else:
+                    assert term[f] == val_lists[2]
+
+
+@pytest.fixture
+def returned_synonyms():
+    n = 4
+    lists = [[], ['test_val1'], ['test_val1', 'test_val2']]
+    copies = []
+    for l in lists:
+        copies.extend([l.copy() for i in range(n)])
+    return copies
+
+
+def test_get_syn_def_dbxref_altid(mocker, owler, returned_synonyms):
+    mocker.patch('encoded.commands.generate_items_from_owl.getObjectLiteralsOfType',
+                 side_effect=returned_synonyms)
+    checks = ['test_val1', 'test_val2']
+    class_ = 'test_class'
+    terms = ['1']
+    for i in range(int(len(returned_synonyms) / 4)):
+        synonyms = gifo.get_synonyms(class_, owler, terms)
+        definitions = gifo.get_definitions(class_, owler, terms)
+        dbxrefs = gifo.get_dbxrefs(class_, owler)
+        altids = gifo.get_alternative_ids(class_, owler)
+        assert synonyms == definitions == dbxrefs == altids
+        if i == 0:
+            assert not synonyms
+        else:
+            assert len(synonyms) == i
+            for syn in synonyms:
+                assert syn in checks
+
+
+@pytest.fixture
+def terms():
+    return {
+        'hp:1': {
+            'hpo_id': 'hp:1',
+            'phenotype_name': 'name1',
+            'parents': []
+        },
+        'hp:2': {
+            'hpo_id': 'hp:2',
+            'phenotype_name': 'name2',
+            'parents': ['name1', 'ObsoleteClass'],
+        },
+        'hp:3': {
+            'hpo_id': 'hp:3',
+            'phenotype_name': 'obsolete name',
+            'parents': ['hp:2'],
+        },
+        'hp:4': {
+            'hpo_id': 'hp:4',
+            'phenotype_name': 'Obsolete name',
+            'parents': ['name1', 'hp:2']
+        },
+        'hp:5': {
+            'hpo_id': 'hp:5',
+            'phenotype_name': '',
+            'parents': ['hp:4']
+        },
+        'hp:6': {
+            'hpo_id': 'hp:6',
+            'parents': ['hp:2'],
+        },
+        'hp:7': {
+            'hpo_id': 'hp:7',
+            'parents': ['hp:6']
+        },
+        'hp:8': {
+            'hpo_id': 'hp:8',
+            'parents': ['hp:7', 'hp:3']
+        },
+        'hp:9': {
+            'hpo_id': 'hp:9',
+            'parents': ['hp:10']
+        }
+    }
+
+
+def test_iterative_parents(terms):
+    for tid, term in terms.items():
+        iparents = []
+        oks = []
+        if 'parents' in term:
+            iparents = gifo.iterative_parents(term['parents'], terms, 'parents')
+        if tid in ['hp:1', 'hp:2', 'hp:9']:
+            assert not iparents
+        if tid in ['hp:3', 'hp:4', 'hp:6']:
+            oks = ['hp:2']
+            assert len(iparents) == 1
+        if tid in ['hp:5', 'hp:7']:
+            oks = ['hp:2', 'hp:4', 'hp:6']
+            assert len(iparents) == 2
+        if tid == 'hp:8':
+            oks = ['hp:7', 'hp:6', 'hp:3', 'hp:2']
+            assert len(iparents) == 4
+        if oks:
+            assert [_id in oks for _id in iparents]
+
+
+def test_get_all_ancestors(terms):
+    for tid, term in terms.items():
+        term = gifo.get_all_ancestors(term, terms, 'parents', 'Phenotype')
+        closure = term['closure']
+        okids = []
+        assert tid in closure  # checks that the term id is included
+        if tid in ['hp:1', 'hp:2', 'hp:9']:
+            assert len(closure) == 1
+        if tid in ['hp:3', 'hp:4', 'hp:6']:
+            assert len(closure) == 2
+            okids.append('hp:2')
+        if tid in ['hp:5', 'hp:7']:
+            assert len(closure) == 3
+            okids = ['hp:4', 'hp:2', 'hp:6']
+        if tid == 'hp:8':
+            assert len(closure) == 5
+            oks = ['hp:7', 'hp:6', 'hp:3', 'hp:2']
+        if okids:
+            assert [_id in okids for _id in closure if _id != tid]
+
+
+@pytest.fixture
+def term_w_closure():
+    return {'hpo_id': 'hp:1', 'uuid': 'uuid1',
+            'closure': ['hp:1', 'hp:2', 'a_term1']}
+
+
+@pytest.fixture
+def terms_w_closures(term_w_closure):
+    # term with 2 slims
+    term_w_two = term_w_closure.copy()
+    term_w_two['hpo_id'] = 'hp:4'
+    term_w_two['uuid'] = 'uuid2'
+    term_w_two['closure'] = term_w_closure['closure'].copy()
+    term_w_two['closure'].append('a_term2')
+    # term w closure but no slim terms
+    term_wo_slim = term_w_closure.copy()
+    term_wo_slim['hpo_id'] = 'hp:5'
+    term_wo_slim['uuid'] = 'uuid5'
+    term_wo_slim['closure'] = term_w_closure['closure'].copy()
+    term_wo_slim['closure'].pop()
+    # term with no closures
+    term_w_none = term_w_closure.copy()
+    term_w_none['hpo_id'] = 'hp:6'
+    term_w_none['uuid'] = 'uuid6'
+    del term_w_none['closure']
+    return [term_w_closure, term_w_two, term_wo_slim, term_w_none]
+
+
+@pytest.fixture
+def slim_term_list():
+    # see ontology_term schema for full schema
+    return [{'hpo_id': 'a_term1', 'uuid': 'uuida1', 'is_slim_for': 'assay'},
+            {'hpo_id': 'a_term2', 'uuid': 'uuida2', 'is_slim_for': 'assay'},
+            {'hpo_id': 'd_term1', 'uuid': 'uuidd1', 'is_slim_for': 'developmental'}]
+
+
+def test_add_slim_to_term(terms_w_closures, slim_term_list):
+    slim_ids = ['a_term1', 'd_term1', 'a_term2']
+    for i, term in enumerate(terms_w_closures):
+        test_term = gifo.add_slim_to_term(term, slim_term_list, 'Phenotype')
+        assert test_term['hpo_id'] == str(i + 1)
+        if i < 2:
+            assert len(test_term['slim_terms']) == 1
+            assert test_term['slim_terms'][0] == slim_ids[i]
+        elif i <= 3:
+            assert len(test_term['slim_terms']) == 2
+            for t in test_term['slim_terms']:
+                assert t in slim_ids
+        elif i > 3:
+            assert 'slim_terms' not in test_term
+
+'''
+    Old stuff below
+'''
+
+
+@pytest.fixture
+def slim_term_list():
+    # see ontology_term schema for full schema
+    return [{'term_id': 'a_term1', 'uuid': 'uuida1', 'is_slim_for': 'assay'},
+            {'term_id': 'a_term2', 'uuid': 'uuida2', 'is_slim_for': 'assay'},
+            {'term_id': 'd_term1', 'uuid': 'uuidd1', 'is_slim_for': 'developmental'}]
+
+
+@pytest.fixture
+def slim_terms_by_ont(slim_term_list):
+    return [
+        [slim_term_list[0],
+         slim_term_list[1]],
+        [slim_term_list[2]],
+        None,
+        None,
+        None
+    ]
+
+
+@pytest.fixture
+def term_w_closure():
+    return {'term_id': '1', 'uuid': 'uuid1',
+            'closure': ['id1', 'id2', 'a_term1']}
+
+
+@pytest.fixture
+def terms_w_closures(term_w_closure):
+    # term with 2 slims
+    term_w_two = term_w_closure.copy()
+    term_w_two['term_id'] = '4'
+    term_w_two['uuid'] = 'uuid2'
+    term_w_two['closure'] = term_w_closure['closure'].copy()
+    term_w_two['closure'].append('a_term2')
+    # term w closure but no slim terms
+    term_wo_slim = term_w_closure.copy()
+    term_wo_slim['term_id'] = '5'
+    term_wo_slim['uuid'] = 'uuid5'
+    term_wo_slim['closure'] = term_w_closure['closure'].copy()
+    term_wo_slim['closure'].pop()
+    # term with both 'closure' and 'closure_with_develops_from' both with the same slim
+    term_with_both = term_w_closure.copy()
+    term_with_both['term_id'] = '3'
+    term_with_both['uuid'] = 'uuid3'
+    term_with_both['closure_with_develops_from'] = ['d_term1']
+    print(term_with_both)
+    # term with 'closure_with_develops_from' slim term'
+    term_cwdf = term_with_both.copy()
+    term_cwdf['term_id'] = '2'
+    term_cwdf['uuid'] = 'uuid2'
+    del term_cwdf['closure']
+    # term with no closures
+    term_w_none = term_cwdf.copy()
+    term_w_none['term_id'] = '6'
+    term_w_none['uuid'] = 'uuid6'
+    del term_w_none['closure_with_develops_from']
+    return [term_w_closure, term_cwdf, term_with_both,
+            term_w_two, term_wo_slim, term_w_none]
+
+
+
+
+@pytest.fixture
+def syn_uris():
+    return ['http://www.ebi.ac.uk/efo/alternative_term',
+            'http://www.geneontology.org/formats/oboInOwl#hasExactSynonym',
+            'http://purl.obolibrary.org/obo/IAO_0000118']
+
+
+@pytest.fixture
+def syn_uris_as_URIRef(syn_uris):
+    return [gifo.convert2namespace(uri) for uri in syn_uris]
+
+
+def test_get_slim_terms(mocker, connection, slim_terms_by_ont):
+    present = ['developmental', 'assay']
+    absent = ['organ', 'system', 'cell']
+    test_slim_terms = slim_terms_by_ont
+    with mocker.patch('encoded.commands.generate_ontology.search_metadata',
+                      side_effect=test_slim_terms):
+        terms = gifo.get_slim_terms(connection)
+        assert len(terms) == 3
+        for term in terms:
+            assert term['is_slim_for'] in present
+            assert term['is_slim_for'] not in absent
+
+
+
+def test_add_slim_terms(terms, slim_term_list):
+    terms = gifo.add_slim_terms(terms, slim_term_list, 'Phenotype')
+    print(terms)
+    for tid, term in terms.items():
+        if tid == 'id6':
+            assert len(term['slim_terms']) == 2
+            assert 'd_term1' in term['slim_terms']
+            assert 'a_term1' in term['slim_terms']
+        elif tid == 'id9':
+            assert 'slim_terms' not in term
+        else:
+            assert len(term['slim_terms']) == 1
+            if tid in ['a_term1', 'id2', 'id3', 'id4']:
+                assert term['slim_terms'][0] == 'a_term1'
+            elif tid in ['d_term1', 'id7', 'id8']:
+                assert term['slim_terms'][0] == 'd_term1'
+
+
+
+def check_if_URIRef(uri):
+    return isinstance(uri, URIRef)
+
+
+def test_convert2namespace(syn_uris):
+    for uri in syn_uris:
+        ns = gifo.convert2namespace(uri)
+        assert check_if_URIRef(ns)
+        assert str(ns) == uri
+
+
+def test_get_syndef_terms_as_uri(mocker, syn_uris):
+    asrdf = [True, False]
+    for rdf in asrdf:
+        uris = gifo.get_syndef_terms_as_uri(all_ontology[2], 'synonym_terms', rdf)
+        if rdf:
+            for uri in uris:
+                assert check_if_URIRef(uri)
+                assert str(uri) in syn_uris
+        else:
+            assert str(uri) in syn_uris
+
+
+def test_get_synonym_term_uris_no_ontology(mocker):
+    with mocker.patch('encoded.commands.generate_ontology.get_syndef_terms_as_uri',
+                      return_value=[]):
+        synterms = gifo.get_synonym_term_uris('ontologys/FAKE')
+        assert not synterms
+
+
+def test_get_definition_term_uris_no_ontology(mocker):
+    with mocker.patch('encoded.commands.generate_ontology.get_syndef_terms_as_uri',
+                      return_value=[]):
+        synterms = gifo.get_definition_term_uris('ontologys/FAKE')
+        assert not synterms
+
+
+def test_get_synonym_term_uris(mocker, syn_uris, syn_uris_as_URIRef):
+    asrdf = [True, False]
+    with mocker.patch('encoded.commands.generate_ontology.get_syndef_terms_as_uri',
+                      return_value=syn_uris_as_URIRef):
+        for rdf in asrdf:
+            uris = gifo.get_synonym_term_uris('ontid', rdf)
+            if rdf:
+                for uri in uris:
+                    assert check_if_URIRef(uri)
+                    assert str(uri) in syn_uris
+            else:
+                assert str(uri) in syn_uris
+
+
+def test_get_definition_term_uris(mocker, syn_uris, syn_uris_as_URIRef):
+    asrdf = [True, False]
+    with mocker.patch('encoded.commands.generate_ontology.get_syndef_terms_as_uri',
+                      return_value=syn_uris_as_URIRef):
+        for rdf in asrdf:
+            uris = gifo.get_synonym_term_uris('ontid', rdf)
+            if rdf:
+                for uri in uris:
+                    assert check_if_URIRef(uri)
+                    assert str(uri) in syn_uris
+            else:
+                assert str(uri) in syn_uris
+
+
+def test_combine_all_parents_w_no_parents():
+    term = {'term_id': 'id1'}
+    term = gifo._combine_all_parents(term)
+    assert not term['all_parents']  # both should be empty lists
+    assert not term['development']
+
+
+def test_combine_all_parents_w_empty_parents():
+    term = {'term_id': 'id1', 'parents': [], 'relationships': [],
+            'develops_from': [], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert not term['all_parents']  # both should be empty lists
+    assert not term['development']
+
+
+def test_combine_all_parents_w_one_parent():
+    term = {'term_id': 'id1', 'parents': ['id2'], 'relationships': [],
+            'develops_from': [], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 1
+    assert term['all_parents'][0] == 'id2'
+    assert term['development'] == term['all_parents']
+
+
+def test_combine_all_parents_w_two_parents():
+    term = {'term_id': 'id1', 'parents': ['id2', 'id3'], 'relationships': [],
+            'develops_from': [], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 2
+    assert 'id2' in term['all_parents']
+    assert 'id3' in term['all_parents']
+    assert sorted(term['development']) == sorted(term['all_parents'])
+
+
+def test_combine_all_parents_w_two_same_parents():
+    term = {'term_id': 'id1', 'parents': ['id2', 'id2'], 'relationships': [],
+            'develops_from': [], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 1
+    assert term['all_parents'][0] == 'id2'
+    assert term['development'] == term['all_parents']
+
+
+def test_combine_all_parents_w_parent_and_relationship_diff():
+    term = {'term_id': 'id1', 'parents': ['id2'], 'relationships': ['id3'],
+            'develops_from': [], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 2
+    assert 'id2' in term['all_parents']
+    assert 'id3' in term['all_parents']
+    assert sorted(term['development']) == sorted(term['all_parents'])
+
+
+def test_combine_all_parents_w_parent_and_relationship_same():
+    term = {'term_id': 'id1', 'parents': ['id2'], 'relationships': ['id2'],
+            'develops_from': [], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 1
+    assert term['all_parents'][0] == 'id2'
+    assert term['development'] == term['all_parents']
+
+
+def test_combine_all_parents_w_parent_and_develops_from_diff():
+    term = {'term_id': 'id1', 'parents': ['id2'], 'relationships': [],
+            'develops_from': ['id3'], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 1
+    assert len(term['development']) == 2
+    assert term['all_parents'][0] == 'id2'
+    assert 'id2' in term['development']
+    assert 'id3' in term['development']
+
+
+def test_combine_all_parents_w_parent_and_develops_from_same():
+    term = {'term_id': 'id1', 'parents': ['id2'], 'relationships': [],
+            'develops_from': ['id2'], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 1
+    assert term['all_parents'][0] == 'id2'
+    assert term['development'] == term['all_parents']
+
+
+def test_combine_all_parents_w_only_develops_from():
+    term = {'term_id': 'id1', 'parents': [], 'relationships': [],
+            'develops_from': ['id2'], 'has_part_inverse': []}
+    term = gifo._combine_all_parents(term)
+    assert not term['all_parents']
+    assert len(term['development']) == 1
+    assert term['development'][0] == 'id2'
+
+
+def test_combine_all_parents_w_has_part_inverse_only():
+    term = {'term_id': 'id1', 'parents': [], 'relationships': [],
+            'develops_from': [], 'has_part_inverse': ['id2']}
+    term = gifo._combine_all_parents(term)
+    assert not term['all_parents']  # both should be empty lists
+    assert not term['development']
+
+
+def test_combine_all_parents_w_has_part_inverse_to_exclude():
+    term = {'term_id': 'id1', 'parents': [], 'relationships': [],
+            'develops_from': ['id2'], 'has_part_inverse': ['id2']}
+    term = gifo._combine_all_parents(term)
+    assert not term['all_parents']  # both should be empty lists
+    assert not term['development']
+
+
+def test_combine_all_parents_w_has_part_inverse_to_exclude_plus_others():
+    term = {'term_id': 'id1', 'parents': ['id2'], 'relationships': [],
+            'develops_from': ['id3', 'id4', 'id5'], 'has_part_inverse': ['id4', 'id5', 'id6']}
+    term = gifo._combine_all_parents(term)
+    assert len(term['all_parents']) == 1
+    assert len(term['development']) == 2
+    assert term['all_parents'][0] == 'id2'
+    assert 'id2' in term['development']
+    assert 'id3' in term['development']
+
+
+
+
+
+
+
+
+
+def test_add_term_and_info(uberon_owler2):
+    testid = 'UBERON:0001772'
+    relid = 'UBERON:0010304'
+    for c in uberon_owler2.allclasses:
+        if gifo.isBlankNode(c):
+            test_class = c
+    parent = gifo.convert2URIRef('http://purl.obolibrary.org/obo/UBERON_0001772')
+    terms = gifo._add_term_and_info(test_class, parent, 'test_rel', uberon_owler2, {})
+    assert testid in terms
+    term = terms[testid]
+    assert term['term_id'] == testid
+    assert relid in term['test_rel']
+
+
+def test_process_intersection_of(uberon_owler3):
+    terms = {}
+    for c in uberon_owler3.allclasses:
+        for i in uberon_owler3.rdfGraph.objects(c, gifo.IntersectionOf):
+            terms = gifo.process_intersection_of(c, i, uberon_owler3, terms)
+    assert len(terms) == 1
+    term = list(terms.values())[0]
+    assert len(term['relationships']) == 1
+    assert term['relationships'][0] == 'UBERON:1'
+    assert len(term['develops_from']) == 1
+    assert term['develops_from'][0] == 'UBERON:2'
+
+
+def test_process_blank_node(uberon_owler3):
+    terms = {}
+    for c in uberon_owler3.allclasses:
+        terms = gifo.process_blank_node(c, uberon_owler3, terms)
+    assert len(terms) == 1
+    assert 'UBERON:0001772' in terms
+
+
+def test_find_and_add_parent_of(uberon_owler4):
+    tid = 'CL:0002553'
+    terms = {tid: {'term_id': tid}}
+    relids = ['UBERON:0002048', 'OBI:0000456', 'CL:0000058', 'CL:0000133']
+    relation = None
+    seen = False
+    for c in uberon_owler4.allclasses:
+        for _, p in enumerate(uberon_owler4.get_classDirectSupers(c, excludeBnodes=False)):
+            if gifo.isBlankNode(p):
+                has_part = False
+                if not seen:
+                    has_part = True
+                    seen = True
+                terms = gifo._find_and_add_parent_of(p, c, uberon_owler4, terms, has_part, relation)
+    assert len(terms) == 2
+    print(terms)
+    for termid, term in terms.items():
+        if termid == tid:
+            assert len(term['relationships']) == 3
+            for t in term['relationships']:
+                assert t in relids
+        else:
+            assert termid in relids
+            assert len(term['has_part_inverse']) == 1
+            assert term['has_part_inverse'][0] == tid
+
+
+
+
+
+@pytest.fixture
+def terms_w_stuff():
+    return {
+        'term1': {
+            'term_id': 't1',
+            'term_name': 'term1',
+            'relationships': ['rel1', 'rel2'],
+            'all_parents': ['p'],
+            'development': 'd',
+            'has_part_inverse': [],
+            'develops_from': '',
+            'part_of': ['p1'],
+            'closure': [],
+            'closure_with_develops_from': None
+        },
+        'term2': {
+            'term_id': 't1',
+            'term_name': 'term1'
+        },
+        'term3': {},
+        'term4': None
+    }
+
+
+def test_cleanup_non_fields(terms_w_stuff):
+    to_delete = ['relationships', 'all_parents', 'development',
+                 'has_part_inverse', 'develops_from', 'part_of',
+                 'closure', 'closure_with_develops_from']
+    to_keep = ['term_id', 'term_name']
+    for d in to_delete + to_keep:
+        assert d in terms_w_stuff['term1']
+    terms = gifo._cleanup_non_fields(terms_w_stuff)
+    assert len(terms) == 2
+    assert terms['term1'] == terms['term2']
+    for d in to_delete:
+        assert d not in terms['term1']
+    for k in to_keep:
+        assert k in terms['term1']
+
+
+@pytest.fixture
+def mock_get_synonyms(mocker):
+    syn_lists = [[], ['syn1'], ['syn1', 'syn2']]
+    return mocker.patch('encoded.commands.generate_ontology.get_synonyms', side_effect=syn_lists)
+
+
+@pytest.fixture
+def mock_get_definitions(mocker):
+    def_lists = [[], ['def1'], ['def1', 'def2']]
+    return mocker.patch('encoded.commands.generate_ontology.get_synonyms', side_effect=def_lists)
+
+
+
+
+
+def test_write_outfile_pretty(simple_terms):
+    filename = 'tmp_test_file'
+    gifo.write_outfile(list(simple_terms.values()), filename, pretty=True)
+    infile = open(filename, 'r')
+    result = json.load(infile)
+    print(result)
+    for r in result:
+        assert r in simple_terms.values()
+    os.remove(filename)
+
+
+def test_write_outfile_notpretty(simple_terms):
+    # import pdb; pdb.set_trace()
+    print(simple_terms)
+    filename = 'tmp_test_file'
+    gifo.write_outfile(list(simple_terms.values()), filename)
+    with open(filename, 'r') as infile:
+        for l in infile:
+            result = json.loads(l)
+            for v in simple_terms.values():
+                assert v in result
+    os.remove(filename)
+
+
+@pytest.fixture
+def matches():
+    return [{'term_id': 't1', 'a': 1, 'b': 2, 'c': 3}, {'term_id': 't1', 'a': 1, 'b': 2, 'c': 3}]
+
+
+def test_terms_match_identical(matches):
+    assert gifo._terms_match(matches[0], matches[1])
+
+
+def test_terms_match_w_parents(matches):
+    t1 = matches[0]
+    t2 = matches[1]
+    p1 = ['OBI:01', 'EFO:01']
+    p2 = [{'@id': '/ontology-terms/OBI:01/', 'display_title': 'blah'},
+          {'@id': '/ontology-terms/EFO:01/', 'display_title': 'hah'}]
+    t1['parents'] = p1
+    t2['parents'] = p2
+    assert gifo._terms_match(t1, t2)
+
+
+def test_terms_match_unmatched_parents_1(matches):
+    t1 = matches[0]
+    t2 = matches[1]
+    p1 = ['OBI:01', 'EFO:01']
+    p2 = [{'@id': '/ontology-terms/OBI:01/', 'display_title': 'blah'}]
+    t1['parents'] = p1
+    t2['parents'] = p2
+    assert not gifo._terms_match(t1, t2)
+
+
+def test_terms_match_unmatched_parents_2(matches):
+    t1 = matches[0]
+    t2 = matches[1]
+    p1 = ['OBI:01', 'EFO:01']
+    p2 = [{'@id': '/ontology-terms/OBI:01/', 'display_title': 'blah'},
+          {'@id': '/ontology-terms/EFO:02/', 'display_title': 'hah'}]
+    t1['parents'] = p1
+    t2['parents'] = p2
+    assert not gifo._terms_match(t1, t2)
+
+
+def test_terms_match_w_ontology(matches):
+    t1 = matches[0]
+    t2 = matches[1]
+    o1 = '530016bc-8535-4448-903e-854af460b254'
+    o2 = {'@id': '/ontologys/530016bc-8535-4448-903e-854af460b254/', 'display_title': 'blah'}
+    t1['source_ontologies'] = [o1]
+    t2['source_ontologies'] = [o2]
+    assert gifo._terms_match(t1, t2)
+
+
+@pytest.fixture
+def ont_terms(matches):
+    t2 = matches[1]
+    t2['term_id'] = 't2'
+    t2['parents'] = ['OBI:01', 'EFO:01']
+    return {
+        't1': matches[0],
+        't2': t2,
+        't3': {'term_id': 't3', 'x': 7, 'y': 8, 'z': 9}
+    }
+
+
+@pytest.fixture
+def ontology_list():
+    return [
+        {'uuid': '1', 'ontology_name': 'ont1'},
+        {'uuid': '2', 'ontology_name': 'ont2'}
+    ]
+
+
+@pytest.fixture
+def db_terms(ont_terms):
+    db_terms = ont_terms.copy()
+    db_terms['t1']['uuid'] = '1234'
+    db_terms['t2']['uuid'] = '5678'
+    del db_terms['t2']['parents']
+    del db_terms['t3']
+    return db_terms
+
+
+def test_id_post_and_patch_filter(ont_terms, db_terms, ontology_list):
+    result = gifo.id_post_and_patch(ont_terms, db_terms, ontology_list)
+    assert len(result) == 1
+    assert 't3' == result[0].get('term_id')
+    # assert len(idmap) == 3
+    # for k, v in idmap.items():
+    #     assert k in ['t1', 't2', 't3']
+    #     if k != 't3':  # t1 and t2 already had uuids
+    #         assert v in ['1234', '5678']
+
+
+def test_id_post_and_patch_no_filter(ont_terms, db_terms, ontology_list):
+    tids = ['t1', 't2', 't3']
+    result = gifo.id_post_and_patch(ont_terms, db_terms, ontology_list, False)
+    assert len(result) == 3
+    for t in result:
+        # assert t.get('term_id') in idmap
+        assert t.get('term_id') in tids
+
+
+# def test_id_post_and_patch_id_obs(ont_terms, db_terms, ontology_list):
+#     db_terms['t4'] = {'term_id': 't4', 'source_ontologies': {'uuid': '1', 'ontology_name': 'ont1'}, 'uuid': '7890'}
+#     result = gifo.id_post_and_patch(ont_terms, db_terms, ontology_list)
+#     assert len(result) == 2
+#     assert '7890' in [t.get('uuid') for t in result]
+#     # assert 't4' in idmap
+
+
+def test_id_post_and_patch_donot_obs(ont_terms, db_terms, ontology_list):
+    db_terms['t4'] = {'term_id': 't4', 'source_ontologies': {'uuid': '1', 'ontology_name': 'ont1'}, 'uuid': '7890'}
+    result = gifo.id_post_and_patch(ont_terms, db_terms, ontology_list, True, False)
+    assert 't4' not in [t.get('term_id') for t in result]
+    # assert 't4' not in idmap
+
+
+# def test_id_post_and_patch_ignore_4dn(ont_terms, db_terms, ontology_list):
+#     db_terms['t4'] = {'term_id': 't4', 'source_ontologies': {'uuid': '4', 'ontology_name': '4DN ont'}, 'uuid': '7890'}
+#     result = gifo.id_post_and_patch(ont_terms, db_terms, ontology_list)
+#     print(result)
+#     assert 't4' not in [t.get('term_id') for t in result]
+#     # assert 't4' not in idmap
+
+
+def valid_uuid(uid):
+    validchars = '0123456789abcdef'
+    uid = uid.replace('-', '')
+    if len(uid) != 32:
+        return False
+    for c in uid:
+        if c not in validchars:
+            return False
+    return True
+
+
+@pytest.fixture
+def embedded_dbterm():
+    return {
+         "synonyms": [
+            "renal pelvis uroepithelium",
+            "renal pelvis transitional epithelium",
+            "pelvis of ureter uroepithelium",
+            "renal pelvis urothelium",
+            "kidney pelvis uroepithelium",
+            "uroepithelium of pelvis of ureter",
+            "urothelium of pelvis of ureter",
+            "uroepithelium of kidney pelvis",
+            "transitional epithelium of kidney pelvis",
+            "transitional epithelium of renal pelvis",
+            "urothelium of kidney pelvis",
+            "uroepithelium of renal pelvis",
+            "urothelium of renal pelvis",
+            "kidney pelvis transitional epithelium",
+            "pelvis of ureter urothelium"
+          ],
+          "preferred_name": "kidney pelvis urothelium",
+          "references": [
+
+          ],
+          "external_references": [
+
+          ],
+          "status": "released",
+          "term_name": "kidney pelvis urothelium",
+          "submitted_by": {
+            "principals_allowed": {
+              "edit": [
+                "group.admin",
+                "userid.986b362f-4eb6-4a9c-8173-3ab267307e3a"
+              ],
+              "view": [
+                "group.admin",
+                "group.read-only-admin",
+                "remoteuser.EMBED",
+                "remoteuser.INDEXER",
+                "userid.986b362f-4eb6-4a9c-8173-3ab267307e3a"
+              ]
+            },
+            "@id": "/users/986b362f-4eb6-4a9c-8173-3ab267307e3a/",
+            "@type": [
+              "User",
+              "Item"
+            ],
+            "uuid": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
+            "display_title": "4dn DCIC"
+          },
+          "display_title": "kidney pelvis urothelium",
+          "schema_version": "1",
+          "@type": [
+            "OntologyTerm",
+            "Item"
+          ],
+          "parents": [
+            {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin"
+                ],
+                "view": [
+                  "system.Everyone"
+                ]
+              },
+              "@id": "/ontology-terms/UBERON:0001254/",
+              "@type": [
+                "OntologyTerm",
+                "Item"
+              ],
+              "uuid": "38dbff69-aac7-46a4-837e-7340c2c5bcd5",
+              "display_title": "urothelium of ureter"
+            },
+            {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin"
+                ],
+                "view": [
+                  "system.Everyone"
+                ]
+              },
+              "@id": "/ontology-terms/UBERON:0004819/",
+              "@type": [
+                "OntologyTerm",
+                "Item"
+              ],
+              "uuid": "57ac2905-0533-43c9-988b-9add8c225a78",
+              "display_title": "kidney epithelium"
+            }
+          ],
+          "date_created": "2017-05-11T16:00:51.747446+00:00",
+          "term_id": "UBERON:0004788",
+          "source_ontology": {
+            "uuid": "530016bc-8535-4448-903e-854af460b254",
+            "display_title": "Uberon",
+            "principals_allowed": {
+              "edit": [
+                "group.admin"
+              ],
+              "view": [
+                "system.Everyone"
+              ]
+            },
+            "@id": "/ontologys/530016bc-8535-4448-903e-854af460b254/",
+            "@type": [
+              "Ontology",
+              "Item"
+            ],
+            "ontology_name": "Uberon"
+          },
+          "uuid": "e5e1690a-1a80-4e50-a3cf-58f2f269abd8",
+          "term_url": "http://purl.obolibrary.org/obo/UBERON_0004788",
+          "last_modified": {
+            "date_modified": "2018-07-11T05:05:30.826642+00:00",
+            "modified_by": {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin",
+                  "userid.986b362f-4eb6-4a9c-8173-3ab267307e3a"
+                ],
+                "view": [
+                  "group.admin",
+                  "group.read-only-admin",
+                  "remoteuser.EMBED",
+                  "remoteuser.INDEXER",
+                  "userid.986b362f-4eb6-4a9c-8173-3ab267307e3a"
+                ]
+              },
+              "@id": "/users/986b362f-4eb6-4a9c-8173-3ab267307e3a/",
+              "@type": [
+                "User",
+                "Item"
+              ],
+              "uuid": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
+              "display_title": "4dn DCIC"
+            }
+          },
+          "principals_allowed": {
+            "edit": [
+              "group.admin"
+            ],
+            "view": [
+              "system.Everyone"
+            ]
+          },
+          "@id": "/ontology-terms/UBERON:0004788/",
+          "slim_terms": [
+            {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin"
+                ],
+                "view": [
+                  "system.Everyone"
+                ]
+              },
+              "term_name": "endoderm",
+              "display_title": "endoderm",
+              "is_slim_for": "developmental",
+              "@id": "/ontology-terms/UBERON:0000925/",
+              "@type": [
+                "OntologyTerm",
+                "Item"
+              ],
+              "uuid": "111121bc-8535-4448-903e-854af460a233"
+            },
+            {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin"
+                ],
+                "view": [
+                  "system.Everyone"
+                ]
+              },
+              "term_name": "kidney",
+              "display_title": "kidney",
+              "is_slim_for": "organ",
+              "@id": "/ontology-terms/UBERON:0002113/",
+              "@type": [
+                "OntologyTerm",
+                "Item"
+              ],
+              "uuid": "111167bc-8535-4448-903e-854af460a233"
+            },
+            {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin"
+                ],
+                "view": [
+                  "system.Everyone"
+                ]
+              },
+              "term_name": "ureter",
+              "display_title": "ureter",
+              "is_slim_for": "organ",
+              "@id": "/ontology-terms/UBERON:0000056/",
+              "@type": [
+                "OntologyTerm",
+                "Item"
+              ],
+              "uuid": "111148bc-8535-4448-903e-854af460a233"
+            },
+            {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin"
+                ],
+                "view": [
+                  "system.Everyone"
+                ]
+              },
+              "term_name": "renal system",
+              "display_title": "renal system",
+              "is_slim_for": "system",
+              "@id": "/ontology-terms/UBERON:0001008/",
+              "@type": [
+                "OntologyTerm",
+                "Item"
+              ],
+              "uuid": "111130bc-8535-4448-903e-854af460a233"
+            },
+            {
+              "principals_allowed": {
+                "edit": [
+                  "group.admin"
+                ],
+                "view": [
+                  "system.Everyone"
+                ]
+              },
+              "term_name": "mesoderm",
+              "display_title": "mesoderm",
+              "is_slim_for": "developmental",
+              "@id": "/ontology-terms/UBERON:0000926/",
+              "@type": [
+                "OntologyTerm",
+                "Item"
+              ],
+              "uuid": "111120bc-8535-4448-903e-854af460a233"
+            }
+          ],
+          "namespace": "http://purl.obolibrary.org/obo",
+          "definition": "the epithelial lining of the luminal space of the kidney pelvis"
+        }
+
+
+def test_get_raw_form(embedded_dbterm):
+    raw_term = gifo.get_raw_form(embedded_dbterm)
+    print(raw_term)
+
+
+def test_update_definition():
+    prefix = 'EFO'
+    tdef = 'here is EFO definition (EFO)'
+    dbdef = 'here is outdated definition (EFO, OBI) and another def (SO)'
+    newdef = gifo.update_definition(tdef, dbdef, prefix)
+    assert tdef in newdef
+    assert 'here is outdated definition (EFO, OBI)' not in newdef
+
+
+@pytest.fixture
+def slim_terms():
+    return [
+        {
+            "uuid": "111119bc-8535-4448-903e-854af460a233",
+            "term_name": "ectoderm",
+            "term_id": "UBERON:0000924",
+            "is_slim_for": "developmental",
+        },
+        {
+            "uuid": "111122bc-8535-4448-903e-854af460a233",
+            "preferred_name": "3D chromatin structure",
+            "term_name": "chromosome conformation identification objective",
+            "term_id": "OBI:0001917",
+            "is_slim_for": "assay"
+        }
+    ]


### PR DESCRIPTION
1. Refactored main method of parse_hpoa.py to break it up a bit and make it easier to write tests.
2. Modified logging set up in all scripts that process Phenotype and Disease and Evidence items
3. Added tests for generate_items_from_owl.
