### PR TITLE
removed duplicates in phenotypic features processing

### DIFF
--- a/src/encoded/types/cohort.py
+++ b/src/encoded/types/cohort.py
@@ -522,8 +522,9 @@ def diagnoses_xml_to_phenotypic_features(testapp, ref_vals, refs, data, cohort, 
                               % (cohort, diagnosis['id'], str(exc)))
                 else:
                     found_term = True
-                    pheno_feat_data['phenotypic_feature'] = pheno_res['uuid']
-                    pheno_feats.append(pheno_feat_data)
+                    if pheno_res['uuid'] not in [item['phenotypic_feature'] for item in pheno_feats]:
+                        pheno_feat_data['phenotypic_feature'] = pheno_res['uuid']
+                        pheno_feats.append(pheno_feat_data)
 
         # if we cannot find the term, update the clinical notes
         if diagnosis.get('name') and not found_term:


### PR DESCRIPTION
**Problem:** Previous fix to cohort didn't fix inability to upload pedigree on cgap prod. Problem seemed to be duplicate (non-unique) items in family phenotypic_features list.

**In this PR:** One added line that only adds a phenotypic feature if it is not already present in list.

**Notes:**
- this wasn't apparent on local at first, because the error only seems to appear if the phenotypes are in the db as HPO terms.
- would be prudent to add a test for pbxml parsing - will work on this but would like to get this change in first so that pedigrees can again be uploaded on prod and other envs.