### PR TITLE
update workflow.title to use workflowHref or Link

### DIFF
--- a/src/encoded/static/components/browse/columnExtensionMap.js
+++ b/src/encoded/static/components/browse/columnExtensionMap.js
@@ -99,12 +99,13 @@ export const columnExtensionMap = {
     'workflow.title' : {
         'title' : "Workflow",
         'render' : function(result, props){
+            const { "@id": link } = result;
             if (!result.workflow || !result.workflow.title) return null;
             const { title }  = result.workflow;
             const workflowHref = object.itemUtil.atId(result.workflow);
             let retLink;
             if (workflowHref){
-                retLink = <a href={link}>{ title }</a>;
+                retLink = <a href={workflowHref || link}>{ title }</a>;
             } else {
                 retLink = title;
             }


### PR DESCRIPTION
Bugfix for:

Transform error
ReferenceError: link is not defined
    at renderFxn (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/src/encoded/static/components/browse/columnExtensionMap.js:107:36)
    at n.render (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js:183:31)
    at d (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:38:231)
    at $a (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:39:16)
    at e.render (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:44:476)
    at e.read (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:44:18)
    at Object.renderToString (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:54:364)
    at Function.transform (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/src/encoded/static/libs/react-middleware.js:82:33)
    at ServerResponse.call (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/subprocess-middleware/middleware.js:52:14)
    at ServerResponse.t.end (/opt/python/bundle/2/app/src/encoded/static/build/webpack:/node_modules/subprocess-middleware/middleware.js:28:11)
--log--
A (non-'Item') type filter is present. Will skip filtering Item types in Facet.
A (non-'Item') type filter is present. Will skip filtering Item types in Facet.
--warn--
memoizedUrlParse called with http://fourfront-cgapwolf.9wzadzju3p.us-east-1.elasticbeanstalk.com/search/?type=WorkflowRun