### PR TITLE
C4-650 Support rescue_terms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.0.0"
+version = "6.1.0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/variant.json
+++ b/src/encoded/schemas/variant.json
@@ -2075,12 +2075,30 @@
         "genes.genes_most_severe_consequence.coding_effect": {
             "title": "Coding Effect",
             "order": 5,
-            "grouping": "Consequence"
+            "grouping": "Consequence",
+            "rescue_terms": [
+                "Missense",
+                "Synonymous",
+                "Frameshift",
+                "Inframe indel",
+                "Nonsense",
+                "Start lost",
+                "Stop lost"
+            ]
         },
         "genes.genes_most_severe_consequence.location": {
             "title": "Location",
             "order": 6,
-            "grouping": "Consequence"
+            "grouping": "Consequence",
+            "rescue_terms": [
+                "UTR",
+                "CDS",
+                "splice site",
+                "intron",
+                "upstream",
+                "miRNA",
+                "downstream"
+            ]
         },
         "genes.genes_most_severe_consequence.impact": {
             "title": "Impact",

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -641,12 +641,30 @@
         "variant.genes.genes_most_severe_consequence.coding_effect": {
             "title": "Coding Effect",
             "order": 5,
-            "grouping": "Consequence"
+            "grouping": "Consequence",
+            "rescue_terms": [
+                "Missense",
+                "Synonymous",
+                "Frameshift",
+                "Inframe indel",
+                "Nonsense",
+                "Start lost",
+                "Stop lost"
+            ]
         },
         "variant.genes.genes_most_severe_consequence.location": {
             "title": "Location",
             "order": 6,
-            "grouping": "Consequence"
+            "grouping": "Consequence",
+            "rescue_terms": [
+                "UTR",
+                "CDS",
+                "splice site",
+                "intron",
+                "upstream",
+                "miRNA",
+                "downstream"
+            ]
         },
         "variant.genes.genes_most_severe_consequence.impact": {
             "title": "Impact",
@@ -722,127 +740,513 @@
         "associated_genotype_labels.proband_genotype_label": {
             "title": "Proband Genotype",
             "order": 12,
-            "grouping": "Genotype"
+            "grouping": "Genotype",
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.mother_genotype_label": {
             "title": "Mother Genotype",
             "order": 13,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.father_genotype_label": {
             "title": "Father Genotype",
             "order": 14,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.co_parent_genotype_label": {
             "title": "Co-Parent Genotype",
             "order": 1000,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.sister_genotype_label": {
             "title": "Sister Genotype",
             "order": 1001,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.sister_II_genotype_label": {
             "title": "Sister II Genotype",
             "order": 1002,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.sister_III_genotype_label": {
             "title": "Sister III Genotype",
             "order": 1003,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.sister_IV_genotype_label": {
             "title": "Sister IV Genotype",
             "order": 1004,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.brother_genotype_label": {
             "title": "Brother Genotype",
             "order": 1005,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.brother_II_genotype_label": {
             "title": "Brother II Genotype",
             "order": 1006,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.brother_III_genotype_label": {
             "title": "Brother III Genotype",
             "order": 1007,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.brother_IV_genotype_label": {
             "title": "Brother IV Genotype",
             "order": 1008,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.daughter_genotype_label": {
             "title": "Daughter Genotype",
             "order": 1009,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.daughter_II_genotype_label": {
             "title": "Daughter II Genotype",
             "order": 1010,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.daughter_III_genotype_label": {
             "title": "Daughter III Genotype",
             "order": 1011,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.daughter_IV_genotype_label": {
             "title": "Daughter IV Genotype",
             "order": 1012,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.son_genotype_label": {
             "title": "Son Genotype",
             "order": 1013,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.son_II_genotype_label": {
             "title": "Son II Genotype",
             "order": 1014,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.son_III_genotype_label": {
             "title": "Son III Genotype",
             "order": 1015,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "associated_genotype_labels.son_IV_genotype_label": {
             "title": "Son IV Genotype",
             "order": 1016,
             "grouping": "Genotype",
-            "default_hidden": true
+            "default_hidden": true,
+            "rescue_terms": [
+                "Heterozygous",
+                "Homozygous reference",
+                "Heterozygous  (multiallelic in family)",
+                "Heterozygous alt/alt -  multiallelic  (multiallelic in family)",
+                "Homozygous alternate",
+                "Homozygous alternate  (multiallelic in family)",
+                "Missing",
+                "Homozygous reference  (multiallelic in family)",
+                "Hemizygous reference",
+                "False",
+                "Hemizygous alternate",
+                "Missing  (multiallelic in family)",
+                "False  (multiallelic in family)",
+                "Hemizygous alternate  (multiallelic in family)",
+                "Hemizygous reference  (multiallelic in family)",
+                "-"
+            ]
         },
         "inheritance_modes": {
             "title": "Inheritance Modes",
             "extended_description": "src/encoded/docs/extended_description_VariantSample_inheritance_mode.html",
             "order": 15,
-            "grouping": "Inheritance"
+            "grouping": "Inheritance",
+            "rescue_terms": [
+                "de novo (strong)",
+                "de novo (medium)",
+                "de novo (weak)",
+                "de novo (chrXY)",
+                "Homozygous recessive",
+                "Compound Het (Phased/strong_pair)",
+                "Compound Het (Phased/medium_pair)",
+                "Compound Het (Phased/weak_pair)",
+                "Compound Het (Unphased/strong_pair)",
+                "Compound Het (Unphased/medium_pair)",
+                "Compound Het (Unphased/weak_pair)",
+                "Loss of Heteozyogousity",
+                "Dominant (maternal)",
+                "Dominant (paternal)",
+                "X-linked recessive (Maternal)",
+                "X-linked dominant (Maternal)",
+                "X-linked dominant (Paternal)",
+                "Y-linked dominant",
+                "Low relevance, homozygous in a parent",
+                "Low relevance, multiallelic site family",
+                "Low relevance, present in both parent(s)",
+                "Low relevance, missing call(s) in family",
+                "Low relevance, mismatching chrXY genotype(s)",
+                "Low relevance, other"
+            ]
         },
         "novoPP": {
             "title": "novoCaller PP",

--- a/src/encoded/search/lucene_builder.py
+++ b/src/encoded/search/lucene_builder.py
@@ -691,10 +691,6 @@ class LuceneBuilder:
                                 cls._check_and_remove_match_from_should(inner_inner_bool[SHOULD], facet_filters,
                                                                         active_filter,
                                                                         query_field, filter_type)
-                        else:
-                            search_log(log_handler=log,
-                                       msg=('Encountered a unexpected nested structure at second level: %s'
-                                            % nested_sub_query[BOOL]))
 
                     # For structure like this:
                     #   {'bool': {'must': {'bool': {'should':

--- a/src/encoded/search/search.py
+++ b/src/encoded/search/search.py
@@ -54,9 +54,10 @@ class SearchBuilder:
         API itself. Search is by far our most complicated API, thus there is a lot of state.
     """
     DEFAULT_SEARCH_FRAME = 'embedded'
-    DEFAULT_HIDDEN = 'default_hidden'
-    ADDITIONAL_FACETS = 'additional_facet'
-    DEBUG = 'debug'
+    DEFAULT_HIDDEN = 'default_hidden'  # facet is hidden by default
+    ADDITIONAL_FACETS = 'additional_facet'  # specifies an aggregation to compute in addition
+    RESCUE_TERMS = 'rescue_terms'  # special facet field that contains terms that should always have buckets
+    DEBUG = 'debug'  # search debug parameter
     MISSING = object()
 
     def __init__(self, context, request, search_type=None, return_generator=False, forced_type='Search',
@@ -875,6 +876,15 @@ class SearchBuilder:
                     for bucket in extract_buckets(source_aggregation['primary_agg']):
                         if bucket['key'] not in term_to_bucket:
                             term_to_bucket[bucket['key']] = bucket
+
+                    # bring in rescue terms
+                    if self.RESCUE_TERMS in facet:
+                        for rescue_term in facet[self.RESCUE_TERMS]:
+                            if rescue_term not in term_to_bucket:
+                                term_to_bucket[rescue_term] = {
+                                    'key': rescue_term,
+                                    'doc_count': 0
+                                }
 
                     result_facet['terms'] = list(term_to_bucket.values())
 

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -13,8 +13,6 @@ from snovault.elasticsearch.indexer_utils import get_namespaced_index
 from snovault.schema_utils import load_schema
 from snovault.util import add_default_embeds
 from webtest import AppError
-from ..commands.run_upgrader_on_inserts import get_inserts
-from ..search import lucene_builder
 from ..search.lucene_builder import LuceneBuilder
 from ..search.search_utils import find_nested_path
 
@@ -958,6 +956,10 @@ class TestNestedSearch(object):
         facets_that_shows_limited_options = es_testapp.get(
             '/search/?type=Variant&hg19.hg19_pos=11780388').json['facets']
         self.verify_facet(facets_that_shows_limited_options, 'hg19.hg19_hgvsg', 1)  # reduced to only 1 option
+
+        # rescue terms show up (7 terms + no value, see variant.json -> facets)
+        self.verify_facet(facets, 'genes.genes_most_severe_consequence.coding_effect', 8)
+        self.verify_facet(facets, 'genes.genes_most_severe_consequence.location', 8)
 
     def test_search_nested_exists_query(self, workbook, es_testapp):
         """ Tests doing a !=No+value search on a nested sub-field. """


### PR DESCRIPTION
- Adds support for `rescue_terms`, allowing us to specify terms on the facet schema that should always show up in the facets (even if they have 0 count in the search result set).
- Adds `rescue_terms` to several fields on variant/variant_sample.
- Remove erroneous debug statement.
- Add small test (as critical code here is fairly straightforward).
- NOTE: requires change in SPC: https://github.com/4dn-dcic/shared-portal-components/blob/master/src/components/browse/components/FacetList/FacetTermsList.js#L67-L72