### PR TITLE
C4-325 Fix deploy

### DIFF
--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -51,7 +51,7 @@ container_commands:
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
   0698_remove_extra_files:
-    command: "rm /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth && rm -rf /opt/python/run/venv/lib/python3.6/site-packages/encoded-3.2.0.dist-info"
+    command: "rm /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth && rm -rf /opt/python/run/venv/lib/python3.6/site-packages/encoded-[0-9]*.dist-info"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -40,8 +40,6 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate"
   0420_still_more_debugging_info:
     command: "source /opt/python/run/venv/bin/activate && echo $PATH"
-  0470_install_wheel:
-    command: "pip install wheel==0.29.0"
   0480_npm_tmp_perms:
     command: "chown -R ec2-user /tmp"
   0490_app_bundle_perms:
@@ -51,9 +49,11 @@ container_commands:
   0600_generate_production_ini:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
   0695_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze"
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c "import sys; print('\n'.join(sys.path))""
+  0696_pip_install_encoded:
+    command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop"
   0697_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze"
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c "import sys; print('\n'.join(sys.path))""
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -49,11 +49,11 @@ container_commands:
   0600_generate_production_ini:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
   0695_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print(sys.path)'"
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && ls -lah /opt/python/run/venv/lib/python3.6/site-packages/"
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
   0697_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print(sys.path)'"
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && ls -lah /opt/python/run/venv/lib/python3.6/site-packages/"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -48,12 +48,8 @@ container_commands:
     command: "cat /dev/urandom | head -c 256 | base64 > session-secret.b64"
   0600_generate_production_ini:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
-  0695_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && ls -lah /opt/python/run/venv/lib/python3.6/site-packages/"
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
-  0697_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && ls -lah /opt/python/run/venv/lib/python3.6/site-packages/ && cat /opt/python/run/venv/lib/python3.6/site-packages/encoded.egg-link && cat /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth"
   0698_remove_extra_files:
     command: "rm /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth && rm -rf /opt/python/run/venv/lib/python3.6/site-packages/encoded-3.2.0.dist-info"
   0700_clear_db_es_contents:

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -40,6 +40,8 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate"
   0420_still_more_debugging_info:
     command: "source /opt/python/run/venv/bin/activate && echo $PATH"
+  0470_install_wheel:
+    command: "pip install wheel==0.29.0"
   0480_npm_tmp_perms:
     command: "chown -R ec2-user /tmp"
   0490_app_bundle_perms:

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -49,11 +49,11 @@ container_commands:
   0600_generate_production_ini:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
   0695_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c "import sys; print('\n'.join(sys.path))""
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print('\n'.join(sys.path))'"
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
   0697_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c "import sys; print('\n'.join(sys.path))""
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print('\n'.join(sys.path))'"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -16,7 +16,7 @@ container_commands:
     command: "curl --silent --location https://rpm.nodesource.com/setup_10.x | sudo bash - && yum install nodejs -y && node --version >> /var/log/deploy.log"
   0100_setup_wsgi_home:
     command: "mkdir -p /home/wsgi && chown wsgi:wsgi /home/wsgi"
-  0190_mostly_ugprade_pip:
+  0190_mostly_ugprade_pip:  # 20.0.1 version known to work
     command: "source /opt/python/run/venv/bin/activate && pip install --upgrade pip==20.0.1 >> /var/log/deploy.log"
   0191_check_pip_version_anew:
     command: "source /opt/python/run/venv/bin/activate && pip --version"
@@ -31,7 +31,7 @@ container_commands:
   0218_uninstall_setuptools:
     command: "source /opt/python/run/venv/bin/activate && pip uninstall -y setuptools"
   0219_install_setuptools:
-    command: "source /opt/python/run/venv/bin/activate && pip install setuptools==44.1.1"
+    command: "source /opt/python/run/venv/bin/activate && pip install setuptools==44.1.1"  # known to work
   0220_populate_venv:
     command: "source /opt/python/run/venv/bin/activate && poetry install"
   0221_get_aws_ips:
@@ -50,7 +50,7 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
-  0698_remove_extra_files:
+  0698_remove_extra_files:  # XXX: This is required as of 10/1/2020 to remove files that mess up the install -Will
     command: "rm /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth && rm -rf /opt/python/run/venv/lib/python3.6/site-packages/encoded-[0-9]*.dist-info"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -17,7 +17,7 @@ container_commands:
   0100_setup_wsgi_home:
     command: "mkdir -p /home/wsgi && chown wsgi:wsgi /home/wsgi"
   0190_mostly_ugprade_pip:
-    command: "source /opt/python/run/venv/bin/activate && pip install --upgrade pip==20.0.0 >> /var/log/deploy.log"
+    command: "source /opt/python/run/venv/bin/activate && pip install --upgrade pip==20.0.1 >> /var/log/deploy.log"
   0191_check_pip_version_anew:
     command: "source /opt/python/run/venv/bin/activate && pip --version"
   0200_install_poetry:

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -40,8 +40,6 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate"
   0420_still_more_debugging_info:
     command: "source /opt/python/run/venv/bin/activate && echo $PATH"
-  0470_install_wheel:
-    command: "pip install wheel"
   0480_npm_tmp_perms:
     command: "chown -R ec2-user /tmp"
   0490_app_bundle_perms:
@@ -52,6 +50,10 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop"
+  0697_check_pip_state:
+    command: "source /opt/python/run/venv/bin/activate && pip freeze"
+  0698_sleep:
+    command: "sleep 120"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -52,8 +52,8 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop"
   0697_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze"
-  0698_symlink:
-    command: "ln -s src/encoded encoded"
+  0698_manual_e:
+    command: "source /opt/python/run/venv/bin/activate && pip install -e ."
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -31,7 +31,7 @@ container_commands:
   0218_uninstall_setuptools:
     command: "source /opt/python/run/venv/bin/activate && pip uninstall -y setuptools"
   0219_install_setuptools:
-    command: "source /opt/python/run/venv/bin/activate && pip install setuptools"
+    command: "source /opt/python/run/venv/bin/activate && pip install setuptools==44.1.1"
   0220_populate_venv:
     command: "source /opt/python/run/venv/bin/activate && poetry install"
   0221_get_aws_ips:
@@ -48,12 +48,12 @@ container_commands:
     command: "cat /dev/urandom | head -c 256 | base64 > session-secret.b64"
   0600_generate_production_ini:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
+  0695_check_pip_state:
+    command: "source /opt/python/run/venv/bin/activate && pip freeze"
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop"
   0697_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze"
-  0698_manual_e:
-    command: "source /opt/python/run/venv/bin/activate && pip install -e ."
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -51,7 +51,7 @@ container_commands:
   0695_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c "import sys; print('\n'.join(sys.path))""
   0696_pip_install_encoded:
-    command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop"
+    command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
   0697_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c "import sys; print('\n'.join(sys.path))""
   0700_clear_db_es_contents:

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -54,6 +54,8 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
   0697_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze && ls -lah /opt/python/run/venv/lib/python3.6/site-packages/ && cat /opt/python/run/venv/lib/python3.6/site-packages/encoded.egg-link && cat /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth"
+  0698_remove_extra_files:
+    command: "rm /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth && rm -rf /opt/python/run/venv/lib/python3.6/site-packages/encoded-3.2.0.dist-info"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -50,8 +50,6 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
   0695_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze"
-  0696_pip_install_encoded:
-    command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop"
   0697_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze"
   0700_clear_db_es_contents:

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -49,11 +49,11 @@ container_commands:
   0600_generate_production_ini:
     command: "source /opt/python/run/venv/bin/activate && python deploy/generate_production_ini.py"
   0695_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print('\n'.join(sys.path))'"
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print(sys.path)'"
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
   0697_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print('\n'.join(sys.path))'"
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && python -c 'import sys; print(sys.path)'"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -53,7 +53,7 @@ container_commands:
   0696_pip_install_encoded:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop --verbose"
   0697_check_pip_state:
-    command: "source /opt/python/run/venv/bin/activate && pip freeze && ls -lah /opt/python/run/venv/lib/python3.6/site-packages/"
+    command: "source /opt/python/run/venv/bin/activate && pip freeze && ls -lah /opt/python/run/venv/lib/python3.6/site-packages/ && cat /opt/python/run/venv/lib/python3.6/site-packages/encoded.egg-link && cat /opt/python/run/venv/lib/python3.6/site-packages/encoded.pth"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -17,7 +17,7 @@ container_commands:
   0100_setup_wsgi_home:
     command: "mkdir -p /home/wsgi && chown wsgi:wsgi /home/wsgi"
   0190_mostly_ugprade_pip:
-    command: "source /opt/python/run/venv/bin/activate && pip install --upgrade pip >> /var/log/deploy.log"
+    command: "source /opt/python/run/venv/bin/activate && pip install --upgrade pip==20.0.0 >> /var/log/deploy.log"
   0191_check_pip_version_anew:
     command: "source /opt/python/run/venv/bin/activate && pip --version"
   0200_install_poetry:

--- a/.ebextensions/20_packages.config
+++ b/.ebextensions/20_packages.config
@@ -52,8 +52,8 @@ container_commands:
     command: "source /opt/python/run/venv/bin/activate && python setup_eb.py develop"
   0697_check_pip_state:
     command: "source /opt/python/run/venv/bin/activate && pip freeze"
-  0698_sleep:
-    command: "sleep 120"
+  0698_symlink:
+    command: "ln -s src/encoded encoded"
   0700_clear_db_es_contents:
     command: "source /opt/python/run/venv/bin/activate && clear-db-es-contents production.ini --app-name app --skip-es --env fourfront-cgapdev >> /var/log/deploy.log"
     leader_only: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.2.0"
+version = "3.2.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- On 10/1 a change was introduced to EB that triggered our setup_eb.py script to generate an extra directory and .pth file breaking the deployment
- Fix this by removing these files with `0698_remove_extra_files`
- Also pins pip and setuptools versions