### PR TITLE
Update poetry.lock after last PR 305 forgot it (C4-563)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -32,14 +32,14 @@ wrapt = "*"
 
 [[package]]
 name = "awscli"
-version = "1.18.221"
+version = "1.18.222"
 description = "Universal Command Line Environment for AWS."
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-botocore = "1.19.61"
+botocore = "1.19.62"
 colorama = {version = ">=0.2.5,<0.4.4", markers = "python_version != \"3.4\""}
 docutils = ">=0.10,<0.16"
 PyYAML = {version = ">=3.10,<5.4", markers = "python_version != \"3.4\""}
@@ -79,14 +79,14 @@ python-versions = "*"
 
 [[package]]
 name = "boto3"
-version = "1.16.61"
+version = "1.16.62"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-botocore = ">=1.19.61,<1.20.0"
+botocore = ">=1.19.62,<1.20.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -363,7 +363,7 @@ xray = ["mypy-boto3-xray (==1.16.61.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.19.61"
+version = "1.19.62"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -1890,7 +1890,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.7"
-content-hash = "a696ef068294a6cf4043ac4f7398bdfcd2e2af782952a883c11e094069861d5f"
+content-hash = "a974917f25bed2e7a419f81019cdc642586c45a4f0422bddb39a07db485c5043"
 
 [metadata.files]
 apipkg = [
@@ -1906,8 +1906,8 @@ aws-xray-sdk = [
     {file = "aws_xray_sdk-0.95-py2.py3-none-any.whl", hash = "sha256:72791618feb22eaff2e628462b0d58f398ce8c1bacfa989b7679817ab1fad60c"},
 ]
 awscli = [
-    {file = "awscli-1.18.221-py2.py3-none-any.whl", hash = "sha256:21f7eaf77c8fc4bd27897ae9c4a302a57d32eacb740cd7cda5bf7c71d25df78d"},
-    {file = "awscli-1.18.221.tar.gz", hash = "sha256:1bc1e89cdd3678571f311863f7e729a2bba056c17b9c3787128a6e1e76d2d48b"},
+    {file = "awscli-1.18.222-py2.py3-none-any.whl", hash = "sha256:50d9361d6b4dbb40ddab4bdf32730a69df4fc545b39cba100cd1560118b4d560"},
+    {file = "awscli-1.18.222.tar.gz", hash = "sha256:9d5050d8b8f9fb3caf8f78345b747187e099c06eec6ea29e86f83abc08477b1b"},
 ]
 "backports.statistics" = [
     {file = "backports.statistics-0.1.0-py2.py3-none-any.whl", hash = "sha256:2732e003151620762ba3ea25b881b5ca0debe2fcbf41b32b6eaff5842a8b99d7"},
@@ -1923,16 +1923,16 @@ boto = [
     {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
 ]
 boto3 = [
-    {file = "boto3-1.16.61-py2.py3-none-any.whl", hash = "sha256:8343a8e87c07cfebd1ca26b21b841f0875f28622e9a08e8dd2d1085881f9a6fd"},
-    {file = "boto3-1.16.61.tar.gz", hash = "sha256:38f503f0502aba4251dff4d19057c31a7b9dd0f54333df5521f8931ee4c65e26"},
+    {file = "boto3-1.16.62-py2.py3-none-any.whl", hash = "sha256:a280123db79e73478bd23933486f3a0ffa2397d1a6381f32573f2731ff48c59a"},
+    {file = "boto3-1.16.62.tar.gz", hash = "sha256:bb91fecf982e1bbfb68bb6bd2c9a0cce3c84ac6f97dd338d1ef9e47780679091"},
 ]
 boto3-stubs = [
     {file = "boto3-stubs-1.16.61.0.tar.gz", hash = "sha256:b545b1ec8212bab2b406cbe735cd2b60013a6fd18ba218050caaca2328571777"},
     {file = "boto3_stubs-1.16.61.0-py3-none-any.whl", hash = "sha256:a91bd83661c441b4881a42964b2bfc656b2675ac15c0f46e27190be427431a3e"},
 ]
 botocore = [
-    {file = "botocore-1.19.61-py2.py3-none-any.whl", hash = "sha256:59da7b91ebd57362b482d3963392f2944296d6dc79877bf716e1c2671a208a74"},
-    {file = "botocore-1.19.61.tar.gz", hash = "sha256:3245c9e996143bcfdea73d105145ca733fcd7d5afe744a8760612fc449c3f810"},
+    {file = "botocore-1.19.62-py2.py3-none-any.whl", hash = "sha256:1046c152e5865aabbe6b10b2d33e652b3dd072516f3976e96cacc6b7c4460d02"},
+    {file = "botocore-1.19.62.tar.gz", hash = "sha256:29b4b9be5b40f392a033926c08c004c01bd6471384ef6f12eaa49ee3870a010c"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.1.6"
+version = "5.1.7"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This fixes [C4-563](https://hms-dbmi.atlassian.net/browse/C4-563), adding a proper lock file for the existing pyproject.toml.