### PR TITLE
Sentry

### DIFF
--- a/deploy/ini_files/any.ini
+++ b/deploy/ini_files/any.ini
@@ -5,6 +5,7 @@ file_upload_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-files
 file_wfout_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-wfoutput
 blob_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-blobs
 system_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-system
+sentry_dsn = ${SENTRY_DSN}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = ${ES_SERVER}

--- a/deploy/ini_files/cgap.ini
+++ b/deploy/ini_files/cgap.ini
@@ -5,6 +5,7 @@ file_upload_bucket = elasticbeanstalk-fourfront-cgap-files
 file_wfout_bucket = elasticbeanstalk-fourfront-cgap-wfoutput
 blob_bucket = elasticbeanstalk-fourfront-cgap-blobs
 system_bucket = elasticbeanstalk-fourfront-cgap-system
+sentry_dsn = ${SENTRY_DSN}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80

--- a/deploy/ini_files/cgapdev.ini
+++ b/deploy/ini_files/cgapdev.ini
@@ -5,6 +5,7 @@ file_upload_bucket = elasticbeanstalk-fourfront-cgapdev-files
 file_wfout_bucket = elasticbeanstalk-fourfront-cgapdev-wfoutput
 blob_bucket = elasticbeanstalk-fourfront-cgapdev-blobs
 system_bucket = elasticbeanstalk-fourfront-cgapdev-system
+sentry_dsn = ${SENTRY_DSN}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.us-east-1.es.amazonaws.com:80

--- a/deploy/ini_files/cgaptest.ini
+++ b/deploy/ini_files/cgaptest.ini
@@ -5,6 +5,7 @@ file_upload_bucket = elasticbeanstalk-fourfront-cgaptest-files
 file_wfout_bucket = elasticbeanstalk-fourfront-cgaptest-wfoutput
 blob_bucket = elasticbeanstalk-fourfront-cgaptest-blobs
 system_bucket = elasticbeanstalk-fourfront-cgaptest-system
+sentry_dsn = ${SENTRY_DSN}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.us-east-1.es.amazonaws.com:80

--- a/deploy/ini_files/cgapwolf.ini
+++ b/deploy/ini_files/cgapwolf.ini
@@ -5,6 +5,7 @@ file_upload_bucket = elasticbeanstalk-fourfront-cgapwolf-files
 file_wfout_bucket = elasticbeanstalk-fourfront-cgapwolf-wfoutput
 blob_bucket = elasticbeanstalk-fourfront-cgapwolf-blobs
 system_bucket = elasticbeanstalk-fourfront-cgapwolf-system
+sentry_dsn = ${SENTRY_DSN}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.us-east-1.es.amazonaws.com:80

--- a/poetry.lock
+++ b/poetry.lock
@@ -1515,6 +1515,33 @@ botocore = ">=1.12.36,<2.0.0"
 
 [[package]]
 category = "main"
+description = "Python client for Sentry (https://sentry.io)"
+name = "sentry-sdk"
+optional = false
+python-versions = "*"
+version = "0.16.4"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.10.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+pure_eval = ["pure-eval", "executing", "asttokens"]
+pyspark = ["pyspark (>=2.4.4)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+tornado = ["tornado (>=5)"]
+
+[[package]]
+category = "main"
 description = "Simple, fast, extensible JSON encoder/decoder for Python"
 name = "simplejson"
 optional = false
@@ -1848,7 +1875,6 @@ version = "0.12.0"
 [[package]]
 category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
@@ -1907,8 +1933,7 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "50fb2fbfca54afb6d53d50254572349c8f1c0a53db8d11cb0ef7af98c1c185ae"
-lock-version = "1.0"
+content-hash = "d7d2b7b679c3878c384e7f43bca9ab37b8374b5e61b6e6ea67ad85c5cf1055fa"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -2404,6 +2429,7 @@ pycryptodome = [
     {file = "pycryptodome-3.9.8-cp38-cp38-win_amd64.whl", hash = "sha256:55eb61aca2c883db770999f50d091ff7c14016f2769ad7bca3d9b75d1d7c1b68"},
     {file = "pycryptodome-3.9.8-cp39-cp39-manylinux1_i686.whl", hash = "sha256:39ef9fb52d6ec7728fce1f1693cb99d60ce302aeebd59bcedea70ca3203fda60"},
     {file = "pycryptodome-3.9.8-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:de6e1cd75677423ff64712c337521e62e3a7a4fc84caabbd93207752e831a85a"},
+    {file = "pycryptodome-3.9.8.tar.gz", hash = "sha256:0e24171cf01021bc5dc17d6a9d4f33a048f09d62cc3f62541e95ef104588bda4"},
 ]
 pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
@@ -2548,6 +2574,10 @@ rutter = [
 s3transfer = [
     {file = "s3transfer-0.2.1-py2.py3-none-any.whl", hash = "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"},
     {file = "s3transfer-0.2.1.tar.gz", hash = "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d"},
+]
+sentry-sdk = [
+    {file = "sentry-sdk-0.16.4.tar.gz", hash = "sha256:5f3d96ebd1cf758216552c1a0dc2ca1a000af19a4f9b4a3f4c237c7069fde1d4"},
+    {file = "sentry_sdk-0.16.4-py2.py3-none-any.whl", hash = "sha256:ec255a60d58a8ba35439491d2daaf4b3d03283d0dbdec84a6e359a77fc36961a"},
 ]
 simplejson = [
     {file = "simplejson-3.17.0-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:87d349517b572964350cc1adc5a31b493bbcee284505e81637d0174b2758ba17"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.4.4"
+version = "2.4.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -113,6 +113,7 @@ xlwt = "1.2.0"
 "zope.deprecation" = "4.4.0"
 "zope.interface" = "4.6.0"
 "zope.sqlalchemy" = "1.3"
+sentry-sdk = "^0.16.4"
 
 [tool.poetry.dev-dependencies]
 # PyCharm says boto3-stubs contains useful type hints

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -111,6 +111,12 @@ def app_version(config):
     # Fourfront does GA stuff here that makes no sense in CGAP (yet).
 
 
+def init_sentry(dsn):
+    """ Helper function that initializes sentry SDK if a dsn is specified. """
+    if dsn:
+        sentry_sdk.init(dsn, integrations=[PyramidIntegration(), SqlalchemyIntegration()])
+
+
 def main(global_config, **local_config):
     """
     This function returns a Pyramid WSGI application.
@@ -200,14 +206,8 @@ def main(global_config, **local_config):
     # registered.
     config.include('.upgrade')
 
-    # initialize sentry reporting, split into "production" and "testing", do nothing in local/testing
-    current_env = settings.get('env.name', None)
-    if current_env in [CGAP_ENV_WEBPROD]:
-        sentry_sdk.init("https://878c137aa36a4a5bafbb9809d6303deb@o427308.ingest.sentry.io/5389894",
-                        integrations=[PyramidIntegration(), SqlalchemyIntegration()])
-    elif current_env is not None:
-        sentry_sdk.init("https://3e791f3faed748e2911f2fa4a4ac73f2@o427308.ingest.sentry.io/5389896",
-                        integrations=[PyramidIntegration(), SqlalchemyIntegration()])
+    # initialize sentry reporting
+    init_sentry(settings.get('sentry_dsn', None))
 
     app = config.make_wsgi_app()
 


### PR DESCRIPTION
- Enables Sentry SDK on CGAP, distinguishing between production and testing alerts.
- UPDATE: new changes require EB configuration to set `$SENTRY_DSN` for sentry to be initialized.