### PR TITLE
Bundle custom logs with beanstalk

### DIFF
--- a/.ebextensions/11_logs.config
+++ b/.ebextensions/11_logs.config
@@ -1,4 +1,16 @@
 files:
+    "/opt/elasticbeanstalk/tasks/bundlelogs.d/deploy.conf" :
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            /var/log/deploy.log
+    "/opt/elasticbeanstalk/tasks/bundlelogs.d/create_mapping.conf" :
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            /var/log/create_mapping.log
     "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.httpd.conf":
         mode: "000644"
         owner: root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.2.3"
+version = "3.2.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This allows the custom logs deploy.log and custom_mappings.log to appear along with the default Beanstalk logs. It'll make debugging Beanstalk errors easier.