### PR TITLE
Submission post/patch result msgs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.1.2"
+version = "3.1.3"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.1.1"
+version = "3.1.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -817,7 +817,7 @@ def post_and_patch_all_items(virtualapp, json_data_final):
                     no_errors = False
         for itype in final_status:
             if final_status[itype]['posted'] > 0 or final_status[itype]['not posted'] > 0:
-                output.append('{}: {} items posted successfully; {} items not posted'.format(
+                output.append('{}: {} items created (with POST); {} items failed creation'.format(
                     itype, final_status[itype]['posted'], final_status[itype]['not posted']
                 ))
     for k, v in json_data_final['patch'].items():
@@ -843,7 +843,7 @@ def post_and_patch_all_items(virtualapp, json_data_final):
                 output.append(str(e))
                 no_errors = False
         if final_status[k]['patched'] > 0 or final_status[k]['not patched'] > 0:
-            output.append('{}: {} items patched successfully; {} items not patched'.format(
+            output.append('{}: attributes of {} items updated (with PATCH); {} items failed updating'.format(
                 k, final_status[k]['patched'], final_status[k]['not patched']
             ))
     return output, no_errors, files

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import xlrd
 
+from dcicutils.lang_utils import n_of
 from dcicutils.qa_utils import ignored
 from dcicutils.misc_utils import VirtualAppError
 from webtest import AppError
@@ -817,9 +818,9 @@ def post_and_patch_all_items(virtualapp, json_data_final):
                     no_errors = False
         for itype in final_status:
             if final_status[itype]['posted'] > 0 or final_status[itype]['not posted'] > 0:
-                output.append('{}: {} items created (with POST); {} items failed creation'.format(
-                    itype, final_status[itype]['posted'], final_status[itype]['not posted']
-                ))
+                output.append('{}: {} created (with POST); {} failed creation'.format(itype,
+                                      n_of(final_status[itype]['posted'], 'item'),
+                                      n_of(final_status[itype]['not posted'], 'item')))
     for k, v in json_data_final['patch'].items():
         final_status.setdefault(k, {'patched': 0, 'not patched': 0})
         for item_id, patch_data in v.items():
@@ -843,9 +844,10 @@ def post_and_patch_all_items(virtualapp, json_data_final):
                 output.append(str(e))
                 no_errors = False
         if final_status[k]['patched'] > 0 or final_status[k]['not patched'] > 0:
-            output.append('{}: attributes of {} items updated (with PATCH); {} items failed updating'.format(
-                k, final_status[k]['patched'], final_status[k]['not patched']
-            ))
+            output.append('{}: attributes of {} updated (with PATCH);'
+                          ' {} failed updating'.format(
+                                    k, n_of(final_status[k]['patched'], 'item'),
+                                    n_of(final_status[k]['not patched'], 'item')))
     return output, no_errors, files
 
 

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -472,8 +472,8 @@ def test_post_and_patch_all_items(testapp, post_data):
     output, success, file_info = post_and_patch_all_items(testapp, post_data)
     assert success
     for itemtype in post_data['post']:
-        assert '{}: 1 items created (with POST); 0 items failed creation'.format(itemtype) in output
-        assert '{}: attributes of 1 items updated (with PATCH); 0 items failed updating'.format(itemtype) in output
+        assert '{}: 1 item created (with POST); 0 items failed creation'.format(itemtype) in output
+        assert '{}: attributes of 1 item updated (with PATCH); 0 items failed updating'.format(itemtype) in output
 
 def test_post_and_patch_all_items_error(testapp, post_data):
     """
@@ -483,4 +483,4 @@ def test_post_and_patch_all_items_error(testapp, post_data):
     post_data['post']['family'][0]['extra_field'] = 'extra field value'
     output, success, file_info = post_and_patch_all_items(testapp, post_data)
     assert not success
-    assert 'family: 0 items created (with POST); 1 items failed creation' in output
+    assert 'family: 0 items created (with POST); 1 item failed creation' in output

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -15,10 +15,11 @@ from ..submit import (
     get_analysis_types,
     map_fields,
     parse_exception,
+    post_and_patch_all_items,
     row_generator,
     validate_all_items,
     validate_item,
-    xls_to_json,
+    xls_to_json
 )
 
 
@@ -84,6 +85,39 @@ def submission_info3(submission_info2):
     info['individual']['test-proj:indiv3'] = {'samples': ['test-proj:samp3']}
     info['sample']['test-proj:samp3'] = {'workup_type': 'WGS'}
     return info
+
+
+@pytest.fixture
+def post_data(project, institution):
+    return {
+        'post': {
+            'family': [{
+                'aliases': ['test-proj:fam1'],
+                'family_id': 'fam1',
+                'members': ['test-proj:indiv1'],
+                'proband': 'test-proj:indiv1',
+                'project': project['@id'],
+                'institution': institution['@id']
+            }],
+            'individual': [{
+                'aliases': ['test-proj:indiv1'],
+                'individual_id': 'indiv1',
+                'sex': 'F',
+                'samples': ['test-proj:samp1'],
+                'project': project['@id'],
+                'institution': institution['@id']
+            }],
+            'sample': [{
+                'aliases': ['test-proj:samp1'],
+                'workup_type': 'WGS',
+                'specimen_accession': 'samp1',
+                'project': project['@id'],
+                'institution': institution['@id']
+            }]
+        },
+        'patch': {},
+        'aliases': {}
+    }
 
 
 @pytest.fixture
@@ -432,3 +466,21 @@ def test_validate_all_items_errors(testapp, mother, empty_items):
     assert "'test-proj:invalid-project-alias' not found" in errors
     assert "'test-proj:invalid-institution-alias' not found" in errors
     assert mother['aliases'][0] not in errors
+
+
+def test_post_and_patch_all_items(testapp, post_data):
+    output, success, file_info = post_and_patch_all_items(testapp, post_data)
+    assert success
+    for itemtype in post_data['post']:
+        assert '{}: 1 items created (with POST); 0 items failed creation'.format(itemtype) in output
+        assert '{}: attributes of 1 items updated (with PATCH); 0 items failed updating'.format(itemtype) in output
+
+def test_post_and_patch_all_items_error(testapp, post_data):
+    """
+    additional property introduced into 'family' item json  -
+    designed to test appropriate error message produced in 'output' when item fails to post
+    """
+    post_data['post']['family'][0]['extra_field'] = 'extra field value'
+    output, success, file_info = post_and_patch_all_items(testapp, post_data)
+    assert not success
+    assert 'family: 0 items created (with POST); 1 items failed creation' in output


### PR DESCRIPTION
Some output messages were changed to make them more intuitive for users. Sample new output:

```
file_fastq: 4 items created (with POST); 0 items failed creation
sample: 37 items created (with POST); 0 items failed creation
individual: 37 items created (with POST); 0 items failed creation
family: 11 items created (with POST); 0 items failed creation
sample_processing: 11 items created (with POST); 0 items failed creation
report: 11 items created (with POST); 0 items failed creation
case: 37 items created (with POST); 0 items failed creation
file_fastq: attributes of 4 items updated (with PATCH); 0 items failed updating
sample: attributes of 37 items updated (with PATCH); 0 items failed updating
individual: attributes of 37 items updated (with PATCH); 0 items failed updating
family: attributes of 11 items updated (with PATCH); 0 items failed updating
sample_processing: attributes of 11 items updated (with PATCH); 0 items failed updating
report: attributes of 11 items updated (with PATCH); 0 items failed updating
case: attributes of 37 items updated (with PATCH); 0 items failed updating
```

Sample old output: 

```
file_fastq: 4 items posted successfully; 0 items not posted
sample: 37 items posted successfully; 0 items not posted
individual: 37 items posted successfully; 0 items not posted
family: 11 items posted successfully; 0 items not posted
sample_processing: 11 items posted successfully; 0 items not posted
report: 11 items posted successfully; 0 items not posted
case: 37 items posted successfully; 0 items not posted
sample: 3 items patched successfully; 0 items not patched
individual: 37 items patched successfully; 0 items not patched
family: 11 items patched successfully; 0 items not patched
sample_processing: 11 items patched successfully; 0 items not patched
case: 37 items patched successfully; 0 items not patched
```