### PR TITLE
Add renderers unit tests and revert to application/json default (C4-571)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.2.0"
+version = "5.2.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.2.1"
+version = "5.2.0.1b0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.2.1"
+version = "5.2.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/ingestion/table_utils.py
+++ b/src/encoded/ingestion/table_utils.py
@@ -678,10 +678,10 @@ class VariantTableParser(object):
         variant_facs = format_variant_cols_or_facs(variant_facs)
         cols.update(variant_cols)  # add variant stuff since we are embedding this info
         facs.update(variant_facs)
-        MappingTableHeader.add_extra_variant_sample_columns(cols)
-        MappingTableHeader.extend_variant_sample_columns(cols)
-        MappingTableHeader.add_extra_variant_sample_facets(facs)
-        MappingTableHeader.extend_variant_sample_facets(facs)
+        self.add_extra_variant_sample_columns(cols)
+        self.extend_variant_sample_columns(cols)
+        self.add_extra_variant_sample_facets(facs)
+        self.extend_variant_sample_facets(facs)
         schema['columns'] = cols
         schema['facets'] = facs
         schema['facets'] = self.sort_schema_properties(schema, key='facets')

--- a/src/encoded/renderers.py
+++ b/src/encoded/renderers.py
@@ -327,14 +327,15 @@ MIME_TYPE_HTML = 'text/html'
 MIME_TYPE_JSON = 'application/json'
 MIME_TYPE_LD_JSON = 'application/ld+json'
 
-MIME_TYPES_SUPPORTED = [MIME_TYPE_HTML, MIME_TYPE_JSON, MIME_TYPE_LD_JSON]
-MIME_TYPE_DEFAULT = MIME_TYPE_JSON
+MIME_TYPES_SUPPORTED = [MIME_TYPE_JSON, MIME_TYPE_HTML, MIME_TYPE_LD_JSON]
+MIME_TYPE_DEFAULT = MIME_TYPES_SUPPORTED[0]
 MIME_TYPE_TRIAGE_MODE = 'modern'  # if this doesn't work, fall back to 'legacy'
 
 DEBUG_MIME_TYPES = environ_bool("DEBUG_MIME_TYPES", default=False)
 
 
 def best_mime_type(request, mode=MIME_TYPE_TRIAGE_MODE):
+    # TODO: I think this function does nothing but return MIME_TYPES_SUPPORTED[0] -kmp 3-Feb-2021
     """
     Given a request, tries to figure out the best kind of MIME type to use in response
     based on what kinds of responses we support and what was requested.
@@ -378,10 +379,21 @@ def best_mime_type(request, mode=MIME_TYPE_TRIAGE_MODE):
 def should_transform(request, response):
     """
     Determines whether to transform the response from JSON->HTML/JS depending on type of response
-    and what the request is looking for to be returned via e.g. request Accept, Authorization header.
-    In case of no Accept header, attempts to guess.
+    and what the request is looking for to be returned via these criteria, which are tried in order
+    until one succeeds:
 
-    Memoized via `lru_cache`. Cache size is set to be 16 (> 1) in case sub-requests fired off during handling.
+    * If the request method is other than GET or HEAD, returns False.
+    * If the response.content_type is other than 'application/json', returns False.
+    * If a 'frame=' query param is given and not 'page' (the default), returns False.
+    * If a 'format=json' query param is given explicitly,
+        * For 'format=html', returns True.
+        * For 'format=json', returns False.
+      This rule does not match if 'format=' is not given explicitly.
+      If 'format=' is given an explicit value of ther than 'html' or 'json', an HTTPNotAcceptable error will be raised.
+    * If the first element of MIME_TYPES_SUPPORTED[0] is 'text/html', returns True.
+    * Otherwise, in all remaining cases, returns False.
+
+    NOTE: Memoized via `lru_cache`. Cache size is set to be 16 (> 1) in case sub-requests fired off during handling.
     """
     # We always return JSON in response to POST, PATCH, etc.
     if request.method not in ('GET', 'HEAD'):

--- a/src/encoded/tests/test_renderers.py
+++ b/src/encoded/tests/test_renderers.py
@@ -1,0 +1,117 @@
+from dcicutils.qa_utils import MockResponse
+from unittest import mock
+from pyramid.testing import DummyRequest
+from .. import renderers
+from ..renderers import (
+    best_mime_type, should_transform, MIME_TYPES_SUPPORTED, MIME_TYPE_DEFAULT,
+    MIME_TYPE_JSON, MIME_TYPE_HTML, MIME_TYPE_LD_JSON,
+)
+
+
+DEFAULT_SHOULD_TRANSFORM = (MIME_TYPE_DEFAULT == MIME_TYPE_HTML)
+
+
+class DummyResponse(MockResponse):
+
+    def __init__(self, content_type=None, status_code: int = 200, json=None, content=None, url=None,
+                 params=None):
+        self.params = {} if params is None else params
+        self.content_type = content_type
+        super().__init__(status_code=status_code, json=json, content=content, url=url)
+
+
+def test_mime_variables():
+
+    # Really these don't need testing but it's useful visually to remind us of their values here.
+    assert MIME_TYPE_HTML == 'text/html'
+    assert MIME_TYPE_JSON == 'application/json'
+    assert MIME_TYPE_LD_JSON == 'application/ld+json'
+    assert MIME_TYPES_SUPPORTED == [MIME_TYPE_JSON, MIME_TYPE_HTML, MIME_TYPE_LD_JSON]
+    assert MIME_TYPE_DEFAULT == MIME_TYPE_JSON
+
+
+VARIOUS_MIME_TYPES_TO_TEST = ['*/*', 'text/html', 'application/json', 'application/ld+json', 'text/xml', 'who/cares']
+
+
+def test_best_mime_type(the_constant_answer=MIME_TYPE_DEFAULT):
+
+    for requested_mime_type in VARIOUS_MIME_TYPES_TO_TEST:
+        req = DummyRequest(headers={'Accept': requested_mime_type})
+        assert best_mime_type(req, 'legacy') == the_constant_answer
+        assert best_mime_type(req, 'modern') == the_constant_answer
+        req = DummyRequest(headers={})  # The Accept header in the request just isn't being consulted
+        assert best_mime_type(req, 'modern') == the_constant_answer
+        assert best_mime_type(req, 'modern') == the_constant_answer
+
+
+def test_best_mime_type_traditional():
+
+    test_best_mime_type('application/json')
+
+
+TYPICAL_URLS = [
+    'http://whatever/foo',
+    'http://whatever/foo/',
+    'http://whatever/foo.json',
+    'http://whatever/foo.html',
+]
+
+ALLOWED_FRAMES_OR_NONE = ['raw', 'page', 'embedded', 'object', 'bad', None]
+
+SOME_HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']
+
+ALLOWED_FORMATS_OR_NONE = ['json', 'html', None]
+
+
+def test_should_transform():
+
+    for method in SOME_HTTP_METHODS:
+        for _format in ALLOWED_FORMATS_OR_NONE:
+            for requested_mime_type in VARIOUS_MIME_TYPES_TO_TEST:
+                for response_content_type in VARIOUS_MIME_TYPES_TO_TEST:
+                    for frame in [None] + ALLOWED_FRAMES_OR_NONE:
+                        for url in TYPICAL_URLS:
+
+                            params = {}
+                            if frame is not None:
+                                params['frame'] = frame
+                            if _format is not None:
+                                params['format'] = _format
+
+                            req = DummyRequest(headers={'Accept': requested_mime_type},
+                                               method=method,
+                                               url=url,
+                                               params=params)
+                            resp = DummyResponse(content_type=response_content_type, url=url)
+
+                            print("method=", method,
+                                  "format=", _format,
+                                  "params=", params,
+                                  "requested=", requested_mime_type,
+                                  "response_content_type=", response_content_type,
+                                  "frame=", frame,
+                                  )
+
+                            if req.method not in ('GET', 'HEAD'):
+                                assert not should_transform(req, resp)
+                            elif resp.content_type != 'application/json':
+                                # If the response MIME type is not application/json,
+                                # it just can't be transformed at all.
+                                assert not should_transform(req, resp)
+                            elif params.get("frame", "page") != 'page':
+                                assert not should_transform(req, resp)
+                            elif _format is not None:
+                                assert should_transform(req, resp) is (_format == 'html')
+                            else:
+                                assert should_transform(req, resp) is DEFAULT_SHOULD_TRANSFORM
+
+
+def test_should_transform_without_best_mime_type():
+
+    with mock.patch.object(renderers, "best_mime_type") as mock_best_mime_type:
+
+        # Demonstrate that best_mime_type(...) could be replaced by MIME_TYPES_SUPPORTED[0]
+        mock_best_mime_type.return_value = MIME_TYPES_SUPPORTED[0]
+
+        test_should_transform()
+

--- a/src/encoded/tests/test_variant_table_intake.py
+++ b/src/encoded/tests/test_variant_table_intake.py
@@ -183,7 +183,6 @@ def test_generate_variant_sample_schema(MTParser, sample_variant_items):
     assert 'facets' in schema
     assert 'variant' in properties
     assert 'file' in properties
-    assert 'variant.display_title' in cols
     assert facs['DP']['order'] == 8
     assert facs['AF']['order'] == 11
     assert cols['DP']['order'] == 20


### PR DESCRIPTION
Following up on [C4-571](https://hms-dbmi.atlassian.net/browse/C4-571) (and [cgap-portal PR #310](https://github.com/dbmi-bgm/cgap-portal/pull/310))

This sets application/json to be the preferred MIME type in the fall-through case of `should_transform` in `renderers.py`. I had a long chat with @alexkb0009 and @willronchetti about this and this seems to be the consensus. It's the value/behavior that was current at the start of January before my recent changes.

I have checked that this did not perturb SubmitCGAP on a localhost example of the file that @sbreiff gave me but she may want to check again.

In brief, the reason this came up is that I was writing some unit tests for this to cover recent changes and I discovered that none of us understood how the code was really working and that the unit tests I wrote that should have covered didn't behave at all like what we expected. So I have added a doc string to `should_transform` that explains the actual expectation and made unit tests to match.

I went back in time to [a Jan 7 checkin by Sarah](https://github.com/dbmi-bgm/cgap-portal/blob/f68d28fbcfc8f1b57eba9ddbf79c532f245354c7/src/encoded/renderers.py) when things were stable and ran the same tests (with a few small mods to accommodate some variables missing at the time). All of these tests pass at that time as well, so I think this is a stable set of tests. All of these tests fail on master right now, so I think it is testing what we want to test. With this change, we'll be back to testing properly and we'll have some protection against future confusion.
