### PR TITLE
C4-154 Load master-inserts on cgaptest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # after having done 'python setup_eb.py develop', at least on the beanstalk. It doesn't
 # sem to be needed locally. -kmp 17-Mar-2020
 name = "encoded"
-version = "2.0.2"
+version = "2.0.3"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/load_data.py
+++ b/src/encoded/commands/load_data.py
@@ -23,7 +23,7 @@ def load_data_should_proceed(env, allow_prod):
     """
     # run on cgaptest -- XXX: this logic should probably be refactored into dcicutils
     if env == CGAP_ENV_MASTERTEST:
-        log.info('load_data: proceeding since we are on cgaptest')
+        log.info('load_data: proceeding since we are on %s' % env)
         return True
     elif env and not allow_prod:  # old logic, allow run on servers if prod is specified
         log.info('load_data: skipping, since on %s' % env)

--- a/src/encoded/commands/load_data.py
+++ b/src/encoded/commands/load_data.py
@@ -18,7 +18,7 @@ def load_data_should_proceed(env, allow_prod):
     """ Returns True on whether or not load_data should proceed.
 
     :param env: env we are on
-    :param allow_prod: parsed arguments from argparse
+    :param allow_prod: prod argument from argparse, defaults to False
     :return: True if load_data should continue, False otherwise
     """
     # run on cgaptest -- XXX: this logic should probably be refactored into dcicutils

--- a/src/encoded/tests/test_loadxl.py
+++ b/src/encoded/tests/test_loadxl.py
@@ -203,5 +203,3 @@ def test_load_data_should_proceed():
     assert load_data_should_proceed(CGAP_ENV_DEV, False) is False
     assert load_data_should_proceed(CGAP_ENV_WEBPROD, True) is True  # XXX: Do we really want this?
     assert load_data_should_proceed(CGAP_ENV_WEBPROD, False) is False
-
-

--- a/src/encoded/tests/test_loadxl.py
+++ b/src/encoded/tests/test_loadxl.py
@@ -4,8 +4,10 @@ import pytest
 from past.builtins import basestring
 from pkg_resources import resource_filename
 from unittest import mock
+from dcicutils.env_utils import CGAP_ENV_MASTERTEST, CGAP_ENV_WEBPROD, CGAP_ENV_DEV, CGAP_ENV_WOLF
 from .. import loadxl
 from ..commands.run_upgrader_on_inserts import get_inserts
+from ..commands.load_data import load_data_should_proceed
 
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
@@ -189,3 +191,17 @@ def test_load_all_gen(testapp):
         assert 'Failure loading inserts' in res4
         assert isinstance(catch4.caught, basestring)
         assert 'Failure loading inserts' in catch4.caught
+
+
+def test_load_data_should_proceed():
+    """ Tests that load_data_should_proceed does the right thing in various environment scenarios """
+    assert load_data_should_proceed(CGAP_ENV_MASTERTEST, True) is True
+    assert load_data_should_proceed(CGAP_ENV_MASTERTEST, False) is True
+    assert load_data_should_proceed(CGAP_ENV_WOLF, True) is True
+    assert load_data_should_proceed(CGAP_ENV_WOLF, False) is False
+    assert load_data_should_proceed(CGAP_ENV_DEV, True) is True
+    assert load_data_should_proceed(CGAP_ENV_DEV, False) is False
+    assert load_data_should_proceed(CGAP_ENV_WEBPROD, True) is True  # XXX: Do we really want this?
+    assert load_data_should_proceed(CGAP_ENV_WEBPROD, False) is False
+
+


### PR DESCRIPTION
- `load_data` logic was never really configured for CGAP.
- This change will allow `load_data` to run on `cgaptest` on deployment while preventing it on other envs and allowing on local.
- This is done through the helper method `load_data_should_proceed`, which is tested in all (current) scenarios