### PR TITLE
Address C4-169 workflow embed issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.2.2"
+version = "2.3.0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -496,7 +496,7 @@ class FileFastq(File):
         "quality_metric.Total Sequences",
         "quality_metric.Sequence length",
         "quality_metric.url"
-    ]  # + file_workflow_run_embeds
+    ]  + file_workflow_run_embeds
     name_key = 'accession'
     rev = dict(File.rev, **{
         'workflow_run_inputs': ('WorkflowRun', 'input_files.value'),
@@ -541,7 +541,7 @@ class FileProcessed(File):
     """Collection for individual processed files."""
     item_type = 'file_processed'
     schema = load_schema('encoded:schemas/file_processed.json')
-    embedded_list = File.embedded_list  # + file_workflow_run_embeds_processed
+    embedded_list = File.embedded_list + file_workflow_run_embeds_processed
     name_key = 'accession'
     rev = dict(File.rev, **{
         'workflow_run_inputs': ('WorkflowRun', 'input_files.value'),


### PR DESCRIPTION
Address [C4-169](https://hms-dbmi.atlassian.net/browse/C4-169) as follows:

1. Make `FileProcessed` include `file_workflow_run_embeds_processed` **(fixes the bug)**.

2. Make `FileFastq` include `file_workflow_run_embeds` **(opportunistic - does this seem like a good idea?)**.

For reference, `file_workflow_run_embeds` implies:

```
    'workflow_run_inputs.workflow.title',
    'workflow_run_inputs.input_files.workflow_argument_name',
    'workflow_run_inputs.input_files.value.filename',
    'workflow_run_inputs.input_files.value.display_title',
    'workflow_run_inputs.input_files.value.file_format',
    'workflow_run_inputs.input_files.value.uuid',
    'workflow_run_inputs.input_files.value.accession',
    'workflow_run_inputs.output_files.workflow_argument_name',
    'workflow_run_inputs.output_files.value.display_title',
    'workflow_run_inputs.output_files.value.file_format',
    'workflow_run_inputs.output_files.value.uuid',
    'workflow_run_inputs.output_files.value.accession',
    'workflow_run_inputs.output_files.value_qc.url',
    'workflow_run_inputs.output_files.value_qc.overall_quality_status'
```

and `file_workflow_run_embeds_processed` implies all of the above plus also these:

```
    'workflow_run_outputs.workflow.title',
    'workflow_run_outputs.input_files.workflow_argument_name',
    'workflow_run_outputs.input_files.value.filename',
    'workflow_run_outputs.input_files.value.display_title',
    'workflow_run_outputs.input_files.value.file_format',
    'workflow_run_outputs.input_files.value.uuid',
    'workflow_run_outputs.input_files.value.accession',
    'workflow_run_outputs.output_files.workflow_argument_name',
    'workflow_run_outputs.output_files.value.display_title',
    'workflow_run_outputs.output_files.value.file_format',
    'workflow_run_outputs.output_files.value.uuid',
    'workflow_run_outputs.output_files.value.accession',
    'workflow_run_outputs.output_files.value_qc.url',
    'workflow_run_outputs.output_files.value_qc.overall_quality_status'
```
