### PR TITLE
Support for local kibana and local psql (C4-566, C4-567)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,16 @@ deploy3:  # uploads: GeneAnnotationFields, then Genes, then AnnotationFields, th
 	python src/encoded/commands/ingestion.py src/encoded/annotations/variant_table_v0.4.8.csv src/encoded/schemas/annotation_field.json src/encoded/schemas/variant.json src/encoded/schemas/variant_sample.json src/encoded/annotations/GAPFI3JX5D2J.vcf hms-dbmi hms-dbmi src/encoded/annotations/gene_table_v0.4.6.csv src/encoded/schemas/gene_annotation_field.json src/encoded/schemas/gene.json src/encoded/annotations/gene_inserts_v0.4.6.json hms-dbmi hms-dbmi development.ini --post-variant-consequences --post-variants --post-gene-annotation-field-inserts --post-gene-inserts --app-name app
 
 psql-dev:  # starts psql with the url after 'sqlalchemy.url =' in development.ini
-	@psql `grep 'sqlalchemy[.]url =' development.ini | sed -E 's/^.* = (.*)/\1/'`
+	@scripts/psql-start dev
 
-kibana-start:
+psql-test:  # starts psql with a url constructed from data in 'ps aux'.
+	@scripts/psql-start test
+
+kibana-start:  # starts a dev version of kibana (default port)
 	scripts/kibana-start
+
+kibana-start-test:  # starts a test version of kibana (port chosen for active tests)
+	scripts/kibana-start test
 
 kibana-stop:
 	scripts/kibana-stop
@@ -156,11 +162,13 @@ info:
 	   $(info - Use 'make deploy1' to spin up postgres/elasticsearch and load inserts.)
 	   $(info - Use 'make deploy2' to spin up the application server.)
 	   $(info - Use 'make deploy3' to load variants and genes.)
-	   $(info - Use 'make kibana-start' to start kibana, and 'make kibana-stop' to stop it.)
+	   $(info - Use 'make kibana-start' to start kibana on the default local ES port, and 'make kibana-stop' to stop it.)
+	   $(info - Use 'make kibana-start-test' to start kibana on the port being used for active testing, and 'make kibana-stop' to stop it.)
 	   $(info - Use 'make kill' to kill postgres and elasticsearch proccesses. Please use with care.)
 	   $(info - Use 'make moto-setup' to install moto, for less flaky tests. Implied by 'make build'.)
 	   $(info - Use 'make npm-setup' to build the front-end. Implied by 'make build'.)
 	   $(info - Use 'make psql-dev' to start psql on data associated with an active 'make deploy1'.)
+	   $(info - Use 'make psql-test' to start psql on data associated with an active test.)
 	   $(info - Use 'make retest' to run failing tests from the previous test run.)
 	   $(info - Use 'make test' to run tests with normal options we use on travis ('-m "working and not performance"').)
 	   $(info - Use 'make test-any' to run tests without marker constraints (i.e., with no '-m' option).)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.1.7"
+version = "5.1.8"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/kibana-start
+++ b/scripts/kibana-start
@@ -1,13 +1,57 @@
-internal_kibana_port=5601
-local_kibana_port=${internal_kibana_port}
+docker_kibana_image=docker.elastic.co/kibana/kibana-oss:6.8.9
+docker_kibana_port=5601
+local_kibana_port=${docker_kibana_port}
+default_es_port=9200
+local_es_port=${default_es_port}
 
+if [ "$1" = "test" ]; then
 
-# TODO: Write something to use in pdb when debugging that will
-#   fish around in 'ps aux' and find the elasticsearch temporarily
-#   running for testing, fish out its port number, and
-#   set local_es_port to that number.  (As a fallback, or in addition,
-#   make the script take that port number as an argument.)
-#   -kmp 27-Jan-2021
+    # This deletes all the output that doesn't match our pattern and includes only what does.
+    # Ref: https://stackoverflow.com/questions/6011661/regexp-sed-suppress-no-match-output
+    port=`ps aux | sed -E '/.*elasticsearch.*-Ehttp[.]port=([0-9]+)[^0-9].*/!d;s//\1/'`
+
+    if [ -z "${port}" ]; then
+        echo "Cannot find test port."
+        exit 1
+    elif [ `echo "${port}" | wc -l` -gt 1 ]; then
+        echo "Found multiple test ports:"
+        echo "${port}"
+        exit 1
+    fi
+
+    if [[ "${port}" =~ ^[0-9]+$ ]]; then
+        local_es_port="${port}"
+        echo "Using local_es_port=${local_es_port}."
+    else
+        echo "Port format is wrong: ${port}"
+        exit 1
+    fi
+
+elif [[ "$1" =~ ^[0-9]+$ ]]; then
+
+    local_es_port=$1
+    echo "Using local_es_port=${local_es_port}."
+
+elif [ $# -gt 0 -a "$1" != "dev" ]; then
+
+    echo "Syntax: $0 [ <es-port> | test | dev ]"
+    echo " Starts kibana. By default, or if 'dev' is given, uses the standard port ${default_es_port}."
+    echo " If es-port is an integer, that port is used."
+    echo " If es-port is the word 'test', a test port is found using 'ps aux'."
+    echo " Note that this will choose its own http port, which will be 5601 for es-port=9200,"
+    echo " or else a generated port number 10000+(<es-port> % 55536) otherwise."
+    exit 1
+
+fi
+
+if [ "${local_es_port}" != "${default_es_port}" ]; then
+    # 0-1023 are reserved ports
+    # 1024-65535 are available for custom use, but usualy 1024-9999 are assigned manually
+    # we'll generate a port in the range 10000-65535. that might sometimes collide, but probably VERY rarely.
+    local_kibana_port=$(( $local_es_port % 55536 + 10000 ))
+fi
+
+echo "Using local_kibana_port=${local_kibana_port}"
 
 docker --version
 
@@ -20,20 +64,34 @@ fi
 existing_network=`docker network ls | grep localnet`
 
 if [ -z "${existing_network}" ]; then
+    echo "creating localnet --driver=bridge"
     docker network create localnet --driver=bridge
 else
     echo "docker localnet is already set up. From 'docker network':"
-    echo " ${existing_network}"
+    # echo " ${existing_network}"
 fi
 
-existing_kibana=`docker ps | egrep 'kibana:[0-9]*.[0-9]+.*[ ].*'`
+# This pattern is structured so that if we need to extract the container id (e.g., to kill it), it will be in \1.
+# But I figured out a way not to have to kill the old one, so that part of the pattern isn't used any more.
+# I retained the first group just for possible future use. At this point, this just detects whether we have a
+# handler for $local_kibana_port at all. This pattern also anticipates kibana images named 'kibana' or 'kibana-oss'.
+# I other image names come up, for example if aws creates its own naming convention, it will need adjusting.
+# -kmp 31-Jan-2021
+kibana_docker_pattern="([0-9a-f]+) .*kibana(-oss)?:[0-9]+[.][0-9]+[.].*0[.]0[.]0[.]0[:]${local_kibana_port}-[>]"
+
+existing_kibana=`docker ps | egrep "${kibana_docker_pattern}"`
 
 if [ -z "${existing_kibana}" ]; then
 
-    docker run -d --network localnet -p ${local_kibana_port}:5601 -e ELASTICSEARCH_URL=http://host.docker.internal:${local_es_port} docker.elastic.co/kibana/kibana-oss:6.8.9
+    echo "Kibana is not already running for ES port ${local_es_port}"
+    docker_es_url="http://host.docker.internal:${local_es_port}"
+    docker run -d --network localnet -p ${local_kibana_port}:${docker_kibana_port} -e ELASTICSEARCH_URL=${docker_es_url} ${docker_kibana_image}
+
+    echo "Waiting for kibana to start..."
+    sleep 5
 
 else
-    echo "Kibana is already running. From 'docker ps':"
+    echo "Kibana is already listening on port ${local_kibana_port} for elasticsearch on port ${local_es_port}:"
     echo " ${existing_kibana}"
 fi
 
@@ -41,4 +99,3 @@ local_kibana_url="http://localhost:${local_kibana_port}/app/kibana#/dev_tools/co
 
 echo "Opening kibana in browser at '${local_kibana_url}'..."
 open "${local_kibana_url}" &
-

--- a/scripts/psql-start
+++ b/scripts/psql-start
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+port=$1
+
+dev_url_line=`grep 'sqlalchemy[.]url =' development.ini`
+
+dev_url=`echo "${dev_url_line}" | sed -E 's/^.* = (.*)$/\1/'`
+dev_port=`echo "${dev_url_line}" | sed -E 's|^.* = .*:([0-9]+)/postgres[?].*$|\1|'`
+
+
+# echo "dev_url=${dev_url}"
+# echo "dev_port=${dev_port}"
+
+
+# There seem be two processes, one for postgres and one for postgres-engine.
+# The relevant data can be obtained from either, but matching both 
+# the match for postgres[^-] excludes the matches on postgres-engine so we
+# can assume the match is unique.
+
+if [ "$port" = 'test' ]; then
+
+    test_process=`ps aux | grep '.*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-]'`
+
+    if [ -z "${test_process}" ]; then
+
+        echo "No test process found."
+	exit 1
+
+    else
+
+        test_url=`echo "$test_process" | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+        psql "${test_url}"
+
+        # psql `ps aux | grep '.*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-]' | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+
+    fi
+
+elif [ "$port" = 'dev' -o "$port" = "$dev_port" ]; then
+
+    dev_url=`grep 'sqlalchemy[.]url =' development.ini | sed -E 's/^.* = (.*)/\1/'`
+    psql "${dev_url}"
+
+elif [[ "${port}" =~ ^[0-9]+$ ]]; then
+
+    port_process=`ps aux | grep ".*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-].*-p[ ]+${port}.*"`
+
+    if [ -z "${port_process}" ]; then
+
+        echo "No postgres process found on port ${port}."
+	exit 1
+
+    else
+
+        port_url=`echo "$test_process" | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+        psql "${port_url}"
+
+        # psql `ps aux | grep '.*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-]' | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+
+    fi
+
+else
+
+    echo "Syntax: $0 [ <port> | test | dev ]"
+    echo ""
+    echo "Starts psql for debugging in a way that corresponds to the given port."
+    echo "The port can be an integer or one of the special tokens 'dev' or 'test'."
+    echo "If 'dev' is given, the port from development.ini (currently '${dev_port}') is used."
+    echo "If 'test' is given, the port will be found from data in 'ps aux'."
+
+fi


### PR DESCRIPTION
This adds and repairs support for local kibana and psql debugging.

`make kibana-start` already existed as a way to start kibana on a local es on the default port used by `make deploy1`, though it had been broken. I fixed it.

`make kibana-start-test` now figures out what es is being used for active testing and will open kibana on that.

`make psql-dev` already existed to open psql on the postgres being used with `make deploy1`.

`make psql-test` is new and opens psql on the postgres used with `make test`.

The underlying script `scripts/kibana-start` is now more featureful. It takes an argument of a port or one of the constant tokens `test` or `dev` to have the port figured out automatically.

Likewise `scripts/psql-start` takes a port, `test`, or `dev`.