### PR TITLE
GlitchFix for #pedigree tab, sortByAge, bg color

### DIFF
--- a/src/encoded/static/components/item-pages/CaseView/PedigreeTabViewBody.js
+++ b/src/encoded/static/components/item-pages/CaseView/PedigreeTabViewBody.js
@@ -215,17 +215,24 @@ export class PedigreeTabViewBody extends React.PureComponent {
             console.error("Expected `dataset` or `graphData` to be present");
         }
 
+        let body = null;
+
+        if (!PedigreeVizLibrary) {
+            body = (
+                <div className="py-3 d-flex align-items-center justify-content-center">
+                    Loading...
+                </div>
+            );
+        } else if (graphData) {
+            body = <PedigreeVizView {...pedigreeVizProps} {...graphData} />;
+        } else if (dataset) {
+            body = <PedigreeViz {...pedigreeVizProps} dataset={dataset} />;
+        }
+
         return (
             <div id={containerId} className={cls}>
                 <FullHeightCalculator {...{ windowWidth, windowHeight, propName, heightDiff }}>
-                    { !PedigreeVizLibrary ? "Loading..."
-                        : (graphData ?
-                            // If already have parsed graph data
-                            <PedigreeVizView {...pedigreeVizProps} {...graphData} />
-                            :
-                            // If letting PedigreeViz parse on the fly (this mostly for local demo/test data)
-                            <PedigreeViz {...pedigreeVizProps} dataset={dataset} />
-                        )}
+                    { body }
                 </FullHeightCalculator>
             </div>
         );

--- a/src/encoded/static/components/item-pages/CaseView/PedigreeTabViewBody.js
+++ b/src/encoded/static/components/item-pages/CaseView/PedigreeTabViewBody.js
@@ -219,13 +219,15 @@ export class PedigreeTabViewBody extends React.PureComponent {
 
         if (!PedigreeVizLibrary) {
             body = (
-                <div className="py-3 d-flex align-items-center justify-content-center">
+                <div className="py-3 text-center">
                     Loading...
                 </div>
             );
         } else if (graphData) {
+            // If already have parsed graph data
             body = <PedigreeVizView {...pedigreeVizProps} {...graphData} />;
         } else if (dataset) {
+            // If letting PedigreeViz parse on the fly (this mostly for local demo/test data)
             body = <PedigreeViz {...pedigreeVizProps} dataset={dataset} />;
         }
 
@@ -237,5 +239,4 @@ export class PedigreeTabViewBody extends React.PureComponent {
             </div>
         );
     }
-
 }

--- a/src/encoded/static/components/item-pages/components/FullHeightCalculator.js
+++ b/src/encoded/static/components/item-pages/components/FullHeightCalculator.js
@@ -52,4 +52,3 @@ export const FullHeightCalculator = React.memo(function FullHeightCalculator({
         return React.cloneElement(child, { [propName]: height });
     });
 });
-

--- a/src/encoded/static/components/item-pages/components/FullHeightCalculator.js
+++ b/src/encoded/static/components/item-pages/components/FullHeightCalculator.js
@@ -48,6 +48,7 @@ export const FullHeightCalculator = React.memo(function FullHeightCalculator({
     const height = Math.max(windowHeight - surroundingComponentsHeight, minHeight);
 
     return React.Children.map(children, function(child){
+        if (!React.isValidElement(child)) return child;
         return React.cloneElement(child, { [propName]: height });
     });
 });

--- a/src/encoded/static/components/viz/PedigreeViz/data-utilities.js
+++ b/src/encoded/static/components/viz/PedigreeViz/data-utilities.js
@@ -172,8 +172,8 @@ export function standardizeObjectsInList(jsonList){
 
 /** Oldest first */
 export function sortByAge(a, b){
-    if (a.isProband) return -1;
-    if (b.isProband) return 1;
+    // if (a.isProband) return -1;
+    // if (b.isProband) return 1;
     if (isNaN(b.age) && !isNaN(a.age)) return -1;
     if (isNaN(a.age) && !isNaN(b.age)) return 1;
     if (isNaN(a.age) && isNaN(b.age)) return 0;

--- a/src/encoded/static/scss/encoded/modules/_pedigree-visualization.scss
+++ b/src/encoded/static/scss/encoded/modules/_pedigree-visualization.scss
@@ -1,4 +1,5 @@
-$pedigree-viz-bg-color: #ffffff !default;
+$pedigree-viz-bg-color: #f8f8f8 !default;
+$pedigree-viz-node-bg-color: #fff !default;
 $pedigree-viz-node-stroke-color: #444 !default;
 
 
@@ -316,7 +317,7 @@ svg.pedigree-viz-shapes-layer.shapes-layer {
 
             .bg-shape-copy {
                 stroke-width: 0px;
-                fill: $pedigree-viz-bg-color;
+                fill: $pedigree-viz-node-bg-color;
             }
 
             .fg-shape {


### PR DESCRIPTION
Minor code adjustments to prevent clientside UI error if ~~click on link for~~ load initial page at pedigree tab (CaseView, etc.)

### E.g.

![](https://i.gyazo.com/7c30d69184946d9b41b6d38bae49d662.png)

---

Also adjusts BG color and sortByAge func so that proband is no longer the left-most child.

### E.g.

![](https://i.gyazo.com/fed7f01703c38353f74ef5592e3f57e8.png)