### PR TITLE
Cleaning up some loose ends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,7 @@ before_install:
 - node --version
 - npm config set python /usr/bin/python2.7
 install:
-# need to manually change the version of six used by Travis for some reason
-- pip uninstall -y six
-- pip install six==1.11.0
-- pip install --upgrade pip==19.0.3
+- pip install --upgrade pip
 - pip install poetry
 - pip install coveralls
 - pip install codacy-coverage

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ kibana-stop:
 kill:  # kills back-end processes associated with the application. Use with care.
 	pkill -f postgres &
 	pkill -f elasticsearch &
+	pkill -f moto_server &
 
 clean-python:
 	@echo -n "Are you sure? This will wipe all libraries installed on this virtualenv [y/N] " && read ans && [ $${ans:-N} = y ]

--- a/examples/s3cp.py
+++ b/examples/s3cp.py
@@ -20,7 +20,7 @@ encode_url = urlparse.urljoin(SERVER,f_obj.get('href'))
 r = requests.get(encode_url, auth=(AUTHID,AUTHPW), headers=HEADERS, allow_redirects=True, stream=True)
 try:
     r.raise_for_status
-except:
+except Exception:
     print '%s href does not resolve' %(f_obj.get('accession'))
     sys.exit()
 

--- a/examples/submit_file.py
+++ b/examples/submit_file.py
@@ -153,7 +153,7 @@ r = requests.post(
 )
 try:
     r.raise_for_status()
-except:
+except Exception:
     print('Submission failed: %s %s' % (r.status_code, r.reason))
     print(r.text)
     raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.1.3"
+version = "2.1.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.1.4"
+version = "2.1.5b0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/submit_file.py
+++ b/scripts/submit_file.py
@@ -159,7 +159,7 @@ r = requests.post(
 )
 try:
     r.raise_for_status()
-except:
+except Exception:
     print('Submission failed: %s %s' % (r.status_code, r.reason))
     print(r.text)
     raise

--- a/src/encoded/commands/add_date_created.py
+++ b/src/encoded/commands/add_date_created.py
@@ -87,7 +87,7 @@ def run(testapp, collections=None, exclude=None, dry_run=False):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is specified wrong here.
         description="Fix date_created", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/check_rendering.py
+++ b/src/encoded/commands/check_rendering.py
@@ -19,6 +19,7 @@ EPILOG = __doc__
 
 logger = logging.getLogger(__name__)
 
+
 def check_path(testapp, path):
     try:
         res = testapp.get(path, status='*').maybe_follow(status='*')
@@ -49,16 +50,15 @@ def run(testapp, collections=None):
         collection_path = resource_path(collection, '')
         check_path(testapp, collection_path)
         failed = 0
+        count = -1  # PyCharm worries the 'count' variable won't get set in the next loop if the collection is empty.
         for count, item in enumerate(itervalues(collection)):
             path = resource_path(item, '')
             if not check_path(testapp, path):
                 failed += 1
         if failed:
-            logger.info('Collection %s: %d of %d failed to render.',
-                collection_path, failed, count)
+            logger.info('Collection %s: %d of %d failed to render.', collection_path, failed, count)
         else:
-            logger.info('Collection %s: all %d rendered ok',
-                collection_path, count)
+            logger.info('Collection %s: all %d rendered ok', collection_path, count)
 
 
 def internal_app(configfile, app_name=None, username='TEST', accept='text/html'):
@@ -80,8 +80,7 @@ def main():
     )
     parser.add_argument('--item-type', action='append', help="Item type")
     parser.add_argument('--app-name', help="Pyramid app name in configfile")
-    parser.add_argument('--username', '-u', default='TEST',
-        help="User uuid/email")
+    parser.add_argument('--username', '-u', default='TEST', help="User uuid/email")
     parser.add_argument('config_uri', help="path to configfile")
     parser.add_argument('path', nargs='*', help="path to test")
     args = parser.parse_args()
@@ -97,8 +96,7 @@ def main():
             if not check_path(testapp, path):
                 failed += 1
         if failed:
-            logger.info('Paths: %d of %d failed to render.',
-                failed, len(args.path))
+            logger.info('Paths: %d of %d failed to render.', failed, len(args.path))
         else:
             logger.info('Paths: all %d rendered ok', len(args.path))
     else:

--- a/src/encoded/commands/check_rendering.py
+++ b/src/encoded/commands/check_rendering.py
@@ -74,7 +74,7 @@ def internal_app(configfile, app_name=None, username='TEST', accept='text/html')
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is specified wrong here.
         description="Check rendering of items", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/clear_variants_and_genes.py
+++ b/src/encoded/commands/clear_variants_and_genes.py
@@ -22,7 +22,7 @@ def main():
     """ Wipes the variant + gene items in appropriate order """
     logging.basicConfig()
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description='Clear an item type out of metadata storage',
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/configure_kibana_index.py
+++ b/src/encoded/commands/configure_kibana_index.py
@@ -16,7 +16,7 @@ def main():
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.INFO)
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Configure Kibana Index", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/create_mapping_on_deploy.py
+++ b/src/encoded/commands/create_mapping_on_deploy.py
@@ -5,7 +5,7 @@ import logging
 from pyramid.paster import get_app
 from snovault.elasticsearch.create_mapping import run as run_create_mapping
 from dcicutils.log_utils import set_logging
-from dcicutils.beanstalk_utils import whodaman
+# from dcicutils.beanstalk_utils import whodaman
 
 log = structlog.getLogger(__name__)
 EPILOG = __doc__
@@ -81,7 +81,7 @@ NEW_BEANSTALK_PROD_ENVS = [
 
 BEANSTALK_PROD_ENVS = [
     ENV_WEBPROD,
-#   ENV_WEBPROD2,
+    # ENV_WEBPROD2,
 ]
 
 
@@ -155,7 +155,8 @@ def _run_create_mapping(app, args):
         if args.wipe_es:  # override deploy_cfg WIPE_ES option
             log.info('Overriding deploy_cfg and wiping ES')
             deploy_cfg['WIPE_ES'] = True
-        run_create_mapping(app, check_first=(not deploy_cfg['WIPE_ES']), purge_queue=args.clear_queue, item_order=ITEM_INDEX_ORDER)
+        run_create_mapping(app, check_first=(not deploy_cfg['WIPE_ES']), purge_queue=args.clear_queue,
+                           item_order=ITEM_INDEX_ORDER)
     except Exception as e:
         log.error("Exception encountered while gathering deployment information or running create_mapping")
         log.error(str(e))
@@ -163,7 +164,7 @@ def _run_create_mapping(app, args):
 
 
 def main():
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Create Elasticsearch mapping on deployment", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -176,7 +177,8 @@ def main():
     app = get_app(args.config_uri, args.app_name)
     # Loading app will have configured from config file. Reconfigure here:
     set_logging(in_prod=app.registry.settings.get('production'), log_name=__name__, level=logging.DEBUG)
-    # set_logging(app.registry.settings.get('elasticsearch.server'), app.registry.settings.get('production'), level=logging.DEBUG)
+    # set_logging(app.registry.settings.get('elasticsearch.server'), app.registry.settings.get('production'),
+    #             level=logging.DEBUG)
 
     _run_create_mapping(app, args)
     exit(0)

--- a/src/encoded/commands/export_data.py
+++ b/src/encoded/commands/export_data.py
@@ -97,7 +97,7 @@ def run(search_url, username='', password=''):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Export Data", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/extract_test_data.py
+++ b/src/encoded/commands/extract_test_data.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import loremipsum
 import os
@@ -132,7 +133,6 @@ def run(pipeline, inpath, outpath):
 
 
 def main():
-    import argparse
     parser = argparse.ArgumentParser(description='Extract test data set.')
     parser.add_argument('--anonymize', '-a', action="store_true",
         help="anonymize the data.")
@@ -144,10 +144,11 @@ def main():
     pipeline = anon_pipeline() if args.anonymize else extract_pipeline()
     try:
         run(pipeline, args.inpath, args.outpath)
-    except:
+    except Exception:
         type, value, tb = sys.exc_info()
         traceback.print_exc()
         # import pdb; pdb.post_mortem(tb)
+
 
 if __name__ == '__main__':
     main()

--- a/src/encoded/commands/extract_test_data.py
+++ b/src/encoded/commands/extract_test_data.py
@@ -1,7 +1,11 @@
 import csv
 import loremipsum
+import os
 import random
 import re
+import sys
+import traceback
+
 from ..loadxl import *
 
 
@@ -138,15 +142,12 @@ def main():
         help="directory to write filtered tsv files to.")
     args = parser.parse_args()
     pipeline = anon_pipeline() if args.anonymize else extract_pipeline()
-    import pdb
-    import sys
-    import traceback
     try:
         run(pipeline, args.inpath, args.outpath)
     except:
         type, value, tb = sys.exc_info()
         traceback.print_exc()
-        pdb.post_mortem(tb)
+        # import pdb; pdb.post_mortem(tb)
 
 if __name__ == '__main__':
     main()

--- a/src/encoded/commands/gene_ingestion.py
+++ b/src/encoded/commands/gene_ingestion.py
@@ -75,7 +75,7 @@ def main():
         --app-name app --post-annotation-field-inserts --post-inserts
     """
     logging.basicConfig()
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Takes in a gene mapping table and produces inserts/schemas",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/gene_table_intake.py
+++ b/src/encoded/commands/gene_table_intake.py
@@ -99,7 +99,7 @@ def main():
                src/encoded/schemas/gene.json development.ini --app-name app --post-inserts
     """
     logging.basicConfig()
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Takes in a variant mapping table and produces variant related inserts/schemas",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -1,5 +1,6 @@
 import argparse
 from datetime import datetime
+import io
 import logging
 import logging.config
 import json
@@ -309,7 +310,7 @@ def connect2server(env=None, key=None, keyfile=None, logger=None):
     if key and keyfile:
         keys = None
         if os.path.isfile(keyfile):
-            with open(keyfile, 'r') as kf:
+            with io.open(keyfile, 'r') as kf:
                 keys_json_string = kf.read()
                 keys = json.loads(keys_json_string)
         if keys:
@@ -582,7 +583,7 @@ def write_outfile(terms, filename, pretty=False):
         write to file by default as a json list or if pretty
         then same with indents and newlines
     '''
-    with open(filename, 'w') as outfile:
+    with io.open(filename, 'w') as outfile:
         if pretty:
             json.dump(terms, outfile, indent=4)
         else:
@@ -654,7 +655,7 @@ def post_report_document_to_portal(connection, itype, logfile):
     attach_fn = None
     if os.path.isfile(logfile):
         attach_fn = '{}_update_report_{}.txt'.format(itype, date)
-        with open(logfile, 'rb') as at:
+        with io.open(logfile, 'rb') as at:
             data = at.read()
             data_href = 'data:%s;base64,%s' % (mimetype, b64encode(data).decode('ascii'))
             attach = {'download': attach_fn, 'type': mimetype, 'href': data_href}

--- a/src/encoded/commands/generate_items_from_owl.py
+++ b/src/encoded/commands/generate_items_from_owl.py
@@ -590,7 +590,7 @@ def write_outfile(terms, filename, pretty=False):
 
 
 def get_args(args):
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Process specified Ontologies and create OntologyTerm inserts for updates",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/encoded/commands/import_data.py
+++ b/src/encoded/commands/import_data.py
@@ -72,7 +72,7 @@ def main():
         ALLOWED_METHODS.append('PATCH')
 
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Import data", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/ingest_genes.py
+++ b/src/encoded/commands/ingest_genes.py
@@ -62,7 +62,7 @@ def main():
             path_to_genes (str): path to genes to ingest
     """
     logging.basicConfig()
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Ingests a given gene file containing JSON formatted genes",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/ingest_vcf.py
+++ b/src/encoded/commands/ingest_vcf.py
@@ -237,7 +237,7 @@ class VCFParser(object):
         elif type == 'number':
             try:
                 return float(value)
-            except:
+            except Exception:
                 return float(value[0])
         elif type == 'boolean':
             if value == '0':
@@ -544,7 +544,7 @@ def main():
             hms-dbmi hms-dbmi production.ini --app-name app --post-inserts
     """
     logging.basicConfig()
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Ingests a given VCF file",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter
@@ -582,7 +582,7 @@ def main():
             vcf_parser.format_variant_sub_embedded_objects(variant)
             try:
                 res = app_handle.post_json('/variant', variant, status=201).json['@graph'][0]  # only one item posted
-            except:
+            except Exception:
                 print('Failed validation')  # some variant gene linkTos do not exist
                 continue
             variant_samples = vcf_parser.create_sample_variant_from_record(record)

--- a/src/encoded/commands/ingestion.py
+++ b/src/encoded/commands/ingestion.py
@@ -47,7 +47,7 @@ def main():
     The idea is to provide as many 'knobs' as possible.
     """
     logging.basicConfig()
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Runs the ingestion process on this server, subject to arguments",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/jsonld_rdf.py
+++ b/src/encoded/commands/jsonld_rdf.py
@@ -29,7 +29,7 @@ def main():
     rdflib_serializers = sorted(
         p.name for p in rdflib.plugin.plugins(kind=rdflib.serializer.Serializer)
         if '/' not in p.name)
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Convert JSON-LD from source URLs to RDF", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/load_access_keys.py
+++ b/src/encoded/commands/load_access_keys.py
@@ -77,7 +77,7 @@ def main():
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.INFO)
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Load Access Keys", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/load_data.py
+++ b/src/encoded/commands/load_data.py
@@ -38,7 +38,7 @@ def main():
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.DEBUG)
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Load Test Data", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/load_items.py
+++ b/src/encoded/commands/load_items.py
@@ -51,7 +51,7 @@ def get_logger(lname, logfile):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Load json formatted Items to Database from a file or a python list or dict", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/migrate_attachments_aws.py
+++ b/src/encoded/commands/migrate_attachments_aws.py
@@ -48,7 +48,7 @@ def run(app):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Move attachment blobs to S3", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -65,7 +65,7 @@ def main():
     raised = False
     try:
         run(app)
-    except:
+    except Exception:
         raised = True
         raise
     finally:

--- a/src/encoded/commands/migrate_dataset_type.py
+++ b/src/encoded/commands/migrate_dataset_type.py
@@ -37,7 +37,7 @@ def run(app):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Migrate dataset type", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -54,7 +54,7 @@ def main():
     raised = False
     try:
         run(app)
-    except:
+    except Exception:
         raised = True
         raise
     finally:

--- a/src/encoded/commands/migrate_files_aws.py
+++ b/src/encoded/commands/migrate_files_aws.py
@@ -41,7 +41,7 @@ def run(app, files):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Migrate files to AWS", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -63,7 +63,7 @@ def main():
     raised = False
     try:
         run(app, good_files)
-    except:
+    except Exception:
         raised = True
         raise
     finally:

--- a/src/encoded/commands/owltools.py
+++ b/src/encoded/commands/owltools.py
@@ -26,7 +26,7 @@ def convert2URIRef(astring):
     '''converts a string to a URIRef type'''
     try:
         astring = URIRef(astring)
-    except:
+    except Exception:
         pass
     return astring
 
@@ -39,7 +39,7 @@ def inferNamespacePrefix(aUri):
     stringa = aUri.__str__()
     try:
         prefix = stringa.replace("#", "").split("/")[-1]
-    except:
+    except Exception:
         prefix = ""
     return prefix
 
@@ -50,7 +50,7 @@ def splitNameFromNamespace(aUri):
     try:
         ns = stringa.split("#")[0]
         name = stringa.split("#")[1]
-    except:
+    except Exception:
         ns = stringa.rsplit("/", 1)[0]
         if '/' in stringa:
             name = stringa.rsplit("/", 1)[1]
@@ -62,13 +62,13 @@ def sortUriListByName(uri_list):
     def get_last_bit(uri_string):
         try:
             x = uri_string.split("#")[1]
-        except:
+        except Exception:
             x = uri_string.split("/")[-1]
         return x
 
     try:
         return sorted(uri_list, key=lambda x: get_last_bit(x.__str__()))
-    except:
+    except Exception:
         # TODO: do more testing.. maybe use a unicode-safe method instead of __str__
         print("Error in <sortUriListByName>: possibly a UnicodeEncodeError")
         return uri_list
@@ -128,10 +128,10 @@ class Owler(object):
         self.rdfGraph = ConjunctiveGraph()
         try:
             self.rdfGraph.parse(uri, format="application/rdf+xml")
-        except:
+        except Exception:
             try:
                 self.rdfGraph.parse(uri, format="n3")
-            except:
+            except Exception:
                 raise exceptions.Error("Could not parse the file! Is it a valid RDF/OWL ontology?")
         finally:
             self.baseURI = self.__get_OntologyURI() or uri

--- a/src/encoded/commands/parse_hpoa.py
+++ b/src/encoded/commands/parse_hpoa.py
@@ -316,7 +316,7 @@ def log_problems(logger, problems):
 
 
 def get_args(args):  # pragma: no cover
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description='Given an HPOA file or url for download generate EvidenceDisPheno items and optionally load',
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/profiler.py
+++ b/src/encoded/commands/profiler.py
@@ -77,7 +77,7 @@ def run(testapp, method, path, data, warm_ups, filename, sortby, stats, callers,
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Update links and keys", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/purge_item_type.py
+++ b/src/encoded/commands/purge_item_type.py
@@ -62,7 +62,7 @@ def main():
     """ Entry point for this command """
     logging.basicConfig()
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description='Clear an item type out of metadata storage',
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/run_upgrader_on_inserts.py
+++ b/src/encoded/commands/run_upgrader_on_inserts.py
@@ -21,7 +21,7 @@ def main():
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.DEBUG)
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Run inserts through an upgrader", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/spreadsheet_to_json.py
+++ b/src/encoded/commands/spreadsheet_to_json.py
@@ -46,7 +46,7 @@ def convert(filename, sheetname=None, outputdir=None, skip_blanks=False):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Convert spreadsheet to json list", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/update_inserts_from_server.py
+++ b/src/encoded/commands/update_inserts_from_server.py
@@ -58,7 +58,7 @@ def main():
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.DEBUG)
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Update Inserts", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/commands/validate_vcf.py
+++ b/src/encoded/commands/validate_vcf.py
@@ -22,13 +22,13 @@ class VCFValidator(object):
             for idx, record in enumerate(self.reader):
                 print("Record %s validated" % idx)
             return True
-        except:  # catch all and re-raise, alerting the user to which record
+        except Exception:  # catch all and re-raise, alerting the user to which record
             print("Record %s failed vcf spec validation" % (idx + 1))
             raise
 
 
 def main():
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Ingests a given VCF file",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/variant_ingestion.py
+++ b/src/encoded/commands/variant_ingestion.py
@@ -40,7 +40,7 @@ def run_ingest_vcf(app_handle, args):
                     vcf_parser.format_variant_sub_embedded_objects(variant)
                     res = app_handle.post_json('/variant', variant, status=201).json['@graph'][0]  # only one item posted
                     success += 1
-                except:  # ANNOTATION spec validation error, recoverable
+                except Exception:  # ANNOTATION spec validation error, recoverable
                     error += 1
                     continue
                 variant_samples = vcf_parser.create_sample_variant_from_record(record)
@@ -97,7 +97,7 @@ def main():
 
     """
     logging.basicConfig()
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Variant Ingestion Program",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/variant_table_intake.py
+++ b/src/encoded/commands/variant_table_intake.py
@@ -203,7 +203,7 @@ class MappingTableParser(object):
                                               'key other than "key" or "title": %s ' % type)
         try:
             fmt = json.loads(json_or_str)
-        except:  # just a string is given, use for both name and title
+        except Exception:  # just a string is given, use for both name and title
             return json_or_str
         else:
             return fmt[type]
@@ -568,7 +568,7 @@ def main():
 
     """
     logging.basicConfig()
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Takes in a mapping table and produces inserts/schemas",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/encoded/commands/verify_item.py
+++ b/src/encoded/commands/verify_item.py
@@ -30,7 +30,7 @@ def run(app, uuids=None):
 def main():
     ''' Verifies and item against database / ES and checks embeds '''
 
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Verifies and item against database / ES and checks embeds", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -404,7 +404,7 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                         # 301 because @id is the existing item path, not uuid
                         testapp.get('/'+an_item['uuid'], status=[200, 301])
                         exists = True
-                    except:
+                    except Exception:
                         pass
                 # skip the items that exists
                 # if overwrite=True, still include them in PATCH round

--- a/src/encoded/memlimit.py
+++ b/src/encoded/memlimit.py
@@ -1,3 +1,8 @@
+import humanfriendly
+import logging
+import psutil
+
+
 # https://code.google.com/p/modwsgi/wiki/RegisteringCleanupCode
 
 
@@ -31,11 +36,6 @@ class ExecuteOnCompletion2:
             self.__callback(environ)
             raise
         return Generator2(result, self.__callback, environ)
-
-
-import logging
-import psutil
-import humanfriendly
 
 
 def rss_checker(rss_limit=None, rss_percent_limit=None):

--- a/src/encoded/search/lucene_builder.py
+++ b/src/encoded/search/lucene_builder.py
@@ -237,7 +237,7 @@ class LuceneBuilder:
 
                                 found = True  # break is not sufficient, see below
                                 break
-                        except:  # Why? We found a 'range' nested query and must add this one separately
+                        except Exception:  # Why? We found a 'range' nested query and must add this one separately
                             continue  # This behavior is absurd. Somehow it knows to combine separate nested range
                             # queries with AND, but of course not regular queries and of course you cannot
                             # combine the range query here due to syntax  - Will

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -134,7 +134,7 @@ def test_create_mapping_on_indexing(app, testapp, registry, elasticsearch):
         try:
             namespaced_index = get_namespaced_index(app, item_type)
             item_index = es.indices.get(index=namespaced_index)
-        except:
+        except Exception:
             assert False
         found_index_mapping_emb = item_index[namespaced_index]['mappings'][item_type]['properties']['embedded']
         found_index_settings = item_index[namespaced_index]['settings']

--- a/src/encoded/tests/test_util.py
+++ b/src/encoded/tests/test_util.py
@@ -1,0 +1,46 @@
+import io
+import os
+import pytest
+
+from unittest import mock
+from ..util import MockFileSystem
+
+
+def test_mock_file_system():
+
+    fs = MockFileSystem()
+
+    with mock.patch.object(io, "open") as mock_open:
+        with mock.patch.object(os.path, "exists") as mock_exists:
+            with mock.patch.object(os, "remove") as mock_remove:
+
+                mock_open.side_effect = fs.open
+                mock_exists.side_effect = fs.exists
+                mock_remove.side_effect = fs.remove
+
+                filename = "no.such.file"
+                assert os.path.exists(filename) is False
+
+                with io.open(filename, 'w') as fp:
+                    fp.write("foo")
+                    fp.write("bar")
+
+                assert os.path.exists(filename) is True
+
+                with io.open(filename, 'r') as fp:
+                    assert fp.read() == 'foobar'
+
+                with io.open(filename, 'r') as fp:
+                    assert fp.read() == 'foobar'
+
+                assert os.path.exists(filename) is True
+
+                os.remove(filename)
+
+                assert os.path.exists(filename) is False
+
+                with pytest.raises(FileNotFoundError):
+                    os.remove(filename)
+
+                with pytest.raises(FileNotFoundError):
+                    io.open(filename, 'r')

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -121,7 +121,7 @@ def get_item_or_none(request, value, itype=None, frame='object'):
     # these paths are cached in indexing
     try:
         item = request.embed(svalue, '@@' + frame)
-    except:
+    except Exception:
         pass
 
     # could lead to unexpected errors if == None
@@ -376,7 +376,7 @@ class Item(snovault.Item):
             type_date = self.__class__.__name__ + " from " + properties.get("date_created", None)[:10]
             return type_date
         # last resort, use uuid
-        except:
+        except Exception:
             return properties.get('uuid', None)
 
     def rev_link_atids(self, request, rev_name):

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -248,7 +248,7 @@ class File(Item):
             # get @id for parent file
             try:
                 at_id = resource_path(self)
-            except:
+            except Exception:
                 at_id = "/" + str(uuid) + "/"
             # ensure at_id ends with a slash
             if not at_id.endswith('/'):
@@ -325,7 +325,7 @@ class File(Item):
                     rev_switch = DicRefRelation[switch]
                     related_fl = relation["file"]
                     relationship_entry = {"relationship_type": rev_switch, "file": my_uuid}
-                except:
+                except Exception:
                     log.error('Error updating related_files on %s _update. %s'
                               % (my_uuid, relation))
                     continue

--- a/src/encoded/util.py
+++ b/src/encoded/util.py
@@ -1,3 +1,4 @@
+import io
 import os
 
 
@@ -26,3 +27,56 @@ def deduplicate_list(lst):
     :return: de-duplicated list
     """
     return list(set(lst))
+
+
+# TODO: Move this mock file system to dcicutils. -kmp 30-Jun-2020
+
+FILE_SYSTEM_VERBOSE = True
+
+class MockFileSystem:
+    """Extremely low-tech mock file system."""
+
+    def __init__(self):
+        self.files = {}
+
+    def exists(self, file):
+        return bool(self.files.get(file))
+
+    def remove(self, file):
+        if not self.files.pop(file, None):
+            raise FileNotFoundError("No such file or directory: %s" % file)
+
+    def open(self, file, mode='r'):
+        if FILE_SYSTEM_VERBOSE: print("Opening %r in mode %r." % (file, mode))
+        if mode == 'w':
+            return self._open_for_write(file_system=self, file=file)
+        elif mode == 'r':
+            return self._open_for_read(file)
+        else:
+            raise AssertionError("Mocked io.open doesn't handle mode=%r." % mode)
+
+    def _open_for_read(self, file):
+        text = self.files.get(file)
+        if text is None:
+            raise FileNotFoundError("No such file or directory: %s" % file)
+        if FILE_SYSTEM_VERBOSE: print("Read %s to %s." % (text, file))
+        return io.StringIO(text)
+
+    def _open_for_write(self, file_system, file):
+
+        class MockFileWriter:
+
+            def __init__(self, file_system, file):
+                self.file_system = file_system
+                self.file = file
+                self.stream = io.StringIO()
+
+            def __enter__(self):
+                return self.stream
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                text = self.stream.getvalue()
+                if FILE_SYSTEM_VERBOSE: print("Writing %s to %s." % (text, file))
+                self.file_system.files[file] = text
+
+        return MockFileWriter(file_system=file_system, file=file)


### PR DESCRIPTION
Various unrelated changes:

1. Adds `moto_server` to the list of things `make clean` kills. (@willronchetti asked for this.)

2. Gets rid of a `pdb` reference that got left out of a previous PR but was requested during code review by @ebberg and @willronchetti.

3. Rewrite all but one `except:` as `except Exception:`. The last one is one I'm not sure of and will have to be tested better another time. (Fourfront had a similar set of changes and they're easy and non-controversial so I figured I'd just get them out of the way.)

4. Add `# noqa` markers on a bunch of argparse calls so that PyCharm doesn't get confused by some incorrect type analysis. PyCharm's code analysis does something heuristic is wrong a lot and causes spurious warnings.

5. Remove a weird foothold dance that `.travis.yml` was doing with uninstalling and reinstalling `six` in a way that I am not convinced is needed. The installation procedure will be simpler this way. A similar change in Fourfront is working OK.

6. Improvements to unit testing for `generate_items_from_owl.py`.

There are a lot of files touched but most of those are items 3 and 4, both of which are very mechanical and should be quick to review.


