### PR TITLE
Upd status proj

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "4.2.3"
+version = "4.2.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "4.2.4"
+version = "4.2.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/data/master-inserts/institution.json
+++ b/src/encoded/tests/data/master-inserts/institution.json
@@ -52,5 +52,12 @@
         "contact_persons": [
             "dvuzman@research.bwh.harvard.edu"
         ]
+    },
+    {
+        "name": "msa-coalition",
+        "title": "Multiple System Atrophy Coalition",
+        "aliases": ["msa:msa-institution"],
+        "date_created": "2020-11-03T22:19:15.807261+00:00",
+        "uuid": "232539d0-41aa-4cdc-835d-7f164f1462ea"
     }
 ]

--- a/src/encoded/tests/data/master-inserts/project.json
+++ b/src/encoded/tests/data/master-inserts/project.json
@@ -3,7 +3,6 @@
         "title": "CGAP Core",
         "uuid": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
         "description": "Core Project for all items that are in general use",
-        "status": "current",
         "name": "hms-dbmi",
         "date_created": "2020-07-15T02:26:28.509115+00:00"
     },
@@ -11,9 +10,16 @@
         "title": "Brigham Genomic Medicine",
         "uuid": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
         "pi": "986b362f-4eb6-4a9c-8173-3acba722bba1",
-        "status": "current",
         "name": "brigham-genomic-medicine",
         "aliases": ["hms-dbmi:BGM"],
         "date_created": "2020-07-21T17:19:17.058289+00:00"
+    },
+    {
+        "name": "multiple-system-atrophy",
+        "title": "Multiple System Atrophy",
+        "aliases": ["hms-dbmi:msa"],
+        "description": "Project for the Multiple System Atrophy Coalition's cases",
+        "date_created": "2020-10-27T20:08:55.654261+00:00",
+        "uuid": "a97a4781-75aa-436d-baca-829335263cdf"
     }
 ]


### PR DESCRIPTION
Removed status property from project master inserts so that the default 'shared' will be used allowing view permission for logged in users.

Added MSA project and MSA institution to master inserts.