### PR TITLE
C4-257 Reduce ingestion listener test flakiness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.3.5"
+version = "2.3.6"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -256,11 +256,15 @@ class IngestionQueueManager:
         }
         return formatted['waiting'], formatted['inflight']
 
-    def receive_messages(self):
-        """ Returns an array of messages, if any that are waiting """
+    def receive_messages(self, batch_size=None):
+        """ Returns an array of messages, if any that are waiting
+
+            :param batch_size: an integer number of messages
+            :returns: messages received or [] if no messages were ready to be received
+        """
         response = self.client.receive_message(
             QueueUrl=self.queue_url,
-            MaxNumberOfMessages=self.batch_size
+            MaxNumberOfMessages=self.batch_size if batch_size is None else batch_size
         )
         return response.get('Messages', [])
 

--- a/src/encoded/tests/test_ingestion_listener.py
+++ b/src/encoded/tests/test_ingestion_listener.py
@@ -55,7 +55,14 @@ def test_ingestion_queue_add_and_receive(setup_and_teardown_sqs_state):
         str(uuid4()), str(uuid4())
     ])
     wait_for_queue_to_catch_up(0)
-    msgs = queue_manager.receive_messages()
+    tries, msgs = 5, []
+    while len(msgs) < 2:
+        if tries < 0:
+            break
+        _msgs = queue_manager.receive_messages(batch_size=1)  # should reduce flakiness
+        msgs.extend(_msgs)
+        wait_for_queue_to_catch_up(0)
+        tries -= 1
     assert len(msgs) == 2
 
 

--- a/src/encoded/tests/test_static_page.py
+++ b/src/encoded/tests/test_static_page.py
@@ -66,8 +66,13 @@ def help_page_json_deleted():
 
 @pytest.fixture(scope='module')
 def posted_help_page_section(testapp, help_page_section_json):
-    res = testapp.post_json('/static-sections/', help_page_section_json, status=201)
-    return res.json['@graph'][0]
+    try:
+        res = testapp.post_json('/static-sections/', help_page_section_json, status=201)
+        val = res.json['@graph'][0]
+    except webtest.AppError:
+        res = testapp.get('/' + help_page_section_json['uuid'], status=301).follow()
+        val = res.json
+    return val
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
- Reduce flakiness of `test_ingestion_queue_add_and_receive` by forcing the test to receive in batches of size 1 and allowing retries on the receive.