### PR TITLE
Centralize some shared code related to finding email address of authorized user making a request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.4.7"
+version = "2.4.8"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_util.py
+++ b/src/encoded/tests/test_util.py
@@ -5,9 +5,9 @@ import pytest
 import tempfile
 
 from unittest import mock
-from dcicutils.qa_utils import ControlledTime
+from dcicutils.qa_utils import ControlledTime, ignored
 from ..util import (
-    debuglog, deduplicate_list, gunzip_content, resolve_file_path, ENCODED_ROOT_DIR,
+    debuglog, deduplicate_list, gunzip_content, resolve_file_path, ENCODED_ROOT_DIR, get_trusted_email,
 )
 from .. import util as util_module
 
@@ -231,3 +231,8 @@ def test_debuglog():
             os.remove(filename)
         except Exception:
             pass
+
+
+def test_get_trusted_email():
+    # TODO: This needs unit testing.
+    ignored(get_trusted_email)

--- a/src/encoded/tests/test_util.py
+++ b/src/encoded/tests/test_util.py
@@ -7,7 +7,7 @@ import tempfile
 from unittest import mock
 from dcicutils.qa_utils import ControlledTime
 from ..util import (
-    debuglog, deduplicate_list, gunzip_content, resolve_file_path, ENCODED_ROOT_DIR, generate_fastq_file,
+    debuglog, deduplicate_list, gunzip_content, resolve_file_path, ENCODED_ROOT_DIR,
 )
 from .. import util as util_module
 
@@ -231,7 +231,3 @@ def test_debuglog():
             os.remove(filename)
         except Exception:
             pass
-
-
-# def test_generate_fastq_file():
-#     ... Need test of generate_fastq_file here ...

--- a/src/encoded/types/cohort.py
+++ b/src/encoded/types/cohort.py
@@ -15,7 +15,8 @@ from snovault import (
 from snovault.util import debug_log
 from webtest import TestApp
 from xml.etree.ElementTree import fromstring
-from .base import Item, get_item_or_none
+from .base import Item
+from ..util import get_trusted_email
 
 
 log = structlog.getLogger(__name__)
@@ -115,17 +116,7 @@ def process_pedigree(context, request):
     ped_timestamp = ped_datetime.isoformat() + '+00:00'
     app = get_app(config_uri, 'app')
     # get user email for TestApp authentication
-    email = getattr(request, '_auth0_authenticated', None)
-    if not email:
-        user_uuid = None
-        for principal in request.effective_principals:
-            if principal.startswith('userid.'):
-                user_uuid = principal[7:]
-                break
-        if not user_uuid:
-            raise HTTPUnprocessableEntity('Cohort %s: Must provide authentication' % cohort)
-        user_props = get_item_or_none(request, user_uuid)
-        email = user_props['email']
+    email = get_trusted_email(request, context="Cohort %s" % cohort)
     environ = {'HTTP_ACCEPT': 'application/json', 'REMOTE_USER': email}
     testapp = TestApp(app, environ)
 

--- a/src/encoded/types/family.py
+++ b/src/encoded/types/family.py
@@ -19,6 +19,7 @@ from snovault.util import debug_log
 from webtest import TestApp
 from xml.etree.ElementTree import fromstring
 from .base import Item, get_item_or_none
+from ..util import get_trusted_email
 
 
 log = structlog.getLogger(__name__)
@@ -598,17 +599,7 @@ def process_pedigree(context, request):
     ped_timestamp = ped_datetime.isoformat() + '+00:00'
     app = get_app(config_uri, 'app')
     # get user email for TestApp authentication
-    email = getattr(request, '_auth0_authenticated', None)
-    if not email:
-        user_uuid = None
-        for principal in request.effective_principals:
-            if principal.startswith('userid.'):
-                user_uuid = principal[7:]
-                break
-        if not user_uuid:
-            raise HTTPUnprocessableEntity('Family %s: Must provide authentication' % family_item)
-        user_props = get_item_or_none(request, user_uuid)
-        email = user_props['email']
+    email = get_trusted_email(request, context="Family %s" % family_item)
     environ = {'HTTP_ACCEPT': 'application/json', 'REMOTE_USER': email}
     testapp = TestApp(app, environ)
 

--- a/src/encoded/util.py
+++ b/src/encoded/util.py
@@ -248,7 +248,6 @@ def get_trusted_email(request, context=None, raise_errors=True):
     This will raise HTTPUnprocessableEntity if there's a problem obtaining the mail.
     """
     try:
-        # import pdb;pdb.set_trace()
         context = context or "Requirement"
         email = getattr(request, '_auth0_authenticated', None)
         if not email:


### PR DESCRIPTION
There's a bit of code that's duplicated between `types/cohort.py` and `types/family.py` that I wanted to centralize so that I can maybe use it for other purposes.

Opportunistic:  The code for `generate_fastq_file` was not yet used and is now available via `dcicutils.data_utils.generate_sample_fastq_file`, so I removed it here. That makes the diffs of `utils.py` a little messy because I'm replacing one function with another when they are unrelated because it happens to be the same place in the file. Side-by-side diff will probably clear that up.

Adding @sbreiff  and @KorayKirli  as reviewers since this is code they've touched in the past. But I'm not really changing the functionality, just consolidating, so I don't expect this will upset anything.