### PR TITLE
V20 UI updates 3

### DIFF
--- a/src/encoded/ingestion/table_utils.py
+++ b/src/encoded/ingestion/table_utils.py
@@ -667,12 +667,14 @@ class VariantTableParser(object):
             "associated_genotype_labels.mother_genotype_label": {
                 "title": "Mother Genotype",
                 "order": 13,
-                "grouping": "Genotype"
+                "grouping": "Genotype",
+                "default_hidden": True
             },
             "associated_genotype_labels.father_genotype_label": {
                 "title": "Father Genotype",
                 "order": 14,
-                "grouping": "Genotype"
+                "grouping": "Genotype",
+                "default_hidden": True
             },
 
             # Below facets are default-hidden unless e.g. additional_facet=associated_genotype_labels.co_parent_genotype_label

--- a/src/encoded/ingestion/table_utils.py
+++ b/src/encoded/ingestion/table_utils.py
@@ -580,6 +580,83 @@ class VariantTableParser(object):
             'order': 15,
         }
 
+        # Range facets using range aggregation_type (ranges will be defined from Q2Q tab in future)
+        facs['variant.csq_gnomadg_af'] = {
+            "title": "GnomAD Alt Allele Frequency",
+            "aggregation_type": "range",
+            "number_step": "any",
+            "order": 18,
+            "grouping": "Population Frequency",
+            "ranges": [	
+                { "from": 0, "to": 0, "label": "unobserved" }, 	
+                { "from": 0, "to": 0.001, "label": "ultra-rare" },	
+                { "from": 0.001, "to": 0.01, "label": "rare" },	
+                { "from": 0.01, "to": 1, "label": "common" }	
+            ]
+        }
+        facs['variant.csq_gnomadg_af_popmax'] = {
+            "title": "GnomAD Alt AF - PopMax",
+            "aggregation_type": "range",
+            "number_step": "any",
+            "order": 19,
+            "grouping": "Population Frequency",
+            "ranges": [	
+                { "from": 0, "to": 0, "label": "unobserved" }, 	
+                { "from": 0, "to": 0.001, "label": "ultra-rare" },	
+                { "from": 0.001, "to": 0.01, "label": "rare" },	
+                { "from": 0.01, "to": 1, "label": "common" }	
+            ]
+        }
+        facs['variant.csq_phylop100way_vertebrate'] = {
+            "title": "PhyloP (100 Vertebrates)",
+            "aggregation_type": "range",
+            "number_step": "any",
+            "order": 22,
+            "grouping": "Effect Predictors",
+            "ranges": [	
+                { "from": -20, "to": -3, "label": "strong positive selection" },	
+                { "from": -3, "to": -2, "label": "positive selection" },	
+                { "from": -2, "to": 2, "label": "low selection" },	
+                { "from": 2, "to": 3, "label": "conserved" },	
+                { "from": 3, "to": 10, "label": "highly conserved"}	
+            ]
+        }
+        facs['FS'] = {
+            "title": "Strand Fisher Score",
+            "aggregation_type": "range",
+            "number_step": "any",
+            "order": 12,
+            "grouping": "Variant Quality",
+            "ranges": [
+                { "to": 20, "label": "Low Strand Bias (P ≥ 0.01)" },	
+                { "from": 20, "label": "High Strand Bias (P < 0.01)" }	
+            ]
+        }
+        facs['AD_ALT'] = {
+            "title": "AD (Alt)",
+            "aggregation_type": "range",
+            "number_step": 1,
+            "order": 10,
+            "grouping": "Variant Quality",
+            "ranges": [	
+                { "from": 1, "to": 4, "label": "Very Low" },	
+                { "from": 5, "to": 9, "label": "Low" },	
+                { "from": 10, "to": 19, "label": "Medium" },	
+                { "from": 20, "label": "High" }	
+            ]
+        }
+        facs['novoPP'] = {
+            "title": "novoCaller PP",
+            "aggregation_type": "range",
+            "number_step": "any",
+            "order": 16,
+            "grouping": "Genotype",
+            "ranges": [	
+                { "from": 0.1, "to": 0.9, "label": "de novo candidate (weak)" },	
+                { "from": 0.9, "to": 1, "label": "de novo candidate (strong)" }	
+            ]
+        }
+
         # Genotype labels (calculated properties)
         facs.update({
             "associated_genotype_labels.proband_genotype_label": {

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -734,12 +734,14 @@
         "associated_genotype_labels.father_genotype_label": {
             "title": "Father Genotype",
             "order": 14,
-            "grouping": "Genotype"
+            "grouping": "Genotype",
+            "default_hidden": true
         },
         "associated_genotype_labels.mother_genotype_label": {
             "title": "Mother Genotype",
             "order": 13,
-            "grouping": "Genotype"
+            "grouping": "Genotype",
+            "default_hidden": true
         },
         "associated_genotype_labels.proband_genotype_label": {
             "title": "Proband Genotype",

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -613,10 +613,31 @@
     "facets": {
         "AD_ALT": {
             "title": "AD (Alt)",
-            "aggregation_type": "stats",
+            "aggregation_type": "range",
             "number_step": 1,
             "order": 10,
-            "grouping": "Variant Quality"
+            "grouping": "Variant Quality",
+            "ranges": [
+                {
+                    "from": 1,
+                    "to": 4,
+                    "label": "Very Low"
+                },
+                {
+                    "from": 5,
+                    "to": 9,
+                    "label": "Low"
+                },
+                {
+                    "from": 10,
+                    "to": 19,
+                    "label": "Medium"
+                },
+                {
+                    "from": 20,
+                    "label": "High"
+                }
+            ]
         },
         "AF": {
             "title": "VAF",
@@ -634,10 +655,20 @@
         },
         "FS": {
             "title": "Strand Fisher Score",
-            "aggregation_type": "stats",
+            "aggregation_type": "range",
             "number_step": "any",
             "order": 12,
-            "grouping": "Variant Quality"
+            "grouping": "Variant Quality",
+            "ranges": [
+                {
+                    "to": 20,
+                    "label": "Low Strand Bias (P \u2265 0.01)"
+                },
+                {
+                    "from": 20,
+                    "label": "High Strand Bias (P < 0.01)"
+                }
+            ]
         },
         "GQ": {
             "title": "Genotype Quality",
@@ -774,10 +805,22 @@
         },
         "novoPP": {
             "title": "novoCaller PP",
-            "aggregation_type": "stats",
+            "aggregation_type": "range",
             "number_step": "any",
             "order": 16,
-            "grouping": "Genotype"
+            "grouping": "Genotype",
+            "ranges": [
+                {
+                    "from": 0.1,
+                    "to": 0.9,
+                    "label": "de novo candidate (weak)"
+                },
+                {
+                    "from": 0.9,
+                    "to": 1,
+                    "label": "de novo candidate (strong)"
+                }
+            ]
         },
         "variant.CHROM": {
             "title": "Chromosome",
@@ -805,17 +848,61 @@
         },
         "variant.csq_gnomadg_af": {
             "title": "GnomAD Alt Allele Frequency",
-            "aggregation_type": "stats",
+            "aggregation_type": "range",
             "number_step": "any",
             "order": 18,
-            "grouping": "Population Frequency"
+            "grouping": "Population Frequency",
+            "ranges": [
+                {
+                    "from": 0,
+                    "to": 0,
+                    "label": "unobserved"
+                },
+                {
+                    "from": 0,
+                    "to": 0.001,
+                    "label": "ultra-rare"
+                },
+                {
+                    "from": 0.001,
+                    "to": 0.01,
+                    "label": "rare"
+                },
+                {
+                    "from": 0.01,
+                    "to": 1,
+                    "label": "common"
+                }
+            ]
         },
         "variant.csq_gnomadg_af_popmax": {
             "title": "GnomAD Alt AF - PopMax",
-            "aggregation_type": "stats",
+            "aggregation_type": "range",
             "number_step": "any",
             "order": 19,
-            "grouping": "Population Frequency"
+            "grouping": "Population Frequency",
+            "ranges": [
+                {
+                    "from": 0,
+                    "to": 0,
+                    "label": "unobserved"
+                },
+                {
+                    "from": 0,
+                    "to": 0.001,
+                    "label": "ultra-rare"
+                },
+                {
+                    "from": 0.001,
+                    "to": 0.01,
+                    "label": "rare"
+                },
+                {
+                    "from": 0.01,
+                    "to": 1,
+                    "label": "common"
+                }
+            ]
         },
         "variant.csq_gnomadg_an": {
             "title": "GnomAD Total Allele Number",
@@ -833,10 +920,37 @@
         },
         "variant.csq_phylop100way_vertebrate": {
             "title": "PhyloP (100 Vertebrates)",
-            "aggregation_type": "stats",
+            "aggregation_type": "range",
             "number_step": "any",
             "order": 22,
-            "grouping": "Effect Predictors"
+            "grouping": "Effect Predictors",
+            "ranges": [
+                {
+                    "from": -20,
+                    "to": -3,
+                    "label": "strong positive selection"
+                },
+                {
+                    "from": -3,
+                    "to": -2,
+                    "label": "positive selection"
+                },
+                {
+                    "from": -2,
+                    "to": 2,
+                    "label": "low selection"
+                },
+                {
+                    "from": 2,
+                    "to": 3,
+                    "label": "conserved"
+                },
+                {
+                    "from": 3,
+                    "to": 10,
+                    "label": "highly conserved"
+                }
+            ]
         },
         "variant.genes.genes_most_severe_consequence.coding_effect": {
             "title": "Coding Effect",

--- a/src/encoded/static/components/item-pages/VariantSampleView/SampleTabBody.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/SampleTabBody.js
@@ -539,6 +539,7 @@ class CompoundHetTableWrapper extends React.Component {
     getMateData() {
         const { cmphetArr = [] } = this.state;
         const encodedQueryString = this.constructGetMatesQuery();
+        // console.log("getQueryString", encodedQueryString);
 
         // Request variant mates
         return ajax.promise(encodedQueryString, 'GET', {})
@@ -569,7 +570,8 @@ class CompoundHetTableWrapper extends React.Component {
                     // update each state object with link data
                     response['@graph'].forEach((svObj) => {
                         const { "@id": svAtId = null, variant = null } = svObj;
-                        const { display_title: variantTitle = null, genes = null } = variant || {};
+                        // console.log("svObj", svObj);
+                        const { display_title: variantTitle = null, genes = [] } = variant || {};
                         if (variantToStateIndexMap[variantTitle] != undefined) {
                             const stateIndex = variantToStateIndexMap[variantTitle];
                             newState[stateIndex]["href"] = svAtId;
@@ -578,11 +580,12 @@ class CompoundHetTableWrapper extends React.Component {
                             genes.forEach((gene) => {
                                 const {
                                     genes_most_severe_consequence = null,
-                                    genes_ensg = null
+                                    genes_most_severe_gene = null
                                 } = gene || {};
 
-                                const { "@id": geneAtId = "" } = genes_ensg;
-                                const thisGene = geneAtId.split("/")[2];
+                                const { "@id": geneAtId = "" } = genes_most_severe_gene || {};
+                                const geneSplit = geneAtId.split("/");
+                                const { 2: thisGene = null } = geneSplit || [];
 
                                 const associatedGene = variantToGeneMap[variantTitle];
                                 if (thisGene === associatedGene) {
@@ -590,10 +593,16 @@ class CompoundHetTableWrapper extends React.Component {
 
                                     newState[stateIndex]["location"] = location;
                                     newState[stateIndex]["coding_effect"] = coding_effect;
+                                } else {
+                                    newState[stateIndex]["location"] = null;
+                                    newState[stateIndex]["coding_effect"] = null;
                                 }
                             });
                         }
                     });
+                    // console.log("newState", newState);
+                    // console.log("variantToStateIndexMap", variantToStateIndexMap);
+                    // console.log("variantToGeneMap", variantToGeneMap);
 
                     // Update state with links, then go ahead and pull/populate with gene data
                     this.setState({ cmphetArr : newState });

--- a/src/encoded/static/components/item-pages/VariantSampleView/VariantSampleInfoHeader.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/VariantSampleInfoHeader.js
@@ -346,24 +346,22 @@ function GDNAList({ context }){
         // POS: pos,
         CHROM: chrom = fallbackElem,
         csq_hg19_chr = fallbackElem,
-        csq_hg19_pos = fallbackElem,
-        csq_hg19_hgvsg = fallbackElem
+        csq_hg19_pos = fallbackElem
     } = variant;
 
-    const renderedRows = [];
-
-    // Canononical GRCh38 entry
-    renderedRows.push(
+    const renderedRows =  (
         <React.Fragment>
+            {/* Canononical GRCh38 entry */}
             <div className="row pb-1 pb-md-03" key="GRCh38">
                 <div className="col-12 col-md-3 font-italic"><em>GRCh38</em></div>
                 <div className="col-12 col-md-2">{ chrom }</div>
                 <div className="col-12 col-md-7">{ hgvsg_placeholder }</div>
             </div>
+            {/* Legacy GRCh37/hg19 support. */}
             <div className="row pb-1 pb-md-03" key="GCRCh37">
                 <div className="col-12 col-md-3 font-italic"><em>GRCh37 (hg19)</em></div>
                 <div className="col-12 col-md-2 ">{ csq_hg19_chr }</div>
-                <div className="col-12 col-md-7">{ csq_hg19_hgvsg }</div>
+                <div className="col-12 col-md-7">{ csq_hg19_pos }</div>
             </div>
         </React.Fragment>
     );

--- a/src/encoded/static/components/item-pages/VariantSampleView/VariantSampleInfoHeader.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/VariantSampleInfoHeader.js
@@ -341,25 +341,36 @@ function GDNAList({ context }){
     const fallbackElem = <em data-tip="Not Available"> - </em>;
     const { variant = {} } = context;
     const {
-        mutanno_hgvsg = fallbackElem,
+        // mutanno_hgvsg = fallbackElem, // (temporarily?) removed
+        display_title: hgvsg_placeholder = fallbackElem,
         // POS: pos,
         CHROM: chrom = fallbackElem,
-        csq_hg19 = []
+        csq_hg19_chr = fallbackElem,
+        csq_hg19_pos = fallbackElem,
+        csq_hg19_hgvsg = fallbackElem
     } = variant;
 
     const renderedRows = [];
 
     // Canononical GRCh38 entry
     renderedRows.push(
-        <div className="row pb-1 pb-md-03" key="GRCh38">
-            <div className="col-12 col-md-3 font-italic"><em>GRCh38</em></div>
-            <div className="col-12 col-md-2">{ chrom }</div>
-            <div className="col-12 col-md-7">{ mutanno_hgvsg }</div>
-        </div>
+        <React.Fragment>
+            <div className="row pb-1 pb-md-03" key="GRCh38">
+                <div className="col-12 col-md-3 font-italic"><em>GRCh38</em></div>
+                <div className="col-12 col-md-2">{ chrom }</div>
+                <div className="col-12 col-md-7">{ hgvsg_placeholder }</div>
+            </div>
+            <div className="row pb-1 pb-md-03" key="GCRCh37">
+                <div className="col-12 col-md-3 font-italic"><em>GRCh37 (hg19)</em></div>
+                <div className="col-12 col-md-2 ">{ csq_hg19_chr }</div>
+                <div className="col-12 col-md-7">{ csq_hg19_hgvsg }</div>
+            </div>
+        </React.Fragment>
     );
 
-    // Legacy GRCh37/hg19 support.
-    csq_hg19.forEach(function({ csq_hg19_pos, csq_hg19_chrom, csq_hg19_hgvsg }, idx){
+    //Legacy GRCh37/hg19 support.
+    /** @DEPRECATED as of Annotations v20; leaving here since csq_hg19 may be reverted to array again in future
+     * csq_hg19.forEach(function({ csq_hg19_pos, csq_hg19_chrom, csq_hg19_hgvsg }, idx){
         renderedRows.push(
             <div className="row pb-1 pb-md-03" key={idx}>
                 <div className="col-12 col-md-3 font-italic"><em>GRCh37 (hg19)</em></div>
@@ -368,6 +379,7 @@ function GDNAList({ context }){
             </div>
         );
     });
+    */
 
     return renderedRows;
 }

--- a/src/encoded/static/components/item-pages/VariantSampleView/VariantTabBody.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/VariantTabBody.js
@@ -335,7 +335,7 @@ function PredictorsSection({ context, getTipForField, currentTranscriptIdx }){
         csq_phylop100way_vertebrate = fallbackElem,
         csq_cadd_phred = fallbackElem,
         transcript = [],
-        spliceai_maxds = fallbackElem,
+        spliceaiMaxds = fallbackElem,
         csq_primateai_score = fallbackElem,
         csq_sift_score = fallbackElem,
         csq_polyphen2_hvar_score = fallbackElem
@@ -431,7 +431,7 @@ function PredictorsSection({ context, getTipForField, currentTranscriptIdx }){
                             <td className="text-left">
                                 <label className="mb-0" data-tip={getTipForField("spliceaiMaxds")}>SpliceAI</label>
                             </td>
-                            <td className="text-left">{ spliceai_maxds }</td>
+                            <td className="text-left">{ spliceaiMaxds }</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/encoded/static/components/item-pages/VariantSampleView/VariantTabBody.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/VariantTabBody.js
@@ -119,7 +119,7 @@ const GnomADTable = React.memo(function GnomADTable({ context, getTipForField })
         'csq_gnomadg_af-xx': gnomad_af_female,
         'csq_gnomadg_af-xy': gnomad_af_male,
         // Allele Numbers
-        csq_gnomadg_af: gnomad_an,
+        csq_gnomadg_an: gnomad_an,
         'csq_gnomadg_an-xx': gnomad_an_female,
         'csq_gnomadg_an-xy': gnomad_an_male,
         // Homozygote Numbers

--- a/src/encoded/static/components/item-pages/VariantSampleView/VariantTabBody.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/VariantTabBody.js
@@ -337,7 +337,7 @@ function PredictorsSection({ context, getTipForField, currentTranscriptIdx }){
         transcript = [],
         spliceai_maxds = fallbackElem,
         csq_primateai_score = fallbackElem,
-        csq_sift = fallbackElem,
+        csq_sift_score = fallbackElem,
         csq_polyphen2_hvar_score = fallbackElem
     } = variant;
 
@@ -396,9 +396,9 @@ function PredictorsSection({ context, getTipForField, currentTranscriptIdx }){
                         </tr>
                         <tr>
                             <td className="text-left">
-                                <label className="mb-0" data-tip={getTipForField("csq_sift")}>SIFT</label>
+                                <label className="mb-0" data-tip={getTipForField("csq_sift_score")}>SIFT</label>
                             </td>
-                            <td className="text-left">{ csq_sift }</td>
+                            <td className="text-left">{ csq_sift_score }</td>
                         </tr>
                         <tr>
                             <td className="text-left">


### PR DESCRIPTION
Changelog:
- fix for comphet coding effect + location error bug
- re-add `hg19`/data type fix (array => single value on variant)
- use variant.display_title as placeholder for  `hgvsg`
- fix sift score (`csq_sift` => `csq_sift_score`)
- fix spliceAI score (`spliceai_maxds` => `spliceaiMaxds`)
- make new range facets persistent via table utils (until Q2Q ingestion implemented -- lmk if this is correct phrasing/terminology)
- regenerate schemas with new range facets
- `csq_gnomad_af` duplicate => `csq_gnomadg_an`

Notes:
- Also updated Q2Q tab of VCF Mapping Table google doc with the new facet field names and some of the missing ones for future reference
- Alex mentioned it might make sense to remove `order` and `number_step` etc, so that those values are pulled from VCF table... but may not be a problem to overwrite? Tried this out, but experienced weirdness... I'm not sure if it's from using `facs[<fieldname>].update()` or from using the `extend_variant_sample_facets` method, but it started generating `Variant.json` schemas with those range facet updates, too.

<details>
  <summary>View code that led to weirdness</summary>

  ```@staticmethod
    def extend_variant_sample_facets(facs):
        # Range facets using range aggregation_type (ranges will be defined from Q2Q tab in future)
        if 'variant.csq_gnomadg_af' in facs:
            facs['variant.csq_gnomadg_af'].update({
                "aggregation_type": "range",
                "grouping": "Population Frequency",
                "ranges": [	
                    { "from": 0, "to": 0, "label": "unobserved" }, 	
                    { "from": 0, "to": 0.001, "label": "ultra-rare" },	
                    { "from": 0.001, "to": 0.01, "label": "rare" },	
                    { "from": 0.01, "to": 1, "label": "common" }	
                ]
            })

        if 'variant.csq_gnomadg_af_popmax' in facs:
            facs['variant.csq_gnomadg_af_popmax'].update({
                "aggregation_type": "range",
                "grouping": "Population Frequency",
                "ranges": [	
                    { "from": 0, "to": 0, "label": "unobserved" }, 	
                    { "from": 0, "to": 0.001, "label": "ultra-rare" },	
                    { "from": 0.001, "to": 0.01, "label": "rare" },	
                    { "from": 0.01, "to": 1, "label": "common" }	
                ]
            })

        if 'variant.csq_phylop100way_vertebrate' in facs:
            facs['variant.csq_phylop100way_vertebrate'].update({
                "aggregation_type": "range",
                "grouping": "Effect Predictors",
                "ranges": [	
                    { "from": -20, "to": -3, "label": "strong positive selection" },	
                    { "from": -3, "to": -2, "label": "positive selection" },	
                    { "from": -2, "to": 2, "label": "low selection" },	
                    { "from": 2, "to": 3, "label": "conserved" },	
                    { "from": 3, "to": 10, "label": "highly conserved"}	
                ]
            })

        if 'FS' in facs:
            facs['FS'].update({
                "aggregation_type": "range",
                "grouping": "Variant Quality",
                "ranges": [
                    { "to": 20, "label": "Low Strand Bias (P ≥ 0.01)" },	
                    { "from": 20, "label": "High Strand Bias (P < 0.01)" }	
                ]
            })

        if 'AD_ALT' in facs:
            facs['AD_ALT'].update({
                "aggregation_type": "range",
                "grouping": "Variant Quality",
                "ranges": [	
                    { "from": 1, "to": 4, "label": "Very Low" },	
                    { "from": 5, "to": 9, "label": "Low" },	
                    { "from": 10, "to": 19, "label": "Medium" },	
                    { "from": 20, "label": "High" }	
                ]
            })
        
        if 'novoPP' in facs:
            facs['novoPP'].update({
                "aggregation_type": "range",
                "grouping": "Genotype",
                "ranges": [	
                    { "from": 0.1, "to": 0.9, "label": "de novo candidate (weak)" },	
                    { "from": 0.9, "to": 1, "label": "de novo candidate (strong)" }	
                ]
            })
```
</details>

- First 5 or so commits (everything except range facets) are currently deployed to `cgap-test` (as of: ~02/09/2021 ~12:30 pm-ish~ redeploying...)





