### PR TITLE
Fix Ingestion Listener Encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "5.6.1"
+version = "5.6.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/ingestion_listener.py
+++ b/src/encoded/ingestion_listener.py
@@ -497,7 +497,9 @@ class IngestionListener:
                 reformat_vcf(reformat_args)
 
                 # Add altcounts by gene
-                formatted_with_alt_counts = tempfile.NamedTemporaryFile(mode='w+')  # cannot pass bytes to vcf.Reader()
+                # Note: you cannot pass this file object to vcf.Reader if it's in rb mode
+                # It's also not guaranteed that it reads utf-8, so pass explicitly
+                formatted_with_alt_counts = tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8')
                 alt_counts_args = {
                     'inputfile': formatted.name,
                     'outputfile': formatted_with_alt_counts.name


### PR DESCRIPTION
- Pass explicit encoding argument to file object read by `vcf.Reader`, which ignores standard encoding resolution rules.