### PR TITLE
Remove WSGI 'maximum-requests' config

### DIFF
--- a/.ebextensions/05_set_wsgi.config
+++ b/.ebextensions/05_set_wsgi.config
@@ -141,8 +141,9 @@ files:
       # - might want to add "request-timeout", though it would interfere with long running requests
       # - "queue-timeout" should not occur since Apache servers match total WSGI threads. Set to value of Apache Timeout
       # - maybe use "restart-interval" than "maximum-requests", but handle long requests
+      # - N.B. testing removing 'restart-interval' altogether -berg [2020-09-24]
 
-      WSGIDaemonProcess wsgi processes=5 threads=4 display-name='%{GROUP}' python-path=/opt/python/current/app:/opt/python/run/venv/lib64/python3.6/site-packages:/opt/python/run/venv/lib/python3.6/site-packages user=wsgi group=wsgi home=/opt/python/current/app graceful-timeout=30 deadlock-timeout=60 queue-timeout=62 maximum-requests=1000
+      WSGIDaemonProcess wsgi processes=5 threads=4 display-name='%{GROUP}' python-path=/opt/python/current/app:/opt/python/run/venv/lib64/python3.6/site-packages:/opt/python/run/venv/lib/python3.6/site-packages user=wsgi group=wsgi home=/opt/python/current/app graceful-timeout=30 deadlock-timeout=60 queue-timeout=62
       WSGIProcessGroup wsgi
       </VirtualHost>
       '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.1.4"
+version = "3.1.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This will stop the servers from restarting every X requests (in this case,
1000). This will have memory usage implications we should understand more fully
before deploying this change, or something similar to production.