### PR TITLE
C4-318 Fix nested searches on sub-nested fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.1.8"
+version = "3.1.9"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/search/search.py
+++ b/src/encoded/search/search.py
@@ -1068,7 +1068,6 @@ class SearchBuilder:
         """
         self._build_query()
         es_results = self.execute_search()
-        import pdb; pdb.set_trace()
         self.format_results(es_results)
         return self.get_response()
 

--- a/src/encoded/search/search.py
+++ b/src/encoded/search/search.py
@@ -1068,6 +1068,7 @@ class SearchBuilder:
         """
         self._build_query()
         es_results = self.execute_search()
+        import pdb; pdb.set_trace()
         self.format_results(es_results)
         return self.get_response()
 

--- a/src/encoded/search/search_utils.py
+++ b/src/encoded/search/search_utils.py
@@ -100,6 +100,7 @@ def find_nested_path(field, es_mapping):
     :return: path for nested query or None
     """
     location = es_mapping
+    possible_nested_paths = []
     path = []
     for cursor in field.split('.'):
         if cursor == 'raw':  # if we get to this point we're definitely at a leaf and should stop
@@ -112,9 +113,10 @@ def find_nested_path(field, es_mapping):
             break
         location = location[cursor]
         path.append(cursor)
-        if location.get('type', None) == 'nested':
-            return '.'.join(path)
-    return None
+        if location.get('type', None) == 'nested':  # this could be a path
+            possible_nested_paths.append('.'.join(path))
+    # the last path added is the closest in proximity to the field and thus is correct
+    return possible_nested_paths[-1] if len(possible_nested_paths) > 0 else None
 
 
 def is_schema_field(field):

--- a/src/encoded/search/search_utils.py
+++ b/src/encoded/search/search_utils.py
@@ -110,13 +110,13 @@ def find_nested_path(field, es_mapping):
                 return None
             location = location['properties']  # else move location forward, but do not add it to the PATH
         if cursor not in location:  # if we still don't see our 'level', we are not a nested field
-            break
+            break   # accumulated path will be discarded (not added to possible_nested_paths)
         location = location[cursor]
         path.append(cursor)
         if location.get('type', None) == 'nested':  # this could be a path
             possible_nested_paths.append('.'.join(path))
     # the last path added is the closest in proximity to the field and thus is correct
-    return possible_nested_paths[-1] if len(possible_nested_paths) > 0 else None
+    return possible_nested_paths[-1] if possible_nested_paths else None
 
 
 def is_schema_field(field):

--- a/src/encoded/tests/data/sample_processing_mapping.json
+++ b/src/encoded/tests/data/sample_processing_mapping.json
@@ -1,0 +1,2134 @@
+{
+  "sample_processing" : {
+    "mappings" : {
+      "sample_processing" : {
+        "dynamic_templates" : [
+          {
+            "template_principals_allowed" : {
+              "path_match" : "principals_allowed.*",
+              "mapping" : {
+                "ignore_above" : 512,
+                "index" : true,
+                "type" : "keyword"
+              }
+            }
+          },
+          {
+            "template_unique_keys" : {
+              "path_match" : "unique_keys.*",
+              "mapping" : {
+                "ignore_above" : 512,
+                "index" : true,
+                "type" : "keyword"
+              }
+            }
+          },
+          {
+            "template_links" : {
+              "path_match" : "links.*",
+              "mapping" : {
+                "ignore_above" : 512,
+                "index" : true,
+                "type" : "keyword"
+              }
+            }
+          }
+        ],
+        "properties" : {
+          "aggregated_items" : {
+            "type" : "object"
+          },
+          "embedded" : {
+            "dynamic" : "false",
+            "properties" : {
+              "@id" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "@type" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "aliases" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "analysis_type" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "cases" : {
+                "type" : "nested",
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "completed_processes" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "date_created" : {
+                "type" : "date",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "format" : "date_optional_time"
+              },
+              "display_title" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "families" : {
+                "type" : "nested",
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "institution" : {
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "last_modified" : {
+                "properties" : {
+                  "date_modified" : {
+                    "type" : "date",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "format" : "date_optional_time"
+                  },
+                  "modified_by" : {
+                    "properties" : {
+                      "@id" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "@type" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "display_title" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "principals_allowed" : {
+                        "properties" : {
+                          "edit" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          },
+                          "view" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          }
+                        }
+                      },
+                      "uuid" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "principals_allowed" : {
+                "properties" : {
+                  "edit" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "view" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "processed_files" : {
+                "type" : "nested",
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "accession" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "project" : {
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "sample_processed_files" : {
+                "type" : "nested",
+                "properties" : {
+                  "processed_files" : {
+                    "type" : "nested",
+                    "properties" : {
+                      "@id" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "@type" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "display_title" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "principals_allowed" : {
+                        "properties" : {
+                          "edit" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          },
+                          "view" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          }
+                        }
+                      },
+                      "uuid" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "sample" : {
+                    "properties" : {
+                      "@id" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "@type" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "display_title" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "principals_allowed" : {
+                        "properties" : {
+                          "edit" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          },
+                          "view" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          }
+                        }
+                      },
+                      "uuid" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "samples" : {
+                "type" : "nested",
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "completed_processes" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "processed_files" : {
+                    "type" : "nested",
+                    "properties" : {
+                      "@id" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "@type" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "display_title" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "principals_allowed" : {
+                        "properties" : {
+                          "edit" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          },
+                          "view" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          }
+                        }
+                      },
+                      "uuid" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "samples_pedigree" : {
+                "type" : "nested",
+                "properties" : {
+                  "association" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "individual" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "parents" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "relationship" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "sample_accession" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "sample_name" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "sex" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "schema_version" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "static_content" : {
+                "type" : "nested",
+                "properties" : {
+                  "content" : {
+                    "properties" : {
+                      "@id" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "@type" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "content" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "display_title" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "principals_allowed" : {
+                        "properties" : {
+                          "edit" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          },
+                          "view" : {
+                            "type" : "text",
+                            "fields" : {
+                              "lower_case_sort" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512,
+                                "normalizer" : "case_insensitive"
+                              },
+                              "raw" : {
+                                "type" : "keyword",
+                                "ignore_above" : 512
+                              }
+                            },
+                            "copy_to" : [
+                              "full_text"
+                            ]
+                          }
+                        }
+                      },
+                      "uuid" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "description" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "location" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "static_headers" : {
+                "type" : "nested",
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "status" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              },
+              "submitted_by" : {
+                "properties" : {
+                  "@id" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "@type" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "display_title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  },
+                  "principals_allowed" : {
+                    "properties" : {
+                      "edit" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      },
+                      "view" : {
+                        "type" : "text",
+                        "fields" : {
+                          "lower_case_sort" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512,
+                            "normalizer" : "case_insensitive"
+                          },
+                          "raw" : {
+                            "type" : "keyword",
+                            "ignore_above" : 512
+                          }
+                        },
+                        "copy_to" : [
+                          "full_text"
+                        ]
+                      }
+                    }
+                  },
+                  "uuid" : {
+                    "type" : "text",
+                    "fields" : {
+                      "lower_case_sort" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512,
+                        "normalizer" : "case_insensitive"
+                      },
+                      "raw" : {
+                        "type" : "keyword",
+                        "ignore_above" : 512
+                      }
+                    },
+                    "copy_to" : [
+                      "full_text"
+                    ]
+                  }
+                }
+              },
+              "uuid" : {
+                "type" : "text",
+                "fields" : {
+                  "lower_case_sort" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512,
+                    "normalizer" : "case_insensitive"
+                  },
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                },
+                "copy_to" : [
+                  "full_text"
+                ]
+              }
+            }
+          },
+          "full_text" : {
+            "type" : "text",
+            "analyzer" : "snovault_index_analyzer",
+            "search_analyzer" : "snovault_search_analyzer"
+          },
+          "indexing_stats" : {
+            "properties" : {
+              "aggregated_items" : {
+                "type" : "float"
+              },
+              "embedded_view" : {
+                "type" : "float"
+              },
+              "object_view" : {
+                "type" : "float"
+              },
+              "paths" : {
+                "type" : "float"
+              },
+              "rev_links" : {
+                "type" : "float"
+              },
+              "total_indexing_view" : {
+                "type" : "float"
+              },
+              "unique_keys" : {
+                "type" : "float"
+              },
+              "upgrade_properties" : {
+                "type" : "float"
+              },
+              "validation" : {
+                "type" : "float"
+              }
+            }
+          },
+          "item_type" : {
+            "type" : "keyword",
+            "copy_to" : [
+              "full_text"
+            ],
+            "ignore_above" : 512
+          },
+          "linked_uuids_embedded" : {
+            "properties" : {
+              "sid" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "uuid" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              }
+            }
+          },
+          "linked_uuids_object" : {
+            "properties" : {
+              "sid" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "uuid" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              }
+            }
+          },
+          "links" : {
+            "properties" : {
+              "families" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "institution" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "last_modified~modified_by" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "processed_files" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "project" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "samples" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "submitted_by" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              }
+            }
+          },
+          "max_sid" : {
+            "type" : "keyword",
+            "ignore_above" : 512
+          },
+          "object" : {
+            "type" : "object",
+            "enabled" : false
+          },
+          "paths" : {
+            "type" : "keyword",
+            "ignore_above" : 512
+          },
+          "principals_allowed" : {
+            "properties" : {
+              "edit" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "view" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              }
+            }
+          },
+          "properties" : {
+            "type" : "object",
+            "enabled" : false
+          },
+          "propsheets" : {
+            "type" : "object",
+            "enabled" : false
+          },
+          "rev_link_names" : {
+            "properties" : {
+              "case" : {
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword",
+                    "ignore_above" : 256
+                  }
+                }
+              },
+              "name" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              },
+              "uuids" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              }
+            }
+          },
+          "rev_linked_to_me" : {
+            "type" : "keyword",
+            "ignore_above" : 512
+          },
+          "sid" : {
+            "type" : "keyword",
+            "ignore_above" : 512
+          },
+          "unique_keys" : {
+            "properties" : {
+              "alias" : {
+                "type" : "keyword",
+                "ignore_above" : 512
+              }
+            }
+          },
+          "uuid" : {
+            "type" : "keyword",
+            "ignore_above" : 512
+          },
+          "validation_errors" : {
+            "properties" : {
+              "description" : {
+                "type" : "text",
+                "fields" : {
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                }
+              },
+              "location" : {
+                "type" : "text",
+                "fields" : {
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                }
+              },
+              "name" : {
+                "type" : "text",
+                "fields" : {
+                  "raw" : {
+                    "type" : "keyword",
+                    "ignore_above" : 512
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -634,6 +634,8 @@ def sample_processing_mapping():
     ('embedded.date_created', None),
     ('embedded.cases', 'embedded.cases'),  # not meaningful but should still work
     ('embedded.cases.@id', 'embedded.cases'),
+    ('embedded.cases.principals_allowed.edit', 'embedded.cases'),
+    ('embedded.families.display_title', 'embedded.families'),
     ('embedded.samples.processed_files.display_title', 'embedded.samples.processed_files')
 ])
 def test_find_nested_path(sample_processing_mapping, field, nested_path):


### PR DESCRIPTION
- `find_nested_path` returns the closest _top level_ nested field when we need the closest nested field to the source field. The former approximation works when you only search on top level nested fields, but fails when searching on sub-nested fields. 
- Augment the algorithm to keep track of all possible nested paths until it has drilled down as far as it can go - the last path seen is the closest in proximity to the nested field we are searching on.
- Add some tests to ensure the above is working.