### PR TITLE
C4-320 Default variant/gene status to 'shared'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "4.0.0"
+version = "4.0.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/ingest_genes.py
+++ b/src/encoded/commands/ingest_genes.py
@@ -49,6 +49,7 @@ class GeneIngestion(object):
         else:
             _iter = self.genes_to_ingest
         for gene in _iter:
+            gene['status'] = 'shared'  # default gene status to shared, so visible to everyone
             if project:
                 gene['project'] = project
             if institution:

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -50,6 +50,7 @@ STATUS_ERROR = 'Error'
 STATUS_IN_PROGRESS = 'In progress'
 CGAP_CORE_PROJECT = '/projects/cgap-core'
 CGAP_CORE_INSTITUTION = '/institutions/hms-dbmi/'
+SHARED = 'shared'
 
 
 def includeme(config):
@@ -577,6 +578,7 @@ class IngestionListener:
         variant = parser.create_variant_from_record(record)
         variant['project'] = project
         variant['institution'] = institution
+        variant['status'] = SHARED  # default variant status to shared, so visible to everyone
         parser.format_variant_sub_embedded_objects(variant)
         try:
             self.vapp.post_json('/variant', variant, status=201)


### PR DESCRIPTION
- Variants posted through the ingestion listener will now have status `shared`
- Genes ingested through the script will now have status `shared`
- NOTE: variants ingested directly through scripts will not have `shared` status