### PR TITLE
Fixes to get_jwt (C4-284)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "2.4.12"
+version = "2.4.13"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_authentication.py
+++ b/src/encoded/tests/test_authentication.py
@@ -101,3 +101,6 @@ class TestNamespacedAuthenticationPolicy(unittest.TestCase):
         result = policy.forget(request)
         self.assertEqual(request.session.get('userid'), None)
         self.assertEqual(result, [])
+
+
+# NOTE: Tests of get_jwt are in test_auth0.py


### PR DESCRIPTION
This fixes `get_jwt` in several ways:

* The reported case was that it wasn't finding JWT for `POST` and `PATCH` request methods.
* There was also a bug where if you passed something like `bearer.somejwt` it would be accepted. Basically any character in position 7 was allowed on an assumption it would be space. That seemed wrong.
* It wasn't trimming the resulting JWT for extra spaces (arguably not a bug since this is syntactically disallowed, but since we're expecting a `base64` token, non-visible space is something it would be hard to spot and good not to fuss over.

I added test cases to make sure I was fixing the problems and not breaking anything.