### PR TITLE
Fix a duplicated bam_sample_id (C4-221)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.1.7"
+version = "2.1.8"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/data/inserts/sample.json
+++ b/src/encoded/tests/data/inserts/sample.json
@@ -32,7 +32,7 @@
         "indication": "cervical cancer",
         "specimen_accession": "12345",
         "specimen_accession_date": "2020-03-01",
-        "bam_sample_id": "test003_sample",
+        "bam_sample_id": "test004_sample",
         "requisition_acceptance": {
             "accepted_rejected": "Rejected",
             "rejection_reason": "DOB missing",


### PR DESCRIPTION
I was getting a conflict on `deploy1` because there are four data items in `src/encoded/tests/data/inserts/sample.json` that had `"bam_sample_id"` of `"test001_sample"`, `"test002_sample"`, `"test003_sample"`, and `"test003_sample"`. This fixes the fourth to be `"test004_sample"`, which I assume is what's needed. It makes the `deploy1` operation succeed on master.
