### PR TITLE
Accept version of snovault with dynamic imports removed

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -217,7 +217,7 @@ description = "Storage support for 4DN Data Portals."
 name = "dcicsnovault"
 optional = false
 python-versions = ">=3.6,<3.7"
-version = "3.0.3"
+version = "3.0.6b0"
 
 [package.dependencies]
 MarkupSafe = ">=0.23,<1"
@@ -486,14 +486,14 @@ description = "Read metadata from Python packages"
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "importlib-resources"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
 category = "main"
@@ -1303,7 +1303,7 @@ description = "Fast, Extensible Progress Meter"
 name = "tqdm"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.46.0"
+version = "4.46.1"
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
@@ -1547,7 +1547,7 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "40b4f828fc45ff248af4389687a56cada6e961908bac984ce75c6a815e2f1a45"
+content-hash = "df595fb1a4140542d66729589bbccae3dd092ab293d56d46be15dedf9e909814"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -1691,8 +1691,8 @@ dcicpyvcf = [
     {file = "dcicpyvcf-1.0.0.tar.gz", hash = "sha256:c5bf8d585002ab3b95d13a47803376b456b931865e4189c38a18cca47b108449"},
 ]
 dcicsnovault = [
-    {file = "dcicsnovault-3.0.3-py3-none-any.whl", hash = "sha256:53e92480758733703380d7e20d3e95ba224748210e9da51e0204503a5038f9db"},
-    {file = "dcicsnovault-3.0.3.tar.gz", hash = "sha256:bd5cd6715a0691e79b446fff98d3bb580f5317477dd8c7fce4a22039a8e30636"},
+    {file = "dcicsnovault-3.0.6b0-py3-none-any.whl", hash = "sha256:983058256958a623a1e0515367664223e27b93b374b8e117581d8e88475b42d7"},
+    {file = "dcicsnovault-3.0.6b0.tar.gz", hash = "sha256:7194471fc402ed52d6523a515f27225f6f1cc74ab4bd6d9c7f6504ec68506510"},
 ]
 dcicutils = [
     {file = "dcicutils-0.31.1-py3-none-any.whl", hash = "sha256:9f2728d6ce4fe9b7a0cabdf5a46a20e34039147192854622881c9a46c3707fd1"},
@@ -1761,8 +1761,8 @@ idna = [
     {file = "idna-2.7.tar.gz", hash = "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
-    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+    {file = "importlib_metadata-1.6.1-py2.py3-none-any.whl", hash = "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"},
+    {file = "importlib_metadata-1.6.1.tar.gz", hash = "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545"},
 ]
 isodate = [
     {file = "isodate-0.5.4.tar.gz", hash = "sha256:42105c41d037246dc1987e36d96f3752ffd5c0c24834dd12e4fdbe1e79544e31"},
@@ -2219,8 +2219,8 @@ toml = [
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 tqdm = [
-    {file = "tqdm-4.46.0-py2.py3-none-any.whl", hash = "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"},
-    {file = "tqdm-4.46.0.tar.gz", hash = "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e"},
+    {file = "tqdm-4.46.1-py2.py3-none-any.whl", hash = "sha256:07c06493f1403c1380b630ae3dcbe5ae62abcf369a93bbc052502279f189ab8c"},
+    {file = "tqdm-4.46.1.tar.gz", hash = "sha256:cd140979c2bebd2311dfb14781d8f19bd5a9debb92dcab9f6ef899c987fcf71f"},
 ]
 transaction = [
     {file = "transaction-2.4.0-py2.py3-none-any.whl", hash = "sha256:b96a5e9aaa73f905759bc9ccf0021bf4864c01ac36666e0d28395e871f6d584a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,7 +217,7 @@ description = "Storage support for 4DN Data Portals."
 name = "dcicsnovault"
 optional = false
 python-versions = ">=3.6,<3.7"
-version = "3.0.6b0"
+version = "3.0.7"
 
 [package.dependencies]
 MarkupSafe = ">=0.23,<1"
@@ -1547,7 +1547,7 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "df595fb1a4140542d66729589bbccae3dd092ab293d56d46be15dedf9e909814"
+content-hash = "090d990a83cd98f7f7854d17f24eab8213859bc72a3c8a6d5cbbeb98ebd5a8e0"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -1691,8 +1691,8 @@ dcicpyvcf = [
     {file = "dcicpyvcf-1.0.0.tar.gz", hash = "sha256:c5bf8d585002ab3b95d13a47803376b456b931865e4189c38a18cca47b108449"},
 ]
 dcicsnovault = [
-    {file = "dcicsnovault-3.0.6b0-py3-none-any.whl", hash = "sha256:983058256958a623a1e0515367664223e27b93b374b8e117581d8e88475b42d7"},
-    {file = "dcicsnovault-3.0.6b0.tar.gz", hash = "sha256:7194471fc402ed52d6523a515f27225f6f1cc74ab4bd6d9c7f6504ec68506510"},
+    {file = "dcicsnovault-3.0.7-py3-none-any.whl", hash = "sha256:df6789ef30a80274c415954f13e2d46810ce1af162f465c747d34d0b81c9cfb1"},
+    {file = "dcicsnovault-3.0.7.tar.gz", hash = "sha256:93b6866cecffa1cacce1dd3079905886a7fd0d3c62650748a4a3734b02c2096b"},
 ]
 dcicutils = [
     {file = "dcicutils-0.31.1-py3-none-any.whl", hash = "sha256:9f2728d6ce4fe9b7a0cabdf5a46a20e34039147192854622881c9a46c3707fd1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # after having done 'python setup_eb.py develop', at least on the beanstalk. It doesn't
 # sem to be needed locally. -kmp 17-Mar-2020
 name = "encoded"
-version = "2.0.4b0"
+version = "2.0.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ certifi = "2018.4.16"
 chardet = "3.0.4"
 colorama = "0.3.3"
 coverage = "4.0.3"
-dcicsnovault = "3.0.6b0"  # ">=3.0.7,<4"
+dcicsnovault = ">=3.0.7,<4"
 dcicutils = ">=0.23.0,<1"
 docutils = "0.12"
 elasticsearch = "5.5.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # after having done 'python setup_eb.py develop', at least on the beanstalk. It doesn't
 # sem to be needed locally. -kmp 17-Mar-2020
 name = "encoded"
-version = "2.0.3"
+version = "2.0.4b0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ certifi = "2018.4.16"
 chardet = "3.0.4"
 colorama = "0.3.3"
 coverage = "4.0.3"
-dcicsnovault = ">=3.0.3,<4"
+dcicsnovault = "3.0.6b0"  # ">=3.0.7,<4"
 dcicutils = ">=0.23.0,<1"
 docutils = "0.12"
 elasticsearch = "5.5.3"


### PR DESCRIPTION
This proposes to accept recent changes to snovault to remove dynamic imports.
If a new version of snovault is issued with a non-beta version, I'll update this PR to use that.