### PR TITLE
Fix intermittent 404 in test_index_data_workbook (C4-570)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ clean-python:
 	pip uninstall -y -r <(pip freeze)
 
 test:
-	poetry run python -m pytest -vv --timeout=200 -m "working and not indexing" && poetry run python -m pytest -vv --timeout=200 -m "working and indexing"
+	poetry run python -m pytest -vv --timeout=200 -m "working and not indexing and not manual" && poetry run python -m pytest -vv --timeout=200 -m "working and indexing and not manual"
 
 retest:
 	poetry run python -m pytest -vv --last-failed
@@ -144,7 +144,7 @@ test-any:
 	poetry run python -m pytest -vv --timeout=200
 
 travis-test:
-	poetry run python -m pytest -vv --instafail --force-flaky --max-runs=3 --timeout=400 -m "working and not indexing and not action_fail" --aws-auth --durations=20 --cov src/encoded --es search-cgap-testing-6-8-vo4mdkmkshvmyddc65ux7dtaou.us-east-1.es.amazonaws.com:443 && poetry run python -m pytest -vv --timeout=300 -m "working and indexing and not action_fail" --aws-auth --es search-cgap-testing-6-8-vo4mdkmkshvmyddc65ux7dtaou.us-east-1.es.amazonaws.com:443
+	poetry run python -m pytest -vv --instafail --force-flaky --max-runs=3 --timeout=400 -m "working and not indexing and not action_fail and not manual" --aws-auth --durations=20 --cov src/encoded --es search-cgap-testing-6-8-vo4mdkmkshvmyddc65ux7dtaou.us-east-1.es.amazonaws.com:443 && poetry run python -m pytest -vv --timeout=300 -m "working and indexing and not action_fail and not manual" --aws-auth --es search-cgap-testing-6-8-vo4mdkmkshvmyddc65ux7dtaou.us-east-1.es.amazonaws.com:443
 
 update:  # updates dependencies
 	poetry update
@@ -172,6 +172,6 @@ info:
 	   $(info - Use 'make psql-dev' to start psql on data associated with an active 'make deploy1'.)
 	   $(info - Use 'make psql-test' to start psql on data associated with an active test.)
 	   $(info - Use 'make retest' to run failing tests from the previous test run.)
-	   $(info - Use 'make test' to run tests with normal options we use on travis ('-m "working and not performance"').)
+	   $(info - Use 'make test' to run tests with normal options we use on travis ('-m "working and not manual"').)
 	   $(info - Use 'make test-any' to run tests without marker constraints (i.e., with no '-m' option).)
 	   $(info - Use 'make update' to update dependencies (and the lock file).)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.2.2"
+version = "5.2.3"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ markers =
     ingestion: mark a test as an ingestion test (deselect with '-m "not ingestion"')
     integrated: an integration test
     integratedx: an excludable integration test, redundantly testing functionality also covered by a unit test
+    manual: a test that is only ever intended to be run manually
     performance: mark a test as a performance test (deselect with '-m "not performance"')
     schema: mark a test as a schema-related test (deselect with '-m "not schema"')
     search: mark a test a search module test (deselect with '-m "not search"')


### PR DESCRIPTION
This fixes the spurious intermittent 404 described in [C4-570](https://hms-dbmi.atlassian.net/browse/C4-570).

This arranges to collect both the normal (non-deleted) _and_ deleted pages in order to do count checking. (This does not address the underlying issue that leads to deleted pages laying around.)

I added a regression test but I have marked that test with `@pytest.mark.manual`, a new tag that can be used to mark tests that will only be run if invoked manually. Our normal `make test` and `make travis-test` will now add `not manual` to the list of conditions about what to run.

The regression test does these things:

* It runs `test_index_data_workbook` normally, to show that it works in its intended way.
* It creates a deleted page and re-runs `test_index_data_workbook` to show that it is not bothered by the deleted page.
* It disables the special protection I've added and re-runs `test_index_data_workbook` with the deleted page still present as a proof that in fact it would have failed without the addition of these changes. It catches this failure, so the overall regression test should succeed.

Also, I had recently bumped the retry count in `check_item_type` from 5 to 20, hoping more waiting would fix things. We can see now that it was not waiting for something to happen, so more time was probably not helping. So I have put the retry count back down to 5. This should speed things up slightly in the case where it was going to fail.

I changed the `check_item_type` function to be a method on a class so that I could dynamically control how it works during the regression test. If you look at how that's written, it should make the structure a little more clear.

So, at this point, only the normal test `test_index_data_workbook` will run, as it always has.

You can test this by manually invoking the regression test as follows:

```
python -m pytest -vv -k test_index_data_workbook_after_posting_deleted_page_c4_570
```

Be prepared to wait quite a long time, 5 minutes on my machine:

```
(cg4env) kentpitman@Kents-MacBook-Pro ~/py/cgap-portal4$ python -m pytest -vv -k test_index_data_workbook_after_posting_deleted_page_c4_570
================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.6.9, pytest-2.9.2, py-1.10.0, pluggy-0.3.1 -- /Users/kentpitman/py/cgap-portal4/cg4env/bin/python
cachedir: .cache
rootdir: /Users/kentpitman/py/cgap-portal4, inifile: pytest.ini
plugins: xdist-1.14, timeout-1.0.0, mock-0.11.0, instafail-0.3.0, exact-fixtures-0.1, cov-2.2.1, flaky-3.7.0
collected 1333 items 

src/encoded/tests/test_search.py::test_index_data_workbook_after_posting_deleted_page_c4_570 PASSED

================================================ 1332 tests deselected by '-ktest_index_data_workbook_after_posting_deleted_page_c4_570' =================================================
============================================================= 1 passed, 1332 deselected, 2 pytest-warnings in 309.22 seconds =============================================================
```


You can also test that the test is working by doing the procedure described in [C4-570](https://hms-dbmi.atlassian.net/browse/C4-570) suggests). The reason I added the regression test, though, is that this mechanism is not as reliable because the tests won't always run in the indicated order. If it doesn't run `test_get_help_page_deleted` first, just press Control-C one or more times to abort the test, and then retry. It may take a few times until you see `test_get_help_page_deleted` running first. Before the fix, this reliably reproduced the error if `test_get_help_page_deleted` ran first and _not otherwise_:

```
python -m pytest -vv src/encoded/tests/test_static_page.py::test_get_help_page_deleted src/encoded/tests/test_search.py::test_index_data_workbook
```

With this fix, though, you should see something similar to what I see (3.5 minutes on my machine):

```
(cg4env) kentpitman@Kents-MacBook-Pro ~/py/cgap-portal4$ python -m pytest -vv src/encoded/tests/test_search.py::test_index_data_workbook src/encoded/tests/test_static_page.py::test_get_help_page_deleted 
================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.6.9, pytest-2.9.2, py-1.10.0, pluggy-0.3.1 -- /Users/kentpitman/py/cgap-portal4/cg4env/bin/python
cachedir: .cache
rootdir: /Users/kentpitman/py/cgap-portal4, inifile: pytest.ini
plugins: xdist-1.14, timeout-1.0.0, mock-0.11.0, instafail-0.3.0, exact-fixtures-0.1, cov-2.2.1, flaky-3.7.0
collected 39 items 

src/encoded/tests/test_static_page.py::test_get_help_page_deleted PASSED
src/encoded/tests/test_search.py::test_index_data_workbook PASSED

=============================================================================== 2 passed in 212.90 seconds ===============================================================================
```
