### PR TITLE
Range facet demo updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1415,8 +1415,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#aa8c4f11bed09b5576a8a6b1405bd05a9698ba49",
-      "from": "github:4dn-dcic/shared-portal-components#0.0.2.97b2",
+      "version": "github:4dn-dcic/shared-portal-components#373c8f96eaca00b9397f9ba0451a6d3fdfcb4d6b",
+      "from": "github:4dn-dcic/shared-portal-components#0.0.2.97",
       "requires": {
         "auth0-lock": "^11.26.3",
         "aws-sdk": "^2.745.0",
@@ -3876,9 +3876,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.825.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.825.0.tgz",
-      "integrity": "sha512-b49nvaETm7uVRLf0FJ1CMmwCRVlLaxHtptVFuxX+2L4FR9VB0sLdgsxhtL3RVFbQlgVFNRV7fJUVK27mC++H+A==",
+      "version": "2.826.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.826.0.tgz",
+      "integrity": "sha512-fuNWmD9gfqrxxPbIIbbTeyEDGaKLqFG9kTXqdaPVpEZhH1xc2UwVJQRA7m+SwfQOcQd6hdS1ii0102DrPiFEdg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1415,8 +1415,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#786f9197ff608e01f0b01742ab4b4ad5e1e43839",
-      "from": "github:4dn-dcic/shared-portal-components#0.0.2.95",
+      "version": "github:4dn-dcic/shared-portal-components#aa8c4f11bed09b5576a8a6b1405bd05a9698ba49",
+      "from": "github:4dn-dcic/shared-portal-components#0.0.2.97b2",
       "requires": {
         "auth0-lock": "^11.26.3",
         "aws-sdk": "^2.745.0",
@@ -3811,9 +3811,9 @@
       }
     },
     "auth0-lock": {
-      "version": "11.27.2",
-      "resolved": "https://registry.npmjs.org/auth0-lock/-/auth0-lock-11.27.2.tgz",
-      "integrity": "sha512-l+LIa0vFfe/upUgOC7KV1M+OGAWPuGl5JIN4PGqrCnA5FBfwHRU+QcMXLMtZB1G1AFqScRz37+PpzbjQdc0S6g==",
+      "version": "11.28.0",
+      "resolved": "https://registry.npmjs.org/auth0-lock/-/auth0-lock-11.28.0.tgz",
+      "integrity": "sha512-rIzDfkgfM/mvTsaLP8v800xnYST6oVfM26Q4h/Bkqlu3fYmH+pUUbuk6uHj9SQXgNIdZhZYNhNdqkIlrTLvKUA==",
       "requires": {
         "auth0-js": "^9.13.3",
         "auth0-password-policies": "^1.0.2",
@@ -3876,9 +3876,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.824.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.824.0.tgz",
-      "integrity": "sha512-9KNRQBkIMPn+6DWb4gR+RzqTMNyGLEwOgXbE4dDehOIAflfLnv3IFwLnzrhxJnleB4guYrILIsBroJFBzjiekg==",
+      "version": "2.825.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.825.0.tgz",
+      "integrity": "sha512-b49nvaETm7uVRLf0FJ1CMmwCRVlLaxHtptVFuxX+2L4FR9VB0sLdgsxhtL3RVFbQlgVFNRV7fJUVK27mC++H+A==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.95",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.97b2",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",
     "detect-browser": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.97b2",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.97",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",
     "detect-browser": "^3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.1.1"
+version = "5.1.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -574,7 +574,8 @@
                 {"to": 20, "label": "Low Strand Bias (P >= 0.01)"},
                 {"from": 20, "label": "High Strand Bias (P < 0.01)"}
             ],
-            "grouping": "Variant Quality"
+            "grouping": "Variant Quality",
+            "abbreviation": "SF"
         },
         "GQ": {
             "title": "Genotype Quality",

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -571,7 +571,7 @@
             "number_step": "any",
             "order": 10,
             "ranges": [
-                {"to": 20, "label": "Low Strand Bias (P >= 0.01)"},
+                {"to": 20, "label": "Low Strand Bias (P ≥ 0.01)"},
                 {"from": 20, "label": "High Strand Bias (P < 0.01)"}
             ],
             "grouping": "Variant Quality",

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -567,9 +567,13 @@
         },
         "FS": {
             "title": "Strand Fisher Score",
-            "aggregation_type": "stats",
+            "aggregation_type": "range",
             "number_step": "any",
             "order": 10,
+            "ranges": [
+                {"to": 20, "label": "Low Strand Bias (P >= 0.01)"},
+                {"from": 20, "label": "High Strand Bias (P < 0.01)"}
+            ],
             "grouping": "Variant Quality"
         },
         "GQ": {


### PR DESCRIPTION
Test with [SPC branch](https://github.com/4dn-dcic/shared-portal-components/pull/54).

### Changelog:

Update Strand Fisher Score to use range aggregation. 
- The score has a threshold of 20. `<=20` should be labelled "low strand bias" and `>20` "high strand bias" with description "Fisher P-value >= 0.01" and "Fisher P-value < 0.01", respectively. (Eventually, we may wish to add descriptions as tooltips, instead, but for now, I merged it into the label in schema).

Update Strand Fisher Score to use abbreviation.
- Added "abbreviation" for this field directly to `variantSample.json` schema facet definition... UI representation handled in SPC branch.