### PR TITLE
Converge some CSS -

### DIFF
--- a/src/encoded/static/components/browse/SearchView.js
+++ b/src/encoded/static/components/browse/SearchView.js
@@ -7,7 +7,6 @@ import url from 'url';
 
 import { memoizedUrlParse, schemaTransforms, analytics } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
-import { ActiveFiltersBar } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/ActiveFiltersBar';
 import { columnExtensionMap } from './columnExtensionMap';
 import { CaseDetailPane } from './CaseDetailPane';
 import { Schemas } from './../util';
@@ -136,10 +135,6 @@ export default class SearchView extends React.PureComponent {
 
         return (
             <div className="container-wide search-page-outer-container" id="content">
-                {/* TEMPORARY UNTIL DECIDE WHERE TO PUT
-                <ActiveFiltersBar {...{ context, filters, schemas }}
-                    termTransformFxn={Schemas.Term.toName} fieldTransformFxn={Schemas.Field.toName}/>
-                */}
                 <CommonSearchView {...passProps} {...{ columnExtensionMap, tableColumnClassName, facetColumnClassName, facets }}
                     renderDetailPane={isCaseSearch ? this.memoized.renderCaseDetailPane : null} termTransformFxn={Schemas.Term.toName} separateSingleTermFacets={false} rowHeight={90} openRowHeight={90} />
             </div>

--- a/src/encoded/static/components/item-pages/CaseView/index.js
+++ b/src/encoded/static/components/item-pages/CaseView/index.js
@@ -467,33 +467,35 @@ const AccessioningTab = React.memo(function AccessioningTab(props) {
                     <span className="current-case text-small text-400 m-0">Current Selection</span>
                 </div>
             </h1>
-            <div className="tab-inner-container">
-                <PartialList className="mb-0" open={isSecondaryFamiliesOpen}
-                    persistent={[
-                        <div key={currFamilyID} className="primary-family">
-                            <h4 className="mt-0 mb-05 text-400">
-                                <span className="text-300">Primary Cases from </span>
-                                { primaryFamilyTitle }
-                            </h4>
-                            <FamilyAccessionStackedTable family={currFamily} result={context}
-                                fadeIn collapseLongLists collapseShow={1} />
-                        </div>
-                    ]}
-                    collapsible={
-                        secondary_families.map(function(family){
-                            const { display_title, '@id' : familyID } = family;
-                            return (
-                                <div className="py-4 secondary-family" key={familyID}>
-                                    <h4 className="mt-0 mb-05 text-400">
-                                        <span className="text-300">Related Cases from </span>
-                                        { display_title }
-                                    </h4>
-                                    <FamilyAccessionStackedTable result={context} family={family} collapseLongLists/>
-                                </div>
-                            );
-                        })
-                    } />
-                { viewSecondaryFamiliesBtn }
+            <div className="tab-inner-container card">
+                <div className="card-body">
+                    <PartialList className="mb-0" open={isSecondaryFamiliesOpen}
+                        persistent={[
+                            <div key={currFamilyID} className="primary-family">
+                                <h4 className="mt-0 mb-05 text-400">
+                                    <span className="text-300">Primary Cases from </span>
+                                    { primaryFamilyTitle }
+                                </h4>
+                                <FamilyAccessionStackedTable family={currFamily} result={context}
+                                    fadeIn collapseLongLists collapseShow={1} />
+                            </div>
+                        ]}
+                        collapsible={
+                            secondary_families.map(function(family){
+                                const { display_title, '@id' : familyID } = family;
+                                return (
+                                    <div className="py-4 secondary-family" key={familyID}>
+                                        <h4 className="mt-0 mb-05 text-400">
+                                            <span className="text-300">Related Cases from </span>
+                                            { display_title }
+                                        </h4>
+                                        <FamilyAccessionStackedTable result={context} family={family} collapseLongLists/>
+                                    </div>
+                                );
+                            })
+                        } />
+                    { viewSecondaryFamiliesBtn }
+                </div>
             </div>
         </React.Fragment>
     );
@@ -580,7 +582,7 @@ const BioinfoStats = React.memo(function BioinfoStats(props) {
     });
 
     return (
-        <>
+        <React.Fragment>
             <div className="row qc-summary">
                 <div className="col-sm-8 text-600">
                     Total Number of Reads:
@@ -665,7 +667,7 @@ const BioinfoStats = React.memo(function BioinfoStats(props) {
                     { (msaStats.filteredVariants && msaStats.filteredVariants.value) ? decorateNumberWithCommas(msaStats.filteredVariants.value) : "" }
                 </div>
             </div>
-        </>
+        </React.Fragment>
     );
 });
 
@@ -694,7 +696,7 @@ const BioinformaticsTab = React.memo(function BioinformaticsTab(props) {
     }, []);
 
     const title = (
-        <h4 data-family-index={0} className="pb-0 p-2 mb-0 d-inline-block w-100">
+        <h4 data-family-index={0} className="my-0 d-inline-block w-100">
             <span className="font-italic text-500">{ familyDisplayTitle }</span>
             {/* { pedFileName ? <span className="text-300">{ " (" + pedFileName + ")" }</span> : null } */}
             <button type="button" className="btn btn-sm btn-primary pull-right"
@@ -713,13 +715,15 @@ const BioinformaticsTab = React.memo(function BioinformaticsTab(props) {
                 <span className="text-600">Current Status:</span><span className="text-success"> PASS <i className="icon icon-check fas"></i></span>
                 <span className="pull-right">3/28/20</span>
             </div> */}
-            <div className="tab-inner-container">
-                <h2 className="section-header">Quality Control Metrics (QC)</h2>
-                <BioinfoStats {...{ caseSample, sampleProcessing }} />
+            <div className="tab-inner-container card">
+                <h4 className="card-header section-header">Quality Control Metrics (QC)</h4>
+                <div className="card-body">
+                    <BioinfoStats {...{ caseSample, sampleProcessing }} />
+                </div>
             </div>
-            <div className="tab-inner-container">
-                <h2 className="section-header">Multisample Analysis Table</h2>
-                <div className="family-index-0" data-is-current-family={true}>
+            <div className="tab-inner-container card">
+                <h4 className="card-header section-header">Multisample Analysis Table</h4>
+                <div className="card-body family-index-0" data-is-current-family={true}>
                     { title }
                     <CaseSummaryTable {...family} sampleProcessing={[sampleProcessing]} isCurrentFamily={true} idx={0} {...{ idToGraphIdentifier }} />
                 </div>

--- a/src/encoded/static/scss/encoded/modules/_item-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_item-pages.scss
@@ -2038,6 +2038,8 @@ $download-button-width : 100px;
 			}
 
 			h1 {
+				/* todo: consider using an h2 instead, as is 2.1rem by default (close to the 2rem set here) and */
+				/* possibly more semantically accurate (i.e. is a section title, not page title) (subjective) */
 				font-size: 2rem;
 				margin-bottom: 20px;
 				font-weight: 500;
@@ -2062,26 +2064,17 @@ $download-button-width : 100px;
 			}
 
 			.tab-inner-container {
-				background-color: #ffffff;
 				margin-bottom: 20px;
-				/* todo: consider having no padding here and instead apply padding to children, perhaps via 'px-' classNames */
-				padding: 20px;
-				border-radius: $border-radius-lg;
-				box-shadow: 0 1px 5px #0002;
-				border-color: #d6d6d6;
 
 				&.qc-status {
 					font-size: 19px;
 				}
 
-				h2.section-header {
+				.card-header.section-header {
 					background-color: $primary-dark;
-					/* This width definition is not needed as blocks will auto-fit available width by default, but left for explicitness */
-					width: calc(100% + 40px);
-					/* This padding definition matches padding of .card-header */
-					padding: 0.75rem 1.25rem;
 					color: #ffff;
-					margin: -20px -20px 10px -20px;
+					font-weight: 400;
+					margin: 0; /* overrides the default `margin: 10px 0` of header (h1, h2, ..) elems */
 				}
 
 				.processing-summary-table {
@@ -2122,8 +2115,8 @@ $download-button-width : 100px;
 					}
 				}
 
-				.row.qc-summary {
-					padding: 2px 0;
+				.row.qc-summary:not(:last-child) {
+					padding-bottom: 5px;
 				}
 
 				.processing-summary-table-container {
@@ -2795,8 +2788,6 @@ $download-button-width : 100px;
 					color: #fff8;
 				}
 				&[data-active="true"] {
-					// background-color: $primary-dark;
-					// color: #fff;
 					@extend .card;
 					color: $primary-dark;
 					display: initial;

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -265,6 +265,11 @@ body[data-pathname="/search/"]:not([data-current-action="add"]) {
 				width: 320px;
 			}
 
+			// Align header height with $search-results-header-row-height.
+			.facets-container.with-header-bg .facets-header {
+				height: $search-results-header-row-height;
+			}
+
 		}
 
 	}
@@ -290,11 +295,6 @@ body[data-pathname="/search/"]:not([data-current-action="add"]) {
 				@include navbar-fixed-position {
 					top: $cgap-search-sticky-header-top-offset;
 					margin-bottom: 0px;
-				}
-
-				// Align header height with $search-results-header-row-height.
-				&.with-header-bg .facets-header {
-					height: $search-results-header-row-height;
 				}
 	
 				body.scrolled-past-160 & {

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -378,12 +378,3 @@ body[data-pathname="/search/"]:not([data-current-action="add"]) {
 	}
 
 }
-
-
-/********************************/
-/****** Active Filters Bar ******/
-/********************************/
-
-@import "../../../../../../node_modules/@hms-dbmi-bgm/shared-portal-components/scss/active-filters-bar.scss"
-
-


### PR DESCRIPTION
- Ensure height of the embedded FacetList header matches height of FacetList on /search/, which matches that of SearchResultTableHeader - [result](https://gyazo.com/9a9f3ad7b884f97fb68a1e76af92fce1)
  - ~~Possible to-do: Have this height take effect in SPC or in same place as for SearchResultTableHeader, at least.~~
  - Drawback of ^ is that then need to import search table scss and facetlist scss from SPC in order and that's arguably more headache of a requirement to need to remember and maintain than the way we sync height now..
- Use Bootstrap's `.card` in place of custom CSS when possible - [result](https://gyazo.com/9b910457b8e3fb66d7aa0186953bdf23)
- Remove/cleanup deprecated ActiveFiltersBar imports (superseded by FilterSetUI now)