### PR TITLE
fix cannot read property 'apply' of null bug

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -170,6 +170,7 @@ export default class App extends React.PureComponent {
 
         // Save navigate fxn and other req'd stuffs to GLOBAL navigate obj.
         // So that we may call it from anywhere if necessary without passing through props.
+        navigate.initializeFromApp(this);
         navigate.setNavigateFunction(this.navigate);
         navigate.registerCallbackFunction(Alerts.updateCurrentAlertsTitleMap.bind(this, null));
 

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -171,7 +171,6 @@ export default class App extends React.PureComponent {
         // Save navigate fxn and other req'd stuffs to GLOBAL navigate obj.
         // So that we may call it from anywhere if necessary without passing through props.
         navigate.initializeFromApp(this);
-        navigate.setNavigateFunction(this.navigate);
         navigate.registerCallbackFunction(Alerts.updateCurrentAlertsTitleMap.bind(this, null));
 
         if (context.schemas) Schemas.set(context.schemas);


### PR DESCRIPTION
Started having [issues with embedded search views](https://gyazo.com/28908ee252732a815e8245c68bdea559) after pulling in new master on CGAP. Traced it back to [this method](https://github.com/4dn-dcic/shared-portal-components/pull/50/files) in SPC.

```
Uncaught TypeError: Cannot read property 'apply' of null
    at Function.navigate.updateUserInfo (navigate.js:97)
    at onLoadResponse (VirtualHrefController.js:235)
    at XMLHttpRequest.xhr.onreadystatechange (ajax.js:110)
```

Thanks to Utku for helping me figure out a better long-term solution to this bug