### PR TITLE
prevent .split() null errors

### DIFF
--- a/src/encoded/static/components/item-pages/CaseView/FilteringTab.js
+++ b/src/encoded/static/components/item-pages/CaseView/FilteringTab.js
@@ -16,21 +16,26 @@ const GenesMostSevereHGVSCColumn = React.memo(function GenesMostSevereHGVSCColum
         genes_most_severe_hgvsp = null
     } = gene || {};
 
+    const rows = [];
     // Memoized on the 1 prop it receives which is dependency for its calculation.
-    const hgvscSplit = genes_most_severe_hgvsc.split(":");
-    const scSplit = hgvscSplit[1].split(".");
+    if (genes_most_severe_hgvsc) {
+        const hgvscSplit = genes_most_severe_hgvsc.split(":");
+        var scSplit = hgvscSplit[1].split(".");
+        rows.push(
+            <div className="text-truncate d-block" key="sc">
+                <span className="text-600">{ scSplit[0] }.</span><span>{ scSplit[1] }</span>
+            </div>);
+    }
 
-    const hgvspSplit = genes_most_severe_hgvsp.split(":");
-    const spSplit = hgvspSplit[1].split(".");
+    if (genes_most_severe_hgvsp) {
+        const hgvspSplit = genes_most_severe_hgvsp.split(":");
+        var spSplit = hgvspSplit[1].split(".");
+        rows.push(
+            <div className="text-truncate d-block" key="sp">
+                <span className="text-600">{ spSplit[0] }.</span><span>{ spSplit[1] }</span>
+            </div>);
+    }
 
-    const rows = [
-        <div className="text-truncate d-block" key="sc">
-            <span className="text-600">{ scSplit[0] }.</span><span>{ scSplit[1] }</span>
-        </div>,
-        <div className="text-truncate d-block" key="sp">
-            <span className="text-600">{ spSplit[0] }.</span><span>{ spSplit[1] }</span>
-        </div>
-    ];
     return <StackedRowColumn className="text-center" {...{ rows }} />;
 });
 


### PR DESCRIPTION
Ran into some client side errors when these values on gene came in null. Since it can break the entire search embed/view if a single item doesn't have these, made some slight adjustments.