### PR TITLE
C4-252 Sentry Fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.3.3"
+version = "2.3.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -344,10 +344,6 @@ class IngestionListener:
     def build_variant_link(self, variant):
         """ This function takes a variant record and returns the corresponding UUID of this variant
             in the portal via search.
-
-            XXX: This should be refactored to be unneeded. You should be able to form the link from
-            annotation_id (or display_title). This slows down the ingestion process by a decent amount,
-            but is tolerable since it still proceeds at the same rate as indexing.
         """
         annotation_id = 'chr%s:%s%s_%s' % (variant['CHROM'], variant['POS'], variant['REF'], variant['ALT'])
         return annotation_id

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -349,9 +349,8 @@ class IngestionListener:
             annotation_id (or display_title). This slows down the ingestion process by a decent amount,
             but is tolerable since it still proceeds at the same rate as indexing.
         """
-        display_title = 'chr%s:%s%s_%s' % (variant['CHROM'], variant['POS'], variant['REF'], variant['ALT'])
-        variant = self.vapp.get('/search/?type=Variant&display_title=%s' % display_title).follow().json
-        return variant['@graph'][0]['uuid']
+        annotation_id = 'chr%s:%s%s_%s' % (variant['CHROM'], variant['POS'], variant['REF'], variant['ALT'])
+        return annotation_id
 
     def build_and_post_variant(self, parser, record, project, institution):
         """ Helper method for below that builds and posts a variant item given a record """

--- a/src/encoded/search/lucene_builder.py
+++ b/src/encoded/search/lucene_builder.py
@@ -812,8 +812,8 @@ class LuceneBuilder:
                                     found = True
                                     break
         except QueryConstructionException:
-            log.error('SEARCH: Detected URL query param manipulation, principals_allowed.view was '
-                      'modified from %s to %s' % (request.effective_principals,
+            log.error('SEARCH: Detected URL query param manipulation, principals_allowed.view was'
+                      ' modified from %s to %s' % (request.effective_principals,
                                                   effective_principals_on_query))
             raise HTTPBadRequest('The search failed - the DCIC team has been notified.')
         except KeyError:

--- a/src/encoded/search/lucene_builder.py
+++ b/src/encoded/search/lucene_builder.py
@@ -812,7 +812,7 @@ class LuceneBuilder:
                                     found = True
                                     break
         except QueryConstructionException:
-            log.error('SEARCH: Detected URL query param manipulation, principals_allowed.view was'
+            log.error('SEARCH: Detected URL query param manipulation, principals_allowed.view was '
                       'modified from %s to %s' % (request.effective_principals,
                                                   effective_principals_on_query))
             raise HTTPBadRequest('The search failed - the DCIC team has been notified.')

--- a/src/encoded/tests/data/variant_workbook/gene_workbook.json
+++ b/src/encoded/tests/data/variant_workbook/gene_workbook.json
@@ -757,5 +757,632 @@
   "brainspan_microarray": "CPSF3L",
   "brainspan_rnaseq": "ENSG00000127054",
   "brainatlas_microarray": "CPSF3L"
+},
+  {
+  "chrom": "1",
+  "spos": 1308597,
+  "epos": 1311677,
+  "ensgid": "ENSG00000169972",
+  "strand": "+",
+  "gene_version": "12",
+  "gene_symbol": "PUSL1",
+  "gene_biotype": "protein_coding",
+  "chrom_hg19": "1",
+  "spos_hg19": 1243947,
+  "epos_hg19": 1247057,
+  "strand_hg19": "+",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "hgnc_id": "26914",
+  "name": "pseudouridine synthase like 1",
+  "entrez_id": "126789",
+  "ucsc_id": "uc001aed.4",
+  "refseq_accession": [
+    "NM_153339"
+  ],
+  "ccds_id": [
+    "CCDS20"
+  ],
+  "uniprot_ids": [
+    "Q8N0Z8"
+  ],
+  "mgd_id": [
+    "MGI:3047787"
+  ],
+  "transcriptid": [
+    {
+      "ensembl_trs": "ENST00000379031",
+      "ensembl_pro": "ENSP00000368318"
+    },
+    {
+      "ensembl_trs": "ENST00000467712",
+      "ensembl_pro": "ENSP00000462968"
+    }]
+  },
+  {
+  "chrom": "1",
+  "spos": 1312502,
+  "epos": 1312566,
+  "ensgid": "ENSG00000283712",
+  "strand": "-",
+  "gene_version": "1",
+  "gene_symbol": "MIR6727",
+  "gene_biotype": "miRNA",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "hgnc_id": "50171",
+  "name": "microRNA 6727",
+  "entrez_id": "102465435",
+  "refseq_accession": [
+    "NR_106785"
+  ],
+  "marrvel": "MIR6727",
+  "gtex_expression": "ENSG00000283712.1"
+}, {
+  "chrom": "1",
+  "spos": 1331280,
+  "epos": 1335314,
+  "ensgid": "ENSG00000169962",
+  "strand": "+",
+  "gene_version": "5",
+  "gene_symbol": "TAS1R3",
+  "gene_biotype": "protein_coding",
+  "chrom_hg19": "1",
+  "spos_hg19": 1266694,
+  "epos_hg19": 1270686,
+  "strand_hg19": "+",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "gene_summary": "DVL1, the human homolog of the Drosophila dishevelled gene (dsh) encodes a cytoplasmic phosphoprotein that regulates cell proliferation, acting as a transducer molecule for developmental processes, including segmentation and neuroblast specification. DVL1 is a candidate gene for neuroblastomatous transformation. The Schwartz-Jampel syndrome and Charcot-Marie-Tooth disease type 2A have been mapped to the same region as DVL1. The phenotypes of these diseases may be consistent with defects which might be expected from aberrant expression of a DVL gene during development. [provided by RefSeq, Jul 2008].",
+  "hgnc_id": "15661",
+  "name": "taste 1 receptor member 3",
+  "entrez_id": "83756",
+  "ucsc_id": "uc010nyk.3",
+  "refseq_accession": [
+    "NM_152228"
+  ],
+  "ccds_id": [
+    "CCDS30556"
+  ],
+  "uniprot_ids": [
+    "Q7RTX0"
+  ],
+  "mgd_id": [
+    "MGI:1933547"
+  ],
+  "omim_id": [
+    "605865"
+  ],
+  "transcriptid": [
+    {
+      "ensembl_trs": "ENST00000339381",
+      "ensembl_pro": "ENSP00000344411"
+    }
+  ],
+  "biogrid": [
+    "123757"
+  ],
+  "string": [
+    "9606.ENSP00000344411"
+  ],
+  "genecards": "ENSG00000169962",
+  "pharmgkb": [
+    "PA38012"
+  ],
+  "pathway_kegg_id": "hsa04742",
+  "pathway_kegg_full": "Taste transduction",
+  "trait_association_gwas": [
+    "Inflammatory bowel disease",
+    "Ulcerative colitis"
+  ],
+  "trait_association_gwas_pmid": [
+    "28067908",
+    "28067908"
+  ],
+  "rvis_exac": 2.383358179,
+  "rvis_percentile_exac": 99.00006024,
+  "gdi_phred": 4.39394,
+  "gdp": "Medium",
+  "mgi_mouse_gene": "Tas1r3",
+  "mgi_mouse_phenotype": "taste/olfaction phenotype; nervous system phenotype (the observable morphological and physiological characteristics of the extensive, intricate network of electochemical structures in the body that is comprised of the brain, spinal cord, nerves, ganglia and parts of the receptor organs that are manifested through development and lifespan)",
+  "obs_mis": 732,
+  "exp_mis": 571.75,
+  "oe_mis": 1.2803,
+  "obs_syn": 387,
+  "exp_syn": 276.14,
+  "oe_syn": 1.4015,
+  "obs_lof": 34,
+  "exp_lof": 28.932,
+  "oe_lof": 1.1752,
+  "cds_length": 2556,
+  "num_coding_exons": 6,
+  "marrvel": "TAS1R3",
+  "gtex_expression": "ENSG00000169962.4",
+  "brainspan_rnaseq": "ENSG00000169962",
+  "brainatlas_microarray": "TAS1R3"
+}, {
+  "chrom": "1",
+  "spos": 1324756,
+  "epos": 1328896,
+  "ensgid": "ENSG00000224051",
+  "strand": "+",
+  "gene_version": "7",
+  "gene_symbol": "CPTP",
+  "gene_biotype": "protein_coding",
+  "chrom_hg19": "1",
+  "spos_hg19": 1260136,
+  "epos_hg19": 1264277,
+  "strand_hg19": "+",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "hgnc_id": "28116",
+  "name": "ceramide-1-phosphate transfer protein",
+  "entrez_id": "80772",
+  "refseq_accession": [
+    "NM_001029885"
+  ],
+  "ccds_id": [
+    "CCDS30555"
+  ],
+  "uniprot_ids": [
+    "Q5TA50"
+  ],
+  "mgd_id": [
+    "MGI:1933107"
+  ],
+  "omim_id": [
+    "615467"
+  ],
+  "transcriptid": [
+    {
+      "ensembl_trs": "ENST00000343938",
+      "ensembl_pro": "ENSP00000343890"
+    },
+    {
+      "ensembl_trs": "ENST00000488011",
+      "ensembl_pro": "ENSP00000462636"
+    }
+  ],
+  "pdb": [
+    "4K80",
+    "4K84",
+    "4K85",
+    "4K8N",
+    "4KBS",
+    "4KF6"
+  ],
+  "biogrid": [
+    "123305"
+  ],
+  "string": [
+    "9606.ENSP00000343890"
+  ],
+  "genecards": "ENSG00000224051",
+  "pharmgkb": [
+    "PA162389853"
+  ],
+  "trait_association_gwas": [
+    "Inflammatory bowel disease",
+    "Ulcerative colitis"
+  ],
+  "trait_association_gwas_pmid": [
+    "28067908",
+    "28067908"
+  ],
+  "rvis_exac": 1.053077318,
+  "rvis_percentile_exac": 91.75350882,
+  "mgi_mouse_gene": "Cptp",
+  "obs_mis": 158,
+  "exp_mis": 154.74,
+  "oe_mis": 1.0211,
+  "obs_syn": 88,
+  "exp_syn": 76.737,
+  "oe_syn": 1.1468,
+  "obs_lof": 3,
+  "exp_lof": 5.3083,
+  "oe_lof": 0.56516,
+  "cds_length": 642,
+  "num_coding_exons": 2,
+  "marrvel": "CPTP",
+  "s_het": 0.006516495,
+  "gtex_expression": "ENSG00000224051.6",
+  "brainspan_rnaseq": "ENSG00000224051",
+  "brainatlas_microarray": "GLTPD1"
+}, {
+  "chrom": "1",
+  "spos": 1335276,
+  "epos": 1349418,
+  "ensgid": "ENSG00000107404",
+  "strand": "-",
+  "gene_version": "20",
+  "gene_symbol": "DVL1",
+  "gene_biotype": "protein_coding",
+  "chrom_hg19": "1",
+  "spos_hg19": 1270656,
+  "epos_hg19": 1284730,
+  "strand_hg19": "-",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "gene_summary": "DVL1, the human homolog of the Drosophila dishevelled gene (dsh) encodes a cytoplasmic phosphoprotein that regulates cell proliferation, acting as a transducer molecule for developmental processes, including segmentation and neuroblast specification. DVL1 is a candidate gene for neuroblastomatous transformation. The Schwartz-Jampel syndrome and Charcot-Marie-Tooth disease type 2A have been mapped to the same region as DVL1. The phenotypes of these diseases may be consistent with defects which might be expected from aberrant expression of a DVL gene during development. [provided by RefSeq, Jul 2008].",
+  "hgnc_id": "3084",
+  "name": "dishevelled segment polarity protein 1",
+  "entrez_id": "1855",
+  "ucsc_id": "uc002quu.4",
+  "refseq_accession": [
+    "NM_004421"
+  ],
+  "ccds_id": [
+    "CCDS22",
+    "CCDS81252"
+  ],
+  "uniprot_ids": [
+    "O14640"
+  ],
+  "mgd_id": [
+    "MGI:94941"
+  ],
+  "omim_id": [
+    "601365"
+  ],
+  "orphanet": "426034",
+  "transcriptid": [
+    {
+      "ensembl_trs": "ENST00000378888",
+      "ensembl_pro": "ENSP00000368166"
+    },
+    {
+      "ensembl_trs": "ENST00000378891",
+      "ensembl_pro": "ENSP00000368169"
+    },
+    {
+      "ensembl_trs": "ENST00000632445",
+      "ensembl_pro": "ENSP00000488888"
+    },
+    {
+      "ensembl_trs": "ENST00000631679",
+      "ensembl_pro": "ENSP00000488181"
+    },
+    {
+      "ensembl_trs": "ENST00000610709",
+      "ensembl_pro": "ENSP00000480077"
+    }
+  ],
+  "biogrid": [
+    "108188"
+  ],
+  "string": [
+    "9606.ENSP00000368169"
+  ],
+  "genecards": "ENSG00000107404",
+  "pharmgkb": [
+    "PA27540"
+  ],
+  "genereviews": [
+    "DVL1"
+  ],
+  "pathway_kegg_id": "hsa04310;hsa04330;hsa04916;hsa05210;hsa05217",
+  "pathway_kegg_full": "Wnt signaling pathway;Notch signaling pathway;Melanogenesis;Colorectal cancer;Basal cell carcinoma",
+  "trait_association_gwas": [
+    "Inflammatory bowel disease",
+    "Ulcerative colitis"
+  ],
+  "trait_association_gwas_pmid": [
+    "28067908",
+    "28067908"
+  ],
+  "rvis_exac": -0.531325214,
+  "rvis_percentile_exac": 20.4927414,
+  "gdi_phred": 2.46667,
+  "gdp": "Medium",
+  "mgi_mouse_gene": "Dvl1",
+  "mgi_mouse_phenotype": "hearing/vestibular/ear phenotype; nervous system phenotype (the observable morphological and physiological characteristics of the extensive, intricate network of electochemical structures in the body that is comprised of the brain, spinal cord, nerves, ganglia and parts of the receptor organs that are manifested through development and lifespan); skeleton phenotype; embryo phenotype; behavior/neurological phenotype (the observable actions or reactions of mammalian organisms that are manifested through development and lifespan); mortality/aging (the observable characteristics related to the ability of a mammalian organism to live and age that are manifested throughout development and life span); normal phenotype; cardiovascular system phenotype (the observable morphological and physiological characteristics of the mammalian heart, blood vessels, or circulatory system that are manifested through development and lifespan)",
+  "obs_mis": 554,
+  "exp_mis": 484.18,
+  "oe_mis": 1.1442,
+  "obs_syn": 294,
+  "exp_syn": 203.72,
+  "oe_syn": 1.4431,
+  "obs_lof": 14,
+  "exp_lof": 29.868,
+  "oe_lof": 0.46872,
+  "cds_length": 2010,
+  "num_coding_exons": 15,
+  "marrvel": "DVL1",
+  "s_het": 0.03182546,
+  "gtex_expression": "ENSG00000107404.19",
+  "brainspan_microarray": "DVL1",
+  "brainspan_rnaseq": "ENSG00000107404",
+  "brainatlas_microarray": "DVL1"
+}, {
+  "chrom": "1",
+  "spos": 1352689,
+  "epos": 1361777,
+  "ensgid": "ENSG00000162576",
+  "strand": "-",
+  "gene_version": "16",
+  "gene_symbol": "MXRA8",
+  "gene_biotype": "protein_coding",
+  "chrom_hg19": "1",
+  "spos_hg19": 1288069,
+  "epos_hg19": 1297157,
+  "strand_hg19": "-",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "gene_summary": "DVL1, the human homolog of the Drosophila dishevelled gene (dsh) encodes a cytoplasmic phosphoprotein that regulates cell proliferation, acting as a transducer molecule for developmental processes, including segmentation and neuroblast specification. DVL1 is a candidate gene for neuroblastomatous transformation. The Schwartz-Jampel syndrome and Charcot-Marie-Tooth disease type 2A have been mapped to the same region as DVL1. The phenotypes of these diseases may be consistent with defects which might be expected from aberrant expression of a DVL gene during development. [provided by RefSeq, Jul 2008].",
+  "hgnc_id": "7542",
+  "name": "matrix remodeling associated 8",
+  "entrez_id": "54587",
+  "ucsc_id": "uc001aew.5",
+  "refseq_accession": [
+    "NM_032348"
+  ],
+  "ccds_id": [
+    "CCDS24",
+    "CCDS59950",
+    "CCDS59951",
+    "CCDS59952"
+  ],
+  "uniprot_ids": [
+    "Q9BRK3"
+  ],
+  "mgd_id": [
+    "MGI:1922011"
+  ],
+  "omim_id": [
+    "617293"
+  ],
+  "transcriptid": [
+    {
+      "ensembl_trs": "ENST00000309212",
+      "ensembl_pro": "ENSP00000307887"
+    },
+    {
+      "ensembl_trs": "ENST00000342753",
+      "ensembl_pro": "ENSP00000344998"
+    },
+    {
+      "ensembl_trs": "ENST00000445648",
+      "ensembl_pro": "ENSP00000399229"
+    },
+    {
+      "ensembl_trs": "ENST00000477278",
+      "ensembl_pro": "ENSP00000436135"
+    }
+  ],
+  "pdb": [
+    "6JO8"
+  ],
+  "biogrid": [
+    "120064"
+  ],
+  "string": [
+    "9606.ENSP00000399229"
+  ],
+  "genecards": "ENSG00000162576",
+  "pharmgkb": [
+    "PA31343"
+  ],
+  "trait_association_gwas": [
+    "Inflammatory bowel disease",
+    "Ulcerative colitis",
+    "Intraocular pressure"
+  ],
+  "trait_association_gwas_pmid": [
+    "28067908",
+    "28067908",
+    "29617998~29617998"
+  ],
+  "rvis_exac": -0.202191696,
+  "rvis_percentile_exac": 36.75682188,
+  "gdi_phred": 3.87909,
+  "gdp": "Medium",
+  "mgi_mouse_gene": "Mxra8",
+  "mgi_mouse_phenotype": "normal phenotype",
+  "obs_mis": 208,
+  "exp_mis": 255.34,
+  "oe_mis": 0.81461,
+  "obs_syn": 143,
+  "exp_syn": 121.78,
+  "oe_syn": 1.1743,
+  "obs_lof": 13,
+  "exp_lof": 18.29,
+  "oe_lof": 0.71077,
+  "cds_length": 1326,
+  "num_coding_exons": 10,
+  "marrvel": "MXRA8",
+  "s_het": 0.019663958,
+  "gtex_expression": "ENSG00000162576.16",
+  "brainspan_microarray": "MXRA8",
+  "brainspan_rnaseq": "ENSG00000162576",
+  "brainatlas_microarray": "MXRA8"
+}, {
+  "chrom": "1",
+  "spos": 1471765,
+  "epos": 1497848,
+  "ensgid": "ENSG00000160072",
+  "strand": "+",
+  "gene_version": "20",
+  "gene_symbol": "ATAD3B",
+  "gene_biotype": "protein_coding",
+  "chrom_hg19": "1",
+  "spos_hg19": 1407143,
+  "epos_hg19": 1433228,
+  "strand_hg19": "+",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "hgnc_id": "24007",
+  "name": "ATPase family AAA domain containing 3B",
+  "entrez_id": "83858",
+  "ucsc_id": "uc001afv.4",
+  "refseq_accession": [
+    "NM_031921"
+  ],
+  "ccds_id": [
+    "CCDS30"
+  ],
+  "uniprot_ids": [
+    "Q5T9A4"
+  ],
+  "mgd_id": [
+    "MGI:1919214"
+  ],
+  "omim_id": [
+    "612317"
+  ],
+  "transcriptid": [
+    {
+      "ensembl_trs": "ENST00000673477",
+      "ensembl_pro": "ENSP00000500094"
+    },
+    {
+      "ensembl_trs": "ENST00000308647",
+      "ensembl_pro": "ENSP00000311766"
+    }
+  ],
+  "biogrid": [
+    "123774"
+  ],
+  "string": [
+    "9606.ENSP00000311766"
+  ],
+  "genecards": "ENSG00000160072",
+  "pharmgkb": [
+    "PA134993325"
+  ],
+  "trait_association_gwas": [
+    "Body mass index"
+  ],
+  "trait_association_gwas_pmid": [
+    "26426971"
+  ],
+  "rvis_exac": 2.490540243,
+  "rvis_percentile_exac": 99.11451117,
+  "gdi_phred": 16.40046,
+  "gdp": "High",
+  "mgi_mouse_gene": "Atad3a",
+  "mgi_mouse_phenotype": "muscle phenotype; homeostasis/metabolism phenotype; cellular phenotype; growth/size/body region phenotype; skeleton phenotype; embryo phenotype; behavior/neurological phenotype (the observable actions or reactions of mammalian organisms that are manifested through development and lifespan); mortality/aging (the observable characteristics related to the ability of a mammalian organism to live and age that are manifested throughout development and life span)",
+  "obs_mis": 557,
+  "exp_mis": 399.85,
+  "oe_mis": 1.393,
+  "obs_syn": 233,
+  "exp_syn": 174.84,
+  "oe_syn": 1.3327,
+  "obs_lof": 32,
+  "exp_lof": 29.105,
+  "oe_lof": 1.0995,
+  "cds_length": 1944,
+  "num_coding_exons": 16,
+  "marrvel": "ATAD3B",
+  "s_het": 0.007010136,
+  "gtex_expression": "ENSG00000160072.19",
+  "brainspan_rnaseq": "ENSG00000160072",
+  "brainatlas_microarray": "ATAD3B"
+}, {
+  "chrom": "1",
+  "spos": 1512162,
+  "epos": 1534685,
+  "ensgid": "ENSG00000197785",
+  "strand": "+",
+  "gene_version": "14",
+  "gene_symbol": "ATAD3A",
+  "gene_biotype": "protein_coding",
+  "chrom_hg19": "1",
+  "spos_hg19": 1447531,
+  "epos_hg19": 1470067,
+  "strand_hg19": "+",
+  "cytoband": [
+    "1p36.33"
+  ],
+  "gene_summary": "This gene encodes a transmembrane-domain containing protein found in the brain and cerebellum. Mutations in this gene result in spinocerebellar ataxia 21. [provided by RefSeq, Dec 2014].",
+  "hgnc_id": "25567",
+  "name": "ATPase family AAA domain containing 3A",
+  "entrez_id": "55210",
+  "ucsc_id": "uc001aga.3",
+  "refseq_accession": [
+    "NM_018188"
+  ],
+  "ccds_id": [
+    "CCDS31",
+    "CCDS53259",
+    "CCDS53260"
+  ],
+  "uniprot_ids": [
+    "Q9NVI7"
+  ],
+  "mgd_id": [
+    "MGI:1919214"
+  ],
+  "omim_id": [
+    "612316"
+  ],
+  "orphanet": "469968",
+  "transcriptid": [
+    {
+      "ensembl_trs": "ENST00000378755",
+      "ensembl_pro": "ENSP00000368030"
+    },
+    {
+      "ensembl_trs": "ENST00000378756",
+      "ensembl_pro": "ENSP00000368031"
+    },
+    {
+      "ensembl_trs": "ENST00000536055",
+      "ensembl_pro": "ENSP00000439290"
+    },
+    {
+      "ensembl_trs": "ENST00000339113",
+      "ensembl_pro": "ENSP00000339421"
+    },
+    {
+      "ensembl_trs": "ENST00000400830",
+      "ensembl_pro": "ENSP00000383631"
+    }
+  ],
+  "biogrid": [
+    "120506"
+  ],
+  "string": [
+    "9606.ENSP00000368030"
+  ],
+  "genecards": "ENSG00000197785",
+  "pharmgkb": [
+    "PA134872099"
+  ],
+  "trait_association_gwas": [
+    "Body mass index"
+  ],
+  "trait_association_gwas_pmid": [
+    "26426971"
+  ],
+  "rvis_exac": 1.057439959,
+  "rvis_percentile_exac": 91.83784109,
+  "gdi_phred": 7.22185,
+  "gdp": "Medium",
+  "mgi_mouse_gene": "Atad3a",
+  "mgi_mouse_phenotype": "muscle phenotype; homeostasis/metabolism phenotype; cellular phenotype; growth/size/body region phenotype; skeleton phenotype; embryo phenotype; behavior/neurological phenotype (the observable actions or reactions of mammalian organisms that are manifested through development and lifespan); mortality/aging (the observable characteristics related to the ability of a mammalian organism to live and age that are manifested throughout development and life span)",
+  "obs_mis": 401,
+  "exp_mis": 401.71,
+  "oe_mis": 0.99824,
+  "obs_syn": 188,
+  "exp_syn": 171.46,
+  "oe_syn": 1.0965,
+  "obs_lof": 19,
+  "exp_lof": 33.718,
+  "oe_lof": 0.5635,
+  "cds_length": 1902,
+  "num_coding_exons": 16,
+  "marrvel": "ATAD3A",
+  "s_het": 0.022281632,
+  "gtex_expression": "ENSG00000197785.13",
+  "brainspan_microarray": "ATAD3A",
+  "brainspan_rnaseq": "ENSG00000197785",
+  "brainatlas_microarray": "ATAD3A"
 }
 ]

--- a/src/encoded/tests/test_ingestion_listener.py
+++ b/src/encoded/tests/test_ingestion_listener.py
@@ -4,16 +4,17 @@ import time
 import mock
 import datetime
 from uuid import uuid4
-from dcicutils.qa_utils import ignored
+from dcicutils.qa_utils import ignored, notice_pytest_fixtures
 from ..ingestion_listener import IngestionQueueManager, run, IngestionListener
 from ..util import gunzip_content
-from .variant_fixtures import gene_workbook, post_variant_consequence_items  # noqa
+from .variant_fixtures import gene_workbook, post_variant_consequence_items
 
 
 pytestmark = [pytest.mark.working, pytest.mark.ingestion]
 QUEUE_INGESTION_URL = '/queue_ingestion'
 INGESTION_STATUS_URL = '/ingestion_status'
 MOCKED_ENV = 'fourfront-cgapother'
+notice_pytest_fixtures(gene_workbook, post_variant_consequence_items)
 
 
 def wait_for_queue_to_catch_up(n):
@@ -134,8 +135,8 @@ def test_ingestion_listener_should_remain_online(setup_and_teardown_sqs_state):
     assert after > (before + end_delta)
 
 
-def test_ingestion_listener_run(testapp, mocked_vcf_file, gene_workbook, post_variant_consequence_items,
-                                setup_and_teardown_sqs_state):
+def test_ingestion_listener_run(testapp, mocked_vcf_file, gene_workbook, setup_and_teardown_sqs_state,
+                                post_variant_consequence_items):
     """ Tests the 'run' method of ingestion listener, which will pull down and ingest a vcf file
         from the SQS queue.
     """

--- a/src/encoded/tests/test_ingestion_listener.py
+++ b/src/encoded/tests/test_ingestion_listener.py
@@ -159,5 +159,5 @@ def test_ingestion_listener_run(testapp, mocked_vcf_file, gene_workbook, post_va
     #      error occurred.
     with mock.patch('encoded.ingestion_listener.IngestionListener.should_remain_online',
                     new=mocked_should_remain_online):
-        #with pytest.raises(ValueError):
-        run(testapp, _queue_manager=queue_manager)  # expected in this test since the source VCF is malformed
+        with pytest.raises(ValueError):
+            run(testapp, _queue_manager=queue_manager)  # expected in this test since the source VCF is malformed

--- a/src/encoded/tests/test_ingestion_listener.py
+++ b/src/encoded/tests/test_ingestion_listener.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from dcicutils.qa_utils import ignored
 from ..ingestion_listener import IngestionQueueManager, run, IngestionListener
 from ..util import gunzip_content
-from .variant_fixtures import gene_workbook  # noqa
+from .variant_fixtures import gene_workbook, post_variant_consequence_items  # noqa
 
 
 pytestmark = [pytest.mark.working, pytest.mark.ingestion]
@@ -134,7 +134,8 @@ def test_ingestion_listener_should_remain_online(setup_and_teardown_sqs_state):
     assert after > (before + end_delta)
 
 
-def test_ingestion_listener_run(testapp, mocked_vcf_file, gene_workbook, setup_and_teardown_sqs_state):
+def test_ingestion_listener_run(testapp, mocked_vcf_file, gene_workbook, post_variant_consequence_items,
+                                setup_and_teardown_sqs_state):
     """ Tests the 'run' method of ingestion listener, which will pull down and ingest a vcf file
         from the SQS queue.
     """
@@ -158,5 +159,5 @@ def test_ingestion_listener_run(testapp, mocked_vcf_file, gene_workbook, setup_a
     #      error occurred.
     with mock.patch('encoded.ingestion_listener.IngestionListener.should_remain_online',
                     new=mocked_should_remain_online):
-        with pytest.raises(ValueError):
-            run(testapp, _queue_manager=queue_manager)  # expected in this test since the source VCF is malformed
+        #with pytest.raises(ValueError):
+        run(testapp, _queue_manager=queue_manager)  # expected in this test since the source VCF is malformed

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -85,11 +85,12 @@ def build_variant_sample_embedded_list():
         'title': 'Variants',
         'description': 'List of all variants'
     },
-    unique_key='variant.annotation_id')
+    unique_key='variant:annotation_id')
 class Variant(Item):
     """ Variant class """
 
     item_type = 'variant'
+    name_key = 'annotation_id'
     schema = load_schema('encoded:schemas/variant.json')
     embedded_list = build_variant_embedded_list()
 
@@ -119,7 +120,7 @@ class Variant(Item):
         'title': 'Variants (sample)',
         'description': 'List of all variants with sample specific information',
     },
-    unique_key='variant_sample.annotation_id')
+    unique_key='variant_sample:annotation_id')
 class VariantSample(Item):
     """Class for variant samples."""
 

--- a/src/encoded/types/workflow.py
+++ b/src/encoded/types/workflow.py
@@ -11,7 +11,7 @@ import pstats
 from collections import OrderedDict, deque
 from dcicutils.env_utils import CGAP_ENV_WEBDEV, is_stg_or_prd_env, prod_bucket_env
 from inspect import signature
-from pyramid.httpexceptions import HTTPUnprocessableEntity
+from pyramid.httpexceptions import HTTPUnprocessableEntity, HTTPBadRequest
 from pyramid.response import Response
 from pyramid.view import view_config
 from snovault import calculated_property, collection, load_schema, CONNECTION, TYPES
@@ -944,12 +944,12 @@ def pseudo_run(context, request):
     res_decode = res['Payload'].read().decode()
     res_dict = json.loads(res_decode)
 
-    # known to fail and propagate exception
+    # propagate response and error up if encountered
     try:
         arn = res_dict['_tibanna']['response']['executionArn']
     except Exception as e:
-        # XXX: do something
-        raise e
+        raise HTTPBadRequest('Exception encountered getting response from lambda: %s\n'
+                             'Response: %s' % (e, res_dict))
 
     # just loop until we get proper status
     for i in range(100):

--- a/src/encoded/types/workflow.py
+++ b/src/encoded/types/workflow.py
@@ -919,6 +919,7 @@ def validate_input_json(context, request):
              permission='add', validators=[validate_input_json])
 @debug_log
 def pseudo_run(context, request):
+    """ XXX: This needs documentation badly. """
     input_json = request.json
 
     # set env_name for awsem runner in tibanna
@@ -942,7 +943,14 @@ def pseudo_run(context, request):
                             Payload=json.dumps(input_json))
     res_decode = res['Payload'].read().decode()
     res_dict = json.loads(res_decode)
-    arn = res_dict['_tibanna']['response']['executionArn']
+
+    # known to fail and propagate exception
+    try:
+        arn = res_dict['_tibanna']['response']['executionArn']
+    except Exception as e:
+        # XXX: do something
+        raise e
+
     # just loop until we get proper status
     for i in range(100):
         res = aws_lambda.invoke(FunctionName=TIBANNA_WORKFLOW_STATUS_LAMBDA_FUNCTION,


### PR DESCRIPTION
- Fix/stub out issues Sentry pointed out from analyzing our testing that could be done quickly
- The biggest issue was in ingestion listener testing, which has been fixed by adding the relevant genes and denoting annotation_id as a name key on variant.