### PR TITLE
Project status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "4.1.2"
+version = "4.1.3"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/institution.json
+++ b/src/encoded/schemas/institution.json
@@ -21,12 +21,14 @@
         "status": {
             "title": "Status",
             "type": "string",
-            "default": "current",
             "permission": "restricted_fields",
+            "default": "shared",
             "enum": [
+                "shared",
                 "current",
-                "obsolete",
+                "revoked",
                 "deleted",
+                "replaced",
                 "inactive"
             ]
         },

--- a/src/encoded/schemas/institution.json
+++ b/src/encoded/schemas/institution.json
@@ -12,6 +12,7 @@
         { "$ref": "mixins.json#/aliases" },
         { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/modified" },
+        { "$ref": "mixins.json#/status" },
         { "$ref": "mixins.json#/static_embeds" }
     ],
     "properties": {
@@ -19,18 +20,7 @@
             "default": "1"
         },
         "status": {
-            "title": "Status",
-            "type": "string",
-            "permission": "restricted_fields",
-            "default": "shared",
-            "enum": [
-                "shared",
-                "current",
-                "revoked",
-                "deleted",
-                "replaced",
-                "inactive"
-            ]
+            "default": "shared"
         },
         "name": {
             "title": "Name",

--- a/src/encoded/schemas/project.json
+++ b/src/encoded/schemas/project.json
@@ -12,6 +12,7 @@
         { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/modified" },
         { "$ref": "mixins.json#/tags" },
+        { "$ref": "mixins.json#/status" },
         { "$ref": "mixins.json#/static_embeds" }
     ],
     "type": "object",
@@ -20,18 +21,7 @@
             "default": "1"
         },
         "status": {
-            "title": "Status",
-            "type": "string",
-            "default": "shared",
-            "permission": "restricted_fields",
-            "enum": [
-                "shared",
-                "current",
-                "revoked",
-                "deleted",
-                "replaced",
-                "inactive"
-            ]
+            "default": "shared"
         },
         "name": {
             "title": "Name",

--- a/src/encoded/schemas/project.json
+++ b/src/encoded/schemas/project.json
@@ -11,7 +11,6 @@
         { "$ref": "mixins.json#/aliases" },
         { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/modified" },
-        { "$ref": "mixins.json#/status" },
         { "$ref": "mixins.json#/tags" },
         { "$ref": "mixins.json#/static_embeds" }
     ],
@@ -23,9 +22,10 @@
         "status": {
             "title": "Status",
             "type": "string",
-            "default": "current",
+            "default": "shared",
             "permission": "restricted_fields",
             "enum": [
+                "shared",
                 "current",
                 "revoked",
                 "deleted",


### PR DESCRIPTION
There was a bug with project view permissions, where users couldn't view the project they were on when it was "current" and status couldn't be changed to "shared".

"shared" now allowed for project and institution status, and is the default status when they are created.