### PR TITLE
Tidying up of health page to use new version info, etc.

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -23,6 +23,8 @@ pyramid.default_locale_name = en
 # this line determines which load function is used in load_data
 # most deployments use: "load_test_data = encoded.loadxl:load_test_data"
 load_test_data = encoded.loadxl:load_local_data
+encoded_version = 100.200.300
+eb_app_version = app-v-development-simulation
 
 [pipeline:debug]
 pipeline =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # after having done 'python setup_eb.py develop', at least on the beanstalk. It doesn't
 # sem to be needed locally. -kmp 17-Mar-2020
 name = "encoded"
-version = "1.1.0b0"
+version = "1.2.0b0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/HealthView.js
+++ b/src/encoded/static/components/item-pages/HealthView.js
@@ -74,6 +74,14 @@ export default class HealthView extends React.PureComponent {
                 <h3 className="text-400 mb-2 mt-3">Configuration</h3>
                 {typeof context.description == "string" ? <p className="description">{context.description}</p> : null}
                 <ItemDetailList excludedKeys={ItemDetailList.Detail.defaultProps.excludedKeys.concat(['content'])} hideButtons context={context} schemas={schemas} keyTitleDescriptionMap={{
+                    'aggregations' : {
+                        title : 'Aggregations',
+                        description : "Aggregations of ES-indexed data."
+                    },
+                    'beanstalk_app_version': {
+                        title : "Beanstalk App Version",
+                        description : "Unique descriptive identifier for this app's ElasticBeanstalk source bundle."
+                    },
                     'blob_bucket' : {
                         title : "Blob Bucket",
                         description : "Name of S3 bucket used for blob data."
@@ -97,21 +105,33 @@ export default class HealthView extends React.PureComponent {
                         title : "File Upload Bucket",
                         description : "Where uploaded files are stored."
                     },
+                    'foursight' : {
+                        title : "Foursight",
+                        description : "URI of corresponding Foursight page."
+                    },
                     'load_data' : {
-                        title : "Data Loaded",
+                        title : "Loaded Data",
                         description : "Data which was loaded into database on initialization or boot."
+                    },
+                    'namespace': {
+                        title : "Namespace",
+                        description : "Similar to the Beanstalk Environment, but if there is a cloned environment with a fourfront-foo-1 and fourfront-foo-2, this is just the shared part (fourfront-foo)."
                     },
                     'ontology_updated' : {
                         title : 'Last Ontology Update',
                         description : "Last time ontologies were updated."
                     },
+                    'processed_file_bucket' : {
+                        title : 'Processed File Bucket',
+                        description : "Name of S3 bucket used for workflow output files from processing steps."
+                    },
+                    'project_version': {
+                        title : "Project Version",
+                        description : "Software version for this portal's software."
+                    },
                     'system_bucket' : {
                         title : 'System Bucket',
                         description : "Name of S3 Bucket used for system data."
-                    },
-                    'aggregations' : {
-                        title : 'Aggregations',
-                        description : "Aggregations of ES-indexed data."
                     }
                 }} />
 

--- a/src/encoded/static/components/item-pages/HealthView.js
+++ b/src/encoded/static/components/item-pages/HealthView.js
@@ -115,7 +115,7 @@ export default class HealthView extends React.PureComponent {
                     },
                     'namespace': {
                         title : "Namespace",
-                        description : "Similar to the Beanstalk Environment, but if there is a cloned environment with a fourfront-foo-1 and fourfront-foo-2, this is just the shared part (fourfront-foo)."
+                        description : "The ElasticSearch namespace to use. This is often the same as the Beanstalk Environment, but don't rely on that."
                     },
                     'ontology_updated' : {
                         title : 'Last Ontology Update',

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,8 @@ indexer.processes =
 elasticsearch.server = 172.31.49.128:9872
 snovault.app_version = 1.3.0
 ga_config_location = ./src/encoded/static/ga_config.json
-
+encoded_version = 111.222.333
+eb_app_version = app-v-test-simulation
 create_tables = true
 load_test_data = encoded.loadxl:load_test_data
 


### PR DESCRIPTION
This fixes several visual things on the `/health` page:

* There's a label that said "Data Loaded" that I changed to "Loaded Data" because the order of presentation seems to be alphabetical order of the keys that can't be seen, so it helps to make the alphabetical order of the titles be consistent with the ordering of the keys.
* Added labeling for the project version and the beanstalk app version, which were recently added.
* Backfilled several other items that seem not to have entries and so were appearing without explanations and without pretty labels.