### PR TITLE
Fix Small Ingestion Listener Bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "4.1.3"
+version = "4.1.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -313,7 +313,7 @@ class IngestionQueueManager:
         self.queue_attrs = {
             self.queue_name: {
                 'DelaySeconds': '1',  # messages initially invisible for 1 sec
-                'VisibilityTimeout': '600',  # 10 mins
+                'VisibilityTimeout': '10800',  # 3 hours
                 'MessageRetentionPeriod': '604800',  # 7 days, in seconds
                 'ReceiveMessageWaitTimeSeconds': '5',  # 5 seconds of long polling
             }
@@ -781,7 +781,7 @@ class IngestionListener:
                     log.error('Some VCF rows for uuid %s failed to post - not marking VCF '
                               'as ingested.' % uuid)
                     self.set_status(uuid, STATUS_ERROR)
-                    self.set_error(uuid, self.first_error_message)
+                    self.set_error(uuid)
                 else:
                     self.set_status(uuid, STATUS_INGESTED)
 


### PR DESCRIPTION
- Fixes 2 small issues with the Ingestion Listener
- First is incorrect function call args to `set_error`. Very unhappy that PyCharm did not catch that when this change went in, it had no problem highlighting it now.
- Second is upping visibility timeout of messages to 3 hours as it could reasonably take some time to ingest a VCF and we don't want to re-queue if we don't have to