### PR TITLE
C4-143 Fix nested facets

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -20,7 +20,7 @@ from snovault.util import (
 )
 from snovault.typeinfo import AbstractTypeInfo
 from elasticsearch_dsl import Search, Nested
-from elasticsearch_dsl.aggs import Terms
+from elasticsearch_dsl.aggs import Terms, ReverseNested
 from elasticsearch import (
     TransportError,
     RequestError,
@@ -1594,11 +1594,20 @@ def fix_nested_aggregations(search, es_mapping):
     aggs_ptr = search.aggs['all_items']
     for agg in aggs_ptr:
         if NESTED in agg:
-            (search.aggs['all_items']
-                  .bucket(agg, 'nested', path=find_nested_path(aggs_ptr.aggs[agg]['primary_agg'].field, es_mapping))
-                  .bucket('primary_agg',
-                          Terms(field=aggs_ptr.aggs[agg]['primary_agg'].field, size=100, missing='No value'))
-                  .bucket('primary_agg_reverse_nested', REVERSE_NESTED))
+            # New:
+            (search.aggs['all_items'][agg]
+                   .bucket('primary_agg',
+                           'nested', path=find_nested_path(aggs_ptr.aggs[agg]['primary_agg'].field, es_mapping))
+                   .bucket('primary_agg',
+                           Terms(field=aggs_ptr.aggs[agg]['primary_agg'].field, size=100, missing='No value'))
+                   .bucket('primary_agg_reverse_nested', REVERSE_NESTED))
+
+            # OLD: (enabled for now)
+            # (search.aggs['all_items']
+            #       .bucket(agg, 'nested', path=find_nested_path(aggs_ptr.aggs[agg]['primary_agg'].field, es_mapping))
+            #       .bucket('primary_agg',
+            #               Terms(field=aggs_ptr.aggs[agg]['primary_agg'].field, size=100, missing='No value'))
+            #       .bucket('primary_agg_reverse_nested', REVERSE_NESTED))
 
 
 def get_query_field(field, facet):
@@ -1856,7 +1865,7 @@ def fix_and_replace_nested_doc_count(result_facet, aggregations, full_agg_name):
     :param full_agg_name: full name of the aggregation
     """
     result_facet['aggregation_type'] = 'terms'
-    buckets = aggregations[full_agg_name]['primary_agg']['buckets']
+    buckets = aggregations[full_agg_name]['primary_agg']['primary_agg']['buckets']
     for bucket in buckets:
         if 'primary_agg_reverse_nested' in bucket:
             bucket['doc_count'] = bucket['primary_agg_reverse_nested']['doc_count']
@@ -1903,13 +1912,16 @@ def format_facets(es_results, facets, total, search_frame='embedded'):
             if facet['aggregation_type'] == 'stats':
                 result_facet['total'] = aggregations[full_agg_name]['doc_count']
                 # Used for fields on which can do range filter on, to provide min + max bounds
-                for k in aggregations[full_agg_name]["primary_agg"].keys():
-                    result_facet[k] = aggregations[full_agg_name]["primary_agg"][k]
+                for k in aggregations[full_agg_name]['primary_agg'].keys():
+                    result_facet[k] = aggregations[full_agg_name]['primary_agg'][k]
             else: # 'terms' assumed.
 
                 # XXX: This needs to be done in case we 'continue' below, unclear why needed in that case
                 # but tests will fail if its not there when expected.
-                result_facet['terms'] = aggregations[full_agg_name]["primary_agg"]["buckets"]
+                bucket_location = aggregations[full_agg_name]['primary_agg']
+                if 'buckets' not in bucket_location:  # account for nested structure
+                    bucket_location = bucket_location['primary_agg']
+                result_facet['terms'] = bucket_location['buckets']
 
                 # Choosing to show facets with one term for summary info on search it provides
                 # XXX: The above comment is misleading - this drops all facets with no buckets

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -19,8 +19,8 @@ from snovault.util import (
     debug_log
 )
 from snovault.typeinfo import AbstractTypeInfo
-from elasticsearch_dsl import Search, Nested
-from elasticsearch_dsl.aggs import Terms, ReverseNested
+from elasticsearch_dsl import Search
+from elasticsearch_dsl.aggs import Terms
 from elasticsearch import (
     TransportError,
     RequestError,

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -810,9 +810,7 @@ class TestNestedSearch(object):
                     '&families.proband=GAPIDISC7R74', status=404)  # proband should disqualify
 
     def test_search_nested_facets_are_correct(self, workbook, testapp):
-        """ Tests that nested facets are properly rendered
-            TODO: this test should be expanded
-        """
+        """ Tests that nested facets are properly rendered """
         facets = testapp.get('/search/?type=Cohort').json['facets']
         self.verify_facet(facets, 'families.proband.display_title', 3)
         facets = testapp.get('/search/?type=Cohort'


### PR DESCRIPTION
- When repairing nested facets, the original version blew away the boolean qualifiers.
- Reformats the query (into a sub-aggregation) to preserve the boolean qualifiers.
- Changes the `format_facets` code _slightly_ to account for new aggregation structure.