### PR TITLE
C4-501 C4-404 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "4.6.3"
+version = "4.6.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/authorization.py
+++ b/src/encoded/authorization.py
@@ -69,3 +69,10 @@ def groupfinder(login, request):
     groups = user_properties.get('groups', [])
     principals.extend('group.%s' % group for group in groups)
     return principals
+
+
+def is_admin_request(request):
+    """ Checks for 'group.admin' in effective_principals on request - if present we know this
+        request was submitted by an admin
+    """
+    return 'group.admin' in request.effective_principals

--- a/src/encoded/search/lucene_builder.py
+++ b/src/encoded/search/lucene_builder.py
@@ -666,7 +666,10 @@ class LuceneBuilder:
 
     @classmethod
     def _check_and_remove_nested(cls, facet_filters, active_filter, query_field, filter_type):
-        """ Helper function for _remove_from_active_filters that handles filter removal for nested query """
+        """ Helper function for _remove_from_active_filters that handles filter removal for nested query
+            Reminder that this code is responsible for constructing the aggregation filter, hence the desire
+            to omit selections on the field we are aggregating on.
+        """
         nested_sub_query = active_filter[NESTED][QUERY]
 
         # For No value searches
@@ -700,8 +703,9 @@ class LuceneBuilder:
                                                                         active_filter,
                                                                         query_field, filter_type)
                         else:
-                            search_log(log_handler=log, msg='Encountered a unexpected nested structure at second level:'
-                                                            ' %s' % nested_sub_query[BOOL])
+                            search_log(log_handler=log,
+                                       msg=('Encountered a unexpected nested structure at second level: %s'
+                                            % nested_sub_query[BOOL]))
 
                     # For structure like this:
                     #   {'bool': {'must': {'bool': {'should':

--- a/src/encoded/search/search.py
+++ b/src/encoded/search/search.py
@@ -124,7 +124,7 @@ class SearchBuilder:
         self.search_frame = self.request.normalized_params.get('frame', self.DEFAULT_SEARCH_FRAME)  # embedded
         self.prepared_terms = self.prepare_search_term(self.request)
         self.additional_facets = self.request.normalized_params.getall(self.ADDITIONAL_FACETS)
-        self.debug_is_active = self.request.normalized_params.getall(self.DEBUG)
+        self.debug_is_active = self.request.normalized_params.getall(self.DEBUG)  # only used if admin
 
         # Can potentially make an outside API call, but ideally is cached
         # Only needed if searching on a single item type

--- a/src/encoded/search/search_utils.py
+++ b/src/encoded/search/search_utils.py
@@ -47,7 +47,7 @@ COMMON_EXCLUDED_URI_PARAMS = [
     # Difference of this and URL params should result in all fields/filters.
     'frame', 'format', 'limit', 'sort', 'from', 'field',
     'mode', 'redirected_from', 'datastore', 'referrer',
-    'currentAction', 'additional_facet'
+    'currentAction', 'additional_facet', 'debug'
 ]
 MAX_FACET_COUNTS = 100
 RAW_FIELD_AGGREGATIONS = [

--- a/src/encoded/tests/test_authorization.py
+++ b/src/encoded/tests/test_authorization.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+from .test_search import MockedRequest
+from ..authorization import is_admin_request
+
+
+pytestmark = [pytest.mark.working]
+
+
+@pytest.mark.parametrize('mock_request, expected', [
+    [MockedRequest(), False],
+    [MockedRequest(principals_allowed=[
+        'group.admin'
+    ]), True],
+    [MockedRequest(principals_allowed=[
+        'lots', 'of', 'other', 'perms', 'but', 'not', 'group', 'dot', 'admin'
+    ]), False]
+])
+def test_authorization_is_admin_request(mock_request, expected):
+    """ Checks that the request tests correctly resolve. """
+    assert is_admin_request(mock_request) is expected

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -621,6 +621,18 @@ def test_search_with_principals_allowed_fails(workbook, anon_es_testapp):
                         '&principals_allowed.view=group.PERMISSION_YOU_DONT_HAVE')
 
 
+def test_search_debug_parameter(workbook, es_testapp, anon_es_testapp):
+    """ Tests that utilizing the query debug parameter works correctly with admin only. """
+    resp_with_debug = es_testapp.get('/search/?type=Family&debug=true', status=200).json
+    assert 'query' in resp_with_debug
+    # no results should still show query
+    resp_with_debug = es_testapp.get('/search/?type=Gene&debug=true', status=404).json
+    assert 'query' in resp_with_debug
+    # no results, no admin, no query
+    resp_without_debug = anon_es_testapp.get('/search/?type=Family&debug=true', status=404).json
+    assert 'query' not in resp_without_debug
+
+
 @pytest.fixture
 def sample_processing_mapping():
     return load_schema('encoded:tests/data/sample_processing_mapping.json')

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -621,15 +621,21 @@ def test_search_with_principals_allowed_fails(workbook, anon_es_testapp):
                         '&principals_allowed.view=group.PERMISSION_YOU_DONT_HAVE')
 
 
-def test_search_debug_parameter(workbook, es_testapp, anon_es_testapp):
+def test_search_debug_parameter(workbook, es_testapp, anon_es_testapp, authenticated_es_testapp):
     """ Tests that utilizing the query debug parameter works correctly with admin only. """
     resp_with_debug = es_testapp.get('/search/?type=Family&debug=true', status=200).json
     assert 'query' in resp_with_debug
     # no results should still show query
     resp_with_debug = es_testapp.get('/search/?type=Gene&debug=true', status=404).json
     assert 'query' in resp_with_debug
+    # doesn't matter what you pass
+    resp_with_debug = es_testapp.get('/search/?type=Gene&debug=blah', status=404).json
+    assert 'query' in resp_with_debug
     # no results, no admin, no query
     resp_without_debug = anon_es_testapp.get('/search/?type=Family&debug=true', status=404).json
+    assert 'query' not in resp_without_debug
+    # authenticated but no admin, no query
+    resp_without_debug = authenticated_es_testapp.get('/search/?type=Family&debug=true', status=200).json
     assert 'query' not in resp_without_debug
 
 
@@ -844,6 +850,12 @@ class TestNestedSearch(object):
         # selecting a facet in search does not affect the cardinality of the aggregation on that facet (alone)
         facets_that_should_show_all_options = es_testapp.get(
             '/search/?type=Variant&hg19.hg19_hgvsg=NC_000001.11:g.12185956del').follow().json['facets']
+        self.verify_facet(facets_that_should_show_all_options, 'hg19.hg19_hgvsg', 3)  # still 3 options
+
+        # selecting two facets has the same behavior
+        facets_that_should_show_all_options = es_testapp.get(
+            '/search/?type=Variant&hg19.hg19_hgvsg=NC_000001.11:g.12185956del'
+            '&hg19.hg19_hgvsg=NC_000001.11:g.11780388G>A').follow().json['facets']
         self.verify_facet(facets_that_should_show_all_options, 'hg19.hg19_hgvsg', 3)  # still 3 options
 
         # selecting a different facet can affect the aggregation if it just so happens to eliminate


### PR DESCRIPTION
- Addresses C4-501 by handling another possible query structure for nested aggregations
- Addresses C4-404 by adding an (admin only) search debug parameter. If `debug=<anything>` is passed to the search, the API will add the final query passed to ES to the response under the field `query` if the source user is an admin.