### PR TITLE
C4-407 Ingestion Listener Error Reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "4.4.0"
+version = "4.5.0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -63,7 +63,7 @@ numpy = "1.19.1" # negspy needs it
 passlib = "1.6.5"
 PasteDeploy = "1.5.2"
 pbkdf2 = "1.3"
-Pillow = "^6.2.2"  # 6.x.x should work for CGAP -Will 11/18/2020 
+Pillow = "^6.2.2"  # 6.x.x should work for CGAP -Will 11/18/2020
 plaster = "1.0"
 plaster-pastedeploy = "0.6"
 psutil = "^5.6.6"

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -335,6 +335,7 @@ class IngestionReport:
     Not creating an item for this is a design decision. The output of this process is more for
     debugging and not for auditing, so it does not merit an item at this time.
     """
+    MAX_ERRORS = 100  # tune this to get more errors, 100 is a lot though and probably more than needed
 
     def __init__(self):
         self.total = 0
@@ -353,7 +354,7 @@ class IngestionReport:
         return len(self.errors)
 
     def get_errors(self):
-        return self.errors
+        return self.errors[:self.MAX_ERRORS]
 
     def mark_success(self):
         """ Marks the current row number as successful, which in this case just involves incrementing the total """

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -324,7 +324,7 @@ class IngestionError:
 
     def to_dict(self):
         return {
-            'body': self.body,
+            'body': str(self.body),
             'row': self.row
         }
 
@@ -706,7 +706,7 @@ class IngestionListener:
                 add_last_modified(variant, userid=LOADXL_USER_UUID)
                 self.vapp.post_json('/variant_sample', sample, status=201)
             except Exception as e:
-                log.error('Encountered exception posting variant_sample: %s' % e)
+                debuglog('Encountered exception posting variant_sample: %s' % e)
                 raise  # propagate/report if error occurs here
 
     def search_for_sample_relations(self, vcf_file_accession):
@@ -762,7 +762,7 @@ class IngestionListener:
                                                     sample_relations)
                 self.ingestion_report.mark_success()
             except Exception as e:  # ANNOTATION spec validation error, recoverable
-                log.error('Encountered exception posting variant at row %s: %s ' % (idx, e))
+                debuglog('Encountered exception posting variant at row %s: %s ' % (idx, e))
                 self.ingestion_report.mark_failure(body=str(e), row=idx)
 
         return self.ingestion_report.total_successful(), self.ingestion_report.total_error()
@@ -849,7 +849,7 @@ class IngestionListener:
                 # patch in progress status
                 self.set_status(uuid, STATUS_IN_PROGRESS)
                 decoded_content = gunzip_content(raw_content)
-                log.info('Got decoded content: %s' % decoded_content[:20])
+                debuglog('Got decoded content: %s' % decoded_content[:20])
                 parser = VCFParser(None, VARIANT_SCHEMA, VARIANT_SAMPLE_SCHEMA,
                                    reader=Reader(fsock=decoded_content.split('\n')))
                 success, error = self.post_variants_and_variant_samples(parser, file_meta)

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -353,8 +353,13 @@ class IngestionReport:
     def total_error(self):
         return len(self.errors)
 
-    def get_errors(self):
-        return self.errors[:self.MAX_ERRORS]
+    def get_errors(self, limit=True):
+        """Returns a limited number of errors, where limit can be True (self.MAX_ERRORS), False (no limit), or an integer."""
+        if limit is True:
+            limit = self.MAX_ERRORS
+        elif limit is False:
+            limit = None
+        return self.errors[:limit]
 
     def mark_success(self):
         """ Marks the current row number as successful, which in this case just involves incrementing the total """

--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -64,7 +64,20 @@
         "file_ingestion_error": {
             "title": "Ingestion Error Report",
             "description": "This field is set when an error occurred in ingestion with the first error encountered",
-            "type": "string"
+            "type": "array",
+            "items": {
+                "title": "Ingestion Error",
+                "type": "object",
+                "properties": {
+                    "body": {
+                        "type": "string",
+                        "index": false
+                    },
+                    "row": {
+                        "type": "integer"
+                    }
+                }
+            }
         },
         "file_classification": {
             "title": "General Classification",

--- a/src/encoded/tests/test_ingestion_listener.py
+++ b/src/encoded/tests/test_ingestion_listener.py
@@ -8,7 +8,8 @@ import time
 from dcicutils.qa_utils import ignored, notice_pytest_fixtures
 from uuid import uuid4
 from pyramid.testing import DummyRequest
-from ..ingestion_listener import IngestionQueueManager, run, IngestionListener, verify_vcf_file_status_is_not_ingested
+from ..ingestion_listener import (IngestionQueueManager, run, IngestionListener,
+                                  verify_vcf_file_status_is_not_ingested, IngestionError, IngestionReport)
 from ..util import gunzip_content
 from .variant_fixtures import gene_workbook, post_variant_consequence_items
 from .workbook_fixtures import workbook, app
@@ -250,3 +251,27 @@ def test_test_port():
 
     from snovault.tests.test_postgresql_fixture import SNOVAULT_DB_TEST_PORT
     assert SNOVAULT_DB_TEST_PORT == 5440
+
+
+@pytest.mark.parametrize('body, row', [
+    ({'foo': 'bar'}, 1),
+    ('Success', 2)
+])
+def test_ingestion_error_basic(body, row):
+    """ Tests basic functionality of the error class """
+    test_error = IngestionError(body, row)
+    test_error_dict = test_error.to_dict()
+    assert test_error_dict['body'] == body
+    assert test_error_dict['row'] == row
+
+
+@pytest.mark.parametrize('success', [5, 10])
+def test_ingestion_report_basic(success):
+    """ Tests basic functionality of the Report class, which is just a collection of errors """
+    report = IngestionReport()
+    for _ in range(success):
+        report.mark_success()
+    report.mark_failure(body={'hello': 'world'}, row=1)
+    assert report.total == success + 1
+    assert report.total_successful() == success
+    assert report.total_error() == 1

--- a/src/encoded/tests/test_ingestion_listener.py
+++ b/src/encoded/tests/test_ingestion_listener.py
@@ -2,15 +2,15 @@ import datetime
 import json
 import mock
 import pytest
-import requests   # XXX: C4-211 this should NOT be necessary - there is a bug somewhere
 import time
 
 from dcicutils.qa_utils import ignored, notice_pytest_fixtures
 from uuid import uuid4
 from pyramid.testing import DummyRequest
-from ..ingestion_listener import (IngestionQueueManager, run, IngestionListener,
-                                  verify_vcf_file_status_is_not_ingested, IngestionError, IngestionReport)
-from ..util import gunzip_content
+from ..ingestion_listener import (
+    IngestionQueueManager, run, IngestionListener, verify_vcf_file_status_is_not_ingested,
+    IngestionError, IngestionReport,
+)
 from .variant_fixtures import gene_workbook, post_variant_consequence_items
 from .workbook_fixtures import workbook, app
 
@@ -272,6 +272,6 @@ def test_ingestion_report_basic(success):
     for _ in range(success):
         report.mark_success()
     report.mark_failure(body={'hello': 'world'}, row=1)
-    assert report.total == success + 1
+    assert report.grand_total == success + 1
     assert report.total_successful() == success
-    assert report.total_error() == 1
+    assert report.total_errors() == 1

--- a/src/encoded/tests/test_ingestion_listener.py
+++ b/src/encoded/tests/test_ingestion_listener.py
@@ -261,7 +261,7 @@ def test_ingestion_error_basic(body, row):
     """ Tests basic functionality of the error class """
     test_error = IngestionError(body, row)
     test_error_dict = test_error.to_dict()
-    assert test_error_dict['body'] == body
+    assert test_error_dict['body'] == str(body)
     assert test_error_dict['row'] == row
 
 


### PR DESCRIPTION
- Updates the ingestion listener to provide more details when errors occur by patching the first 100 responses and associated rows to the `file_ingestion_error` field on `file_processed`.
- Sentry will now receive a (better) summary log message and verbose logging has been reduced.
- Some (very simple) unit tests on the error structure, which is very straightforward