### PR TITLE
Submit cgap fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1437,8 +1437,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#802a3db227d420809935a5982c96548ec00eda85",
-      "from": "github:4dn-dcic/shared-portal-components#0.1.1",
+      "version": "github:4dn-dcic/shared-portal-components#e71cd58ff170b5156caf0c175dfa78f1c28d1a48",
+      "from": "github:4dn-dcic/shared-portal-components#0.1.2",
       "requires": {
         "auth0-lock": "^11.26.3",
         "aws-sdk": "^2.745.0",
@@ -2769,9 +2769,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-wjtKehFAIARq2OxK8j3JrggNlEslJfNuSm2ArteIbKyRMts2g0a7KzTxfRVNUM+O0gnBJ2hNV8nWPOYBgI1sew=="
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.1.tgz",
+      "integrity": "sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA=="
     },
     "@restart/context": {
       "version": "2.1.4",
@@ -3890,9 +3890,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.860.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.860.0.tgz",
-      "integrity": "sha512-BUBWw28PNDhRDnPEnXiPEvgTWD8Iyq5pl9lk/WhXC/vkACJ3aUVe+sicezI1/JQRjLrO3R6w7X20YknVWfAibA==",
+      "version": "2.861.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.861.0.tgz",
+      "integrity": "sha512-qb7YttyMLk0URhbNWBBZQZXDhKJy/url1GYeIlfgpQ/JQC5B2tOuJ66fPBoHyDuV6B9CQv/UorRFw1n15lvSEw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.1",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.2",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",
     "detect-browser": "^3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.3.13"
+version = "5.3.14"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/forms/ExcelSubmissionView.js
+++ b/src/encoded/static/components/forms/ExcelSubmissionView.js
@@ -35,7 +35,7 @@ export default class ExcelSubmissionView extends React.PureComponent {
             submissionItem: null,
             user: null
         };
-        console.log('excelsubmissionview props', props);
+        // console.log('excelsubmissionview props', props);
     }
 
     componentDidUpdate(pastState){
@@ -495,7 +495,7 @@ class PanelTwo extends React.PureComponent {
     onAddedFile(response){
         const json = JSON.parse(response);
         const { filename, submission_uri } = json;
-        console.log("json", json);
+        // console.log("json", json);
 
         let message = null;
         if (submission_uri) {
@@ -597,7 +597,7 @@ function CreatedItemsTable(props) {
         }
         const label = (
             <React.Fragment>
-                <a className="text-600" href={atID}>{alias}</a>
+                <a className="text-600" href={atID} target="_blank" rel="noreferrer">{alias}</a>
                 <i className="icon icon-external-link-alt fas text-smaller ml-05"></i>
             </React.Fragment>
         );
@@ -645,7 +645,7 @@ function Poller(props){
         console.log("Checking if processing status is updated.");
         ajax.promise(getURL, "GET")
             .then((response)=> {
-                console.log("response", response);
+                // console.log("response", response);
                 const {
                     processing_status : { outcome, state, progress } = {},
                     validation_errors = [],


### PR DESCRIPTION
**Changelog:**
- Open links to newly ingested items in new window by default (cgap excel submission interface, tab 2 post-success)
- Update SPC to `v0.1.2`, which updates multipart formdata ajax submission method for recent JWT updates
     - Note: Popper.js core and aws-sdk auto-updated in `package.lock` on `npm install`
- Comment out some random `console.log()`s