### PR TITLE
Simplify travis build procedure more, picking up moto in the process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,7 @@ before_install:
 - node --version
 - npm config set python /usr/bin/python2.7
 install:
-- pip install --upgrade pip
-- pip install poetry
-- poetry install
-- make npm-setup
+- make build
 before_script:
 - configure-kibana-index --es-endpoint search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80
 script:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ macpoetry-install:  # Same as 'poetry install' except that on OSX Catalina, an e
 	bin/macpoetry-install
 
 configure:  # does any pre-requisite installs
+	pip install --upgrade pip
 	pip install poetry
 
 macbuild:  # builds for Catalina

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.1.11"
+version = "2.1.12"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This small change has two effects:

* Use `make build` rather than a bunch of calls to lower-level things (`poetry install`, etc.) in `.travis.yml`, picking up `moto` in the process since it's done by `make build` and was not part of the lower level call sequence.

* Add `pip install --upgrade pip` to the list of things `make configure` does just because it's a good idea and might help some things install better. Travis was already doing this, but our install procedure documents you have to do it yourself if you want. Better not to leave it to chance.