### PR TITLE
Update ingestion statuses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "3.3.1"
+version = "3.3.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -546,6 +546,10 @@ class IngestionListener:
                 debuglog("Deleted messages")
                 break
 
+    def set_status(self, uuid, status):
+        """ Sets the file_ingestion_status of the given uuid """
+        self.vapp.patch_json('/' + uuid, {'file_ingestion_status': status})
+
     @staticmethod
     def build_variant_link(variant):
         """ This function takes a variant record and returns the corresponding UUID of this variant
@@ -748,7 +752,7 @@ class IngestionListener:
 
                 # gunzip content, pass to parser, post variants/variant_samples
                 # patch in progress status
-                self.vapp.patch_json('/' + uuid, {'file_ingestion_status': STATUS_IN_PROGRESS})
+                self.set_status(uuid, STATUS_IN_PROGRESS)
                 decoded_content = gunzip_content(raw_content)
                 log.info('Got decoded content: %s' % decoded_content[:20])
                 parser = VCFParser(None, VARIANT_SCHEMA, VARIANT_SAMPLE_SCHEMA,
@@ -759,9 +763,9 @@ class IngestionListener:
                 if error > 0:
                     log.error('Some VCF rows for uuid %s failed to post - not marking VCF '
                               'as ingested.' % uuid)
-                    self.vapp.patch_json('/' + uuid, {'file_ingestion_status': STATUS_ERROR})
+                    self.set_status(uuid, STATUS_ERROR)
                 else:
-                    self.vapp.patch_json('/' + uuid, {'file_ingestion_status': STATUS_INGESTED})
+                    self.set_status(uuid, STATUS_INGESTED)
 
                 # report results in error_log regardless of status
                 msg = ('INGESTION_REPORT:\n'

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -47,6 +47,7 @@ STATUS_QUEUED = 'Queued'
 STATUS_INGESTED = 'Ingested'
 STATUS_DISABLED = 'Ingestion disabled'
 STATUS_ERROR = 'Error'
+STATUS_IN_PROGRESS = 'In progress'
 CGAP_CORE_PROJECT = '/projects/cgap-core'
 CGAP_CORE_INSTITUTION = '/institutions/hms-dbmi/'
 
@@ -746,6 +747,8 @@ class IngestionListener:
                     continue
 
                 # gunzip content, pass to parser, post variants/variant_samples
+                # patch in progress status
+                self.vapp.patch_json('/' + uuid, {'file_ingestion_status': STATUS_IN_PROGRESS})
                 decoded_content = gunzip_content(raw_content)
                 log.info('Got decoded content: %s' % decoded_content[:20])
                 parser = VCFParser(None, VARIANT_SCHEMA, VARIANT_SAMPLE_SCHEMA,

--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -56,7 +56,8 @@
                 "Waiting",
                 "Queued",
                 "Ingested",
-                "Ingestion disabled"
+                "Ingestion disabled",
+                "Error"
             ]
         },
         "file_classification": {

--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -55,6 +55,7 @@
                 "N/A",
                 "Waiting",
                 "Queued",
+                "In progress",
                 "Ingested",
                 "Ingestion disabled",
                 "Error"


### PR DESCRIPTION
- Adds `In progress` to `file_ingestion_status`, patching in the ingester just before it downloads the processed file (ie: in current setup, a single processed file (at most) should be `In progress` when items are being generated from it)
- Adds `Error` to `file_ingestion_status`, patching in the ingester if an error occurred, otherwise `Ingested` status will be patched
- Add a log statement to debug intermediary PATCH on queueing, which doesn't seem to be working