### PR TITLE
Search fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.1.4"
+version = "3.1.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/search/lucene_builder.py
+++ b/src/encoded/search/lucene_builder.py
@@ -121,10 +121,13 @@ class LuceneBuilder:
                 must_terms = cls.construct_nested_sub_queries(query_field, filters, key='must_terms')
                 must_not_terms = cls.construct_nested_sub_queries(query_field, filters, key='must_not_terms')
 
+                # XXX: BREAKING ES 6 CHANGE
+                # MUST -> MUST_NOT EXISTS does not work?
+                # Have to use EXISTS under MUST_NOT
                 if filters['add_no_value'] is True:  # when searching on 'No Value'
                     should_arr = [must_terms] if must_terms else []
-                    should_arr.append({BOOL: {MUST_NOT: {EXISTS: {FIELD: query_field}}}})  # field=value OR field DNE
-                    must_filters_nested.append((query_field, should_arr))
+                    should_arr.append({BOOL: {MUST: {EXISTS: {FIELD: query_field}}}})  # field=value OR field DNE
+                    must_not_filters_nested.append((query_field, should_arr))
                 elif filters['add_no_value'] is False:  # when not searching on 'No Value'
                     should_arr = [must_terms] if must_terms else []
                     should_arr.append({EXISTS: {FIELD: query_field}})   # field=value OR field EXISTS

--- a/src/encoded/search/search.py
+++ b/src/encoded/search/search.py
@@ -22,7 +22,6 @@ from snovault.elasticsearch.create_mapping import determine_if_is_date_field
 from snovault.util import (
     debug_log,
 )
-from snovault.elasticsearch.indexer_utils import get_namespaced_index
 from snovault.typeinfo import AbstractTypeInfo
 from .lucene_builder import LuceneBuilder
 from .search_utils import (

--- a/src/encoded/search/search.py
+++ b/src/encoded/search/search.py
@@ -91,9 +91,9 @@ class SearchBuilder:
             item_type_snake_case = ''.join(['_' + c.lower() if c.isupper() else c for c in self.doc_types[0]]).lstrip('_')
             mappings = self.request.registry[STORAGE].read.mappings.get()
             if item_type in mappings:  # mappings use snake case but search uses CamelCase
-                return mappings[item_type]
+                return mappings[item_type]['mappings'][item_type]['properties']
             elif item_type_snake_case in mappings:
-                return mappings[item_type_snake_case]
+                return mappings[item_type_snake_case]['mappings'][item_type_snake_case]['properties']
             else:
                 return get_es_mapping(self.es, self.es_index)
         return {}


### PR DESCRIPTION
This PR fixes two issues - the first problem is mapping resolution from the cache does not drill down far enough to correctly resolve nested paths, thus breaking nested searches. The second problem is in ES6 apparently you cannot compute a 'does not exist' query by wrapping the `MUST_NOT` sub-query in a `MUST` parent query. The following query used to work but now does not:
```
{
    "query": {
        "bool": {
            "filter": [{
                "bool": {
                    "must": [{
                        "nested": {
                            "path": "embedded.files",
                            "query": {
                                "bool": {
                                    "must_not": [{
                                        "exists": {
                                            "field": "embedded.files.display_title.raw"
                                        }
                                    }]
                                }
                            }
                        }
                    }, {
                        "nested": {
                            "path": "embedded.cram_files",
                            "query": {
                              "bool": {
                                "must": {
                                  "exists": {
                                    "field": "embedded.cram_files.display_title.raw"
                                }
                                }
                              }
                            }
                        }
                    }]
...
```
To fix this, instead of wrapping the "must not exists" part of the query in the `must` parent query, compute a normal `exists` query under the `must_not` parent query like below:
```
{
  "query": {
    "bool": {
      "filter": [{
        "bool": {
          "must": [{
            "nested": {
              "path": "embedded.cram_files",
              "query": {
                "exists": {
                  "field": "embedded.cram_files.display_title.raw"
                }
              }
            }
          }],
          "must_not": [{
            "nested": {
              "path": "embedded.files",
              "query": {
                "bool": {
                  "must": [{
                    "exists": {
                      "field": "embedded.files.display_title.raw"
                    }
                  }]
                }
              }
            }
          }]
        }
      }]
    }
  }
}
```

This query strategy works as expected. I have scoured the ES documentation and have seen no mention of this change, which is very frustrating but perhaps not surprising.