### PR TITLE
Fix premature release of the any.ini deployment strategy (C4-144)

### DIFF
--- a/deploy/generate_production_ini.py
+++ b/deploy/generate_production_ini.py
@@ -200,6 +200,13 @@ def main():
             description="Generates a product.ini file from a template appropriate for the given environment,"
                         " which defaults from the value of the ENV_NAME environment variable "
                         " and may be given with or without a 'fourfront-' prefix. ")
+        parser.add_argument("--use_any",
+                            help="whether or not to prefer the new any.ini template over a named template",
+                            action='store_true',
+                            # In order for us to change the default to True, we'd need to re-issue beanstalks
+                            # with the new environment variables. The any.ini template relies on different
+                            # variables. -kmp 29-Apr-2020
+                            default=False)
         parser.add_argument("--env",
                             help="environment name",
                             default=os.environ['ENV_NAME'],
@@ -227,8 +234,9 @@ def main():
                             help="an ElasticSearch namespace",
                             default=None)
         args = parser.parse_args()
-        # template_file_name = environment_template_filename(args.env)
-        template_file_name = any_environment_template_filename()
+        template_file_name = (any_environment_template_filename()
+                              if args.use_any
+                              else environment_template_filename(args.env))
         ini_file_name = args.target
         # print("template_file_name=", template_file_name)
         # print("ini_file_name=", ini_file_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # after having done 'python setup_eb.py develop', at least on the beanstalk. It doesn't
 # sem to be needed locally. -kmp 17-Mar-2020
 name = "encoded"
-version = "1.5.1"
+version = "1.5.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Per [C4-144](https://hms-dbmi.atlassian.net/browse/C4-144): There was an error in the deployment strategy we released recently for CGAP. It needs additional environment variables that won't be present in a default beanstalk so we shouldn't use the default deployment strategy involving `any.ini` in the init files. In this PR, we make the change conditional on a command line option that is defaultly `False`.