### PR TITLE
Samples submit bug fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.3.14"
+version = "5.3.15"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -541,6 +541,7 @@ class SubmissionMetadata:
                 # extend list field (e.g. combine samples in diff rows for Individual item)
                 elif key != 'aliases' and isinstance(value, list):
                     previous[item.alias][key].extend(value)
+                    previous[item.alias][key] = list(set(previous[item.alias][key]))
 
     def add_family_metadata(self, idx, family, individual):
         """

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -535,9 +535,12 @@ class SubmissionMetadata:
         if item.alias not in prev:
             previous[item.alias] = item.metadata
         else:
-            for key in item.metadata:
+            for key, value in item.metadata.items():
                 if key not in previous[item.alias]:
-                    previous[item.alias][key] = item.metadata[key]
+                    previous[item.alias][key] = value
+                # extend list field (e.g. combine samples in diff rows for Individual item)
+                elif key != 'aliases' and isinstance(value, list):
+                    previous[item.alias][key].extend(value)
 
     def add_family_metadata(self, idx, family, individual):
         """

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -192,7 +192,9 @@ def example_rows():
         {'individual id': '789', 'analysis id': '1111', 'relation to proband': 'father',
          'report required': 'N', 'workup type': 'WGS', 'specimen id': '3'},
         {'individual id': '456', 'analysis id': '2222', 'relation to proband': 'proband',
-         'report required': 'N', 'workup type': 'WGS', 'specimen id': '1'},
+         'report required': 'Y', 'workup type': 'WGS', 'specimen id': '1'},
+        {'individual id': '456', 'analysis id': '4444', 'relation to proband': 'proband',
+         'report required': 'Y', 'workup type': 'WES', 'specimen id': '7'},
         {'individual id': '555', 'analysis id': '3333', 'relation to proband': 'proband',
          'report required': 'Y', 'workup type': 'WES', 'specimen id': '5'},
         {'individual id': '546', 'analysis id': '3333', 'relation to proband': 'mother',
@@ -362,7 +364,7 @@ class TestSubmissionMetadata:
         """test family aliases are named after proband individual ids"""
         proj_name = project['name'] + ':'
         fams = example_rows_obj.family_dict
-        assert sorted(list(fams.keys())) == ['1111', '2222', '3333']
+        assert sorted(list(fams.keys())) == ['1111', '2222', '3333', '4444']
         assert fams['1111'] == proj_name + 'family-456'
         assert fams['2222'] == proj_name + 'family-456'
         assert fams['3333'] == proj_name + 'family-555'
@@ -480,10 +482,11 @@ class TestSubmissionMetadata:
         assert example_rows_obj.json_out
         assert len(example_rows_obj.individuals) == 5
         assert len(example_rows_obj.families) == 2
-        assert len(example_rows_obj.samples) == 5
-        assert len(example_rows_obj.sample_processings) == 3
-        assert len(example_rows_obj.cases) == 6
-        assert len(example_rows_obj.reports) == 2
+        assert len(example_rows_obj.samples) == 6
+        assert len(example_rows_obj.sample_processings) == 4
+        assert len(example_rows_obj.cases) == 7
+        assert len(example_rows_obj.reports) == 4
+        assert len(example_rows_obj.individuals['encode-project:individual-456']['samples']) == 2
 
     def test_create_json_out(self, example_rows_obj, project, institution):
         """tests that all expected items are present in final json as well as


### PR DESCRIPTION
There was an issue where if an individual had multiple samples, represented as multiple lines on the submission spreadsheet, instead of individuals being linked to both samples, one sample would overwrite the other one. This has been fixed so that the 'samples' field on Individual gets extended, and multiple samples can be linked to an individual in submit.py. 