### PR TITLE
Sample types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.1.10"
+version = "3.1.11"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/sample.json
+++ b/src/encoded/schemas/sample.json
@@ -43,7 +43,9 @@
             "label": "specimen",
             "lookup": 20,
             "suggested_enum": [
-                "blood",
+                "peripheral blood",
+                "cord blood",
+                "plasma",
                 "saliva"
             ]
         },

--- a/src/encoded/tests/data/demo_inserts/sample.json
+++ b/src/encoded/tests/data/demo_inserts/sample.json
@@ -45,7 +45,7 @@
                 "value": "A201"
             }
         ],
-        "specimen_type": "blood",
+        "specimen_type": "peripheral blood",
         "date_transported": "2019-03-07",
         "sequence_id": "BAE2201",
         "other_specimen_ids": [
@@ -101,7 +101,7 @@
                 "value": "A202"
             }
         ],
-        "specimen_type": "blood",
+        "specimen_type": "peripheral blood",
         "date_transported": "2019-03-07",
         "sequence_id": "BAE2202",
         "other_specimen_ids": [
@@ -157,7 +157,7 @@
                 "value": "A203"
             }
         ],
-        "specimen_type": "blood",
+        "specimen_type": "peripheral blood",
         "date_transported": "2019-03-07",
         "sequence_id": "BAE2203",
         "other_specimen_ids": [

--- a/src/encoded/tests/data/inserts/sample.json
+++ b/src/encoded/tests/data/inserts/sample.json
@@ -26,7 +26,7 @@
         "status": "released",
         "uuid": "a4b98709-25fe-48a4-afde-8f886b57abc9",
         "workup_type": "WGS",
-        "specimen_type": "blood",
+        "specimen_type": "peripheral blood",
         "requisition_type": "BioBank",
         "date_requisition_received": "2020-01-01",
         "indication": "cervical cancer",

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -31,7 +31,7 @@ def row_dict():
         'analysis id': '999',
         'report required': 'Y',
         'specimen id': '3464467',
-        'specimen type': 'blood',
+        'specimen type': 'saliva',
         'workup type': 'WGS'
     }
 

--- a/src/encoded/tests/test_types_sample.py
+++ b/src/encoded/tests/test_types_sample.py
@@ -27,7 +27,7 @@ def sample_one(project, institution):
     return {
         'project': project['@id'],
         'institution': institution['@id'],
-        'specimen_type': 'blood',
+        'specimen_type': 'peripheral blood',
         'date_received': '2018-12-1'
     }
 
@@ -38,16 +38,6 @@ def sample_two(project, institution):
         'project': project['@id'],
         'institution': institution['@id'],
         'specimen_type': 'saliva',
-        'date_received': '2015-12-7'
-    }
-
-
-@pytest.fixture
-def sample_invalid_specimen_type(project, institution, MIndividual):
-    return {
-        'project': project['@id'],
-        'institution': institution['@id'],
-        'specimen_type': 'skin',
         'date_received': '2015-12-7'
     }
 
@@ -67,16 +57,14 @@ def test_post_valid_samples(testapp, sample_one, sample_two):
     testapp.post_json('/sample', sample_two, status=201)
 
 
-def test_post_invalid_samples(testapp, sample_invalid_specimen_type, sample_no_project):
+def test_post_invalid_samples(testapp, sample_no_project):
     testapp.post_json('/sample', sample_no_project, status=422)
-    # testapp.post_json('/sample', sample_invalid_specimen_type, status=422)
 
 
 def test_post_valid_patch_error(testapp, sample_one):
     res = testapp.post_json('/sample', sample_one, status=201).json['@graph'][0]
     testapp.patch_json(res['@id'], {'date_received': '12-3-2003'}, status=422)
     testapp.patch_json(res['@id'], {'project': 'does_not_exist'}, status=422)
-    # testapp.patch_json(res['@id'], {'specimen_type': 'hair'}, status=422)
 
 
 def test_sample_individual_revlink(testapp, sample_one, MIndividual):


### PR DESCRIPTION
Suggested enum for `specimen_type` property in Sample schema changed from `["blood", "saliva"]` to 
`["peripheral blood", "cord blood", "plasma", "saliva"]`.

Inserts and tests edited accordingly.