### PR TITLE
Robots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.3.0"
+version = "3.3.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/inheritance_mode.py
+++ b/src/encoded/inheritance_mode.py
@@ -347,7 +347,7 @@ class InheritanceMode:
             cmphet = variant_sample.get("cmphet")
             novoPP = variant_sample.get("novoPP", -1)
         except Exception as e:
-            log.error('Was not able to extract inheritance modes - the required fields do not exist!'
+            log.info('Was not able to extract inheritance modes - the required fields do not exist!'
                       '\n%s\n%s\n%s' % (sample_geno, variant_sample, e))
             return {}
 

--- a/src/encoded/static/robots.txt
+++ b/src/encoded/static/robots.txt
@@ -6,3 +6,9 @@ Disallow: /*@@download
 Disallow: /profiles/
 Disallow: /*@@download*
 Disallow: /cgi-bin/
+User-agent: SemrushBot
+Disallow: /
+User-agent: AhrefsBot
+Disallow: /
+User-agent: PetalBot
+Disallow: /


### PR DESCRIPTION
- Disable some specific bots we've found to be problematic on FF
- Change error log in inheritance mode computation to an info log as it is spamming sentry when we ingest variant samples without inheritance mode information