### PR TITLE
Proper domain when unset cookie re: expired session

### DIFF
--- a/src/encoded/authentication.py
+++ b/src/encoded/authentication.py
@@ -322,8 +322,6 @@ def login(context, request):
     # however login is only triggered through AJAX so we can depend on request.referrer here,
     # and have it serve as minor layer of obfuscation.
 
-    print("TTT", request.referrer, referrer_domain, request.domain)
-
     if not referrer_domain or referrer_domain != request.domain:
         raise HTTPForbidden("Expected a valid referrer domain")
 

--- a/src/encoded/authentication.py
+++ b/src/encoded/authentication.py
@@ -313,14 +313,16 @@ def login(context, request):
     if request_token is None:
         request_token = request.json_body.get("id_token", None)
 
-    request_parts = urlparse(request.referrer)
+    referrer_parts = urlparse(request.referrer)
     # These should be equal; sometimes referrer request header may not be present
-    referrer_domain = request_parts.hostname
-    is_https = request_parts.scheme == "https"
+    referrer_domain = referrer_parts.hostname
+    is_https = referrer_parts.scheme == "https"
 
     # `request.domain` is more consistently-present than request.referrer
     # however login is only triggered through AJAX so we can depend on request.referrer here,
     # and have it serve as minor layer of obfuscation.
+
+    print("TTT", request.referrer, referrer_domain, request.domain)
 
     if not referrer_domain or referrer_domain != request.domain:
         raise HTTPForbidden("Expected a valid referrer domain")
@@ -511,14 +513,14 @@ def impersonate_user(context, request):
 	)
 
     # Better place to get this maybe?
-    request_parts = urlparse(request.referrer)
-    request_domain = request_parts.hostname
-    is_https = request_parts.scheme == "https"
+    referrer_parts = urlparse(request.referrer)
+    referrer_domain = referrer_parts.hostname
+    is_https = referrer_parts.scheme == "https"
 
     request.response.set_cookie(
         "jwtToken",
         value=id_token.decode('utf-8'),
-        domain=request_domain,
+        domain=referrer_domain,
         path="/",
         httponly=True,
         samesite="strict",

--- a/src/encoded/authentication.py
+++ b/src/encoded/authentication.py
@@ -313,21 +313,13 @@ def login(context, request):
     if request_token is None:
         request_token = request.json_body.get("id_token", None)
 
-    app_url_parts = urlparse(request.application_url)
-    app_domain = app_url_parts.hostname
-    is_https = app_url_parts.scheme == "https"
 
-    # `request.domain` is more consistently-present than request.referrer
-    # however login is only triggered through AJAX so we can depend on request.referrer here,
-    # and have it serve as minor layer of obfuscation.
-
-    if not app_domain or app_domain != request.domain:
-        raise HTTPForbidden("Expected a valid origin")
+    is_https = request.scheme == "https"
 
     request.response.set_cookie(
         "jwtToken",
         value=request_token,
-        domain=app_domain,
+        domain=request.domain,
         path="/",
         httponly=True,
         samesite="strict",
@@ -509,18 +501,12 @@ def impersonate_user(context, request):
         algorithm=JWT_ENCODING_ALGORITHM
 	)
 
-
-    app_url_parts = urlparse(request.application_url)
-    app_domain = app_url_parts.hostname
-    is_https = app_url_parts.scheme == "https"
-
-    if not app_domain or app_domain != request.domain:
-        raise HTTPForbidden("Expected a valid origin")
+    is_https = request.scheme == "https"
 
     request.response.set_cookie(
         "jwtToken",
         value=id_token.decode('utf-8'),
-        domain=app_domain,
+        domain=request.domain,
         path="/",
         httponly=True,
         samesite="strict",

--- a/src/encoded/renderers.py
+++ b/src/encoded/renderers.py
@@ -169,15 +169,17 @@ def security_tween_factory(handler, registry):
                 # Especially for initial document requests by browser, but also desired for AJAX and other requests,
                 # unset jwtToken cookie so initial client-side React render has App(instance).state.session = false
                 # to be synced w/ server-side
-                request_parts = urlparse(request.referrer)
-                request_domain = request_parts.hostname
+
                 response.set_cookie(
                     name='jwtToken',
                     value=None,
-                    domain=request_domain,
+                    domain=request.domain,
                     max_age=0,
-                    path='/'
-                )  # = Same as response.delete_cookie(..)
+                    path='/',
+                    overwrite=True
+                )
+
+                # = Same as response.delete_cookie(..)
                 response.status_code = 401
                 response.headers['WWW-Authenticate'] = (
                     "Bearer realm=\"{}\", title=\"Session Expired\"; Basic realm=\"{}\""

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -32,10 +32,6 @@ README:
 """
 
 
-TEST_HTTP_HOST = "mytestingwebsite.somewhere.example.com"
-
-
-
 @pytest.fixture(autouse=True)
 def autouse_external_tx(external_tx):
     pass
@@ -195,8 +191,7 @@ def root(registry):
 def anontestapp(app):
     """TestApp for anonymous user (i.e., no user specified), accepting JSON data."""
     environ = {
-        'HTTP_ACCEPT': "application/json",
-        'HTTP_HOST': TEST_HTTP_HOST
+        'HTTP_ACCEPT': "application/json"
     }
     return webtest.TestApp(app, environ)
 
@@ -205,8 +200,7 @@ def anontestapp(app):
 def anonhtmltestapp(app):
     """TestApp for anonymous (not logged in) user, accepting text/html content."""
     environ = {
-        'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TEST_HTTP_HOST
+        'HTTP_ACCEPT': 'text/html'
     }
     test_app = webtest.TestApp(app, environ)
     return test_app
@@ -216,8 +210,7 @@ def anonhtmltestapp(app):
 def anon_es_testapp(es_app):
     """ TestApp simulating a bare Request entering the application (with ES enabled) """
     environ = {
-        'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST
+        'HTTP_ACCEPT': 'application/json'
     }
     return webtest.TestApp(es_app, environ)
 
@@ -226,8 +219,7 @@ def anon_es_testapp(es_app):
 def anon_html_es_testapp(es_app):
     """TestApp with ES + Postgres for anonymous (not logged in) user, accepting text/html content."""
     environ = {
-        'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TEST_HTTP_HOST
+        'HTTP_ACCEPT': 'text/html'
     }
     return webtest.TestApp(es_app, environ)
 
@@ -237,7 +229,6 @@ def testapp(app):
     """TestApp for username TEST, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'TEST'
     }
     return webtest.TestApp(app, environ)
@@ -248,7 +239,6 @@ def htmltestapp(app):
     """TestApp for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'TEST',
     }
     test_app = webtest.TestApp(app, environ)
@@ -260,7 +250,6 @@ def es_testapp(es_app):
     """ TestApp with ES + Postgres. Must be imported where it is needed. """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -271,7 +260,6 @@ def html_es_testapp(es_app):
     """TestApp with ES + Postgres for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -282,7 +270,6 @@ def authenticated_testapp(app):
     """TestApp for an authenticated, non-admin user (TEST_AUTHENTICATED), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(app, environ)
@@ -293,7 +280,6 @@ def authenticated_es_testapp(es_app):
     """ TestApp for authenticated non-admin user with ES """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(es_app, environ)
@@ -304,7 +290,6 @@ def submitter_testapp(app):
     """TestApp for a non-admin user (TEST_SUBMITTER), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'TEST_SUBMITTER',
     }
     return webtest.TestApp(app, environ)
@@ -316,7 +301,6 @@ def indexer_testapp(es_app):
         Always uses the ES app (obviously, but not so obvious previously) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'INDEXER',
     }
     return webtest.TestApp(es_app, environ)
@@ -327,7 +311,6 @@ def embed_testapp(app):
     """TestApp for user EMBED, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
         'REMOTE_USER': 'EMBED',
     }
     return webtest.TestApp(app, environ)

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -32,6 +32,9 @@ README:
 """
 
 
+TESTING_DOMAIN_REFERRER = "mytestingwebsite.somewhere.example.com"
+
+
 @pytest.fixture(autouse=True)
 def autouse_external_tx(external_tx):
     pass
@@ -192,7 +195,8 @@ def anontestapp(app):
     """TestApp for anonymous user (i.e., no user specified), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': "application/json",
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
     }
     return webtest.TestApp(app, environ)
 
@@ -202,7 +206,8 @@ def anonhtmltestapp(app):
     """TestApp for anonymous (not logged in) user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
     }
     test_app = webtest.TestApp(app, environ)
     return test_app
@@ -213,7 +218,8 @@ def anon_es_testapp(es_app):
     """ TestApp simulating a bare Request entering the application (with ES enabled) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
     }
     return webtest.TestApp(es_app, environ)
 
@@ -223,7 +229,8 @@ def anon_html_es_testapp(es_app):
     """TestApp with ES + Postgres for anonymous (not logged in) user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
     }
     return webtest.TestApp(es_app, environ)
 
@@ -233,7 +240,8 @@ def testapp(app):
     """TestApp for username TEST, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'TEST'
     }
     return webtest.TestApp(app, environ)
@@ -244,7 +252,8 @@ def htmltestapp(app):
     """TestApp for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'TEST',
     }
     test_app = webtest.TestApp(app, environ)
@@ -256,7 +265,8 @@ def es_testapp(es_app):
     """ TestApp with ES + Postgres. Must be imported where it is needed. """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -267,7 +277,8 @@ def html_es_testapp(es_app):
     """TestApp with ES + Postgres for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -278,7 +289,8 @@ def authenticated_testapp(app):
     """TestApp for an authenticated, non-admin user (TEST_AUTHENTICATED), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(app, environ)
@@ -289,7 +301,8 @@ def authenticated_es_testapp(es_app):
     """ TestApp for authenticated non-admin user with ES """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(es_app, environ)
@@ -300,7 +313,8 @@ def submitter_testapp(app):
     """TestApp for a non-admin user (TEST_SUBMITTER), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'TEST_SUBMITTER',
     }
     return webtest.TestApp(app, environ)
@@ -312,7 +326,8 @@ def indexer_testapp(es_app):
         Always uses the ES app (obviously, but not so obvious previously) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'INDEXER',
     }
     return webtest.TestApp(es_app, environ)
@@ -323,7 +338,8 @@ def embed_testapp(app):
     """TestApp for user EMBED, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
+        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
         'REMOTE_USER': 'EMBED',
     }
     return webtest.TestApp(app, environ)

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -212,7 +212,7 @@ def anonhtmltestapp(app):
 def anon_es_testapp(es_app):
     """ TestApp simulating a bare Request entering the application (with ES enabled) """
     environ = {
-        'HTTP_ACCEPT': 'application/json',,
+        'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
     }
     return webtest.TestApp(es_app, environ)

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -33,7 +33,6 @@ README:
 
 
 TEST_HTTP_HOST = "mytestingwebsite.somewhere.example.com"
-TEST_HTTP_REFERER = "https://" + TEST_HTTP_HOST
 
 
 
@@ -197,8 +196,7 @@ def anontestapp(app):
     """TestApp for anonymous user (i.e., no user specified), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': "application/json",
-        'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER
+        'HTTP_HOST': TEST_HTTP_HOST
     }
     return webtest.TestApp(app, environ)
 
@@ -208,8 +206,7 @@ def anonhtmltestapp(app):
     """TestApp for anonymous (not logged in) user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER
+        'HTTP_HOST': TEST_HTTP_HOST
     }
     test_app = webtest.TestApp(app, environ)
     return test_app
@@ -220,8 +217,7 @@ def anon_es_testapp(es_app):
     """ TestApp simulating a bare Request entering the application (with ES enabled) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER
+        'HTTP_HOST': TEST_HTTP_HOST
     }
     return webtest.TestApp(es_app, environ)
 
@@ -231,8 +227,7 @@ def anon_html_es_testapp(es_app):
     """TestApp with ES + Postgres for anonymous (not logged in) user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER
+        'HTTP_HOST': TEST_HTTP_HOST
     }
     return webtest.TestApp(es_app, environ)
 
@@ -243,7 +238,6 @@ def testapp(app):
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST'
     }
     return webtest.TestApp(app, environ)
@@ -255,7 +249,6 @@ def htmltestapp(app):
     environ = {
         'HTTP_ACCEPT': 'text/html',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST',
     }
     test_app = webtest.TestApp(app, environ)
@@ -268,7 +261,6 @@ def es_testapp(es_app):
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -280,7 +272,6 @@ def html_es_testapp(es_app):
     environ = {
         'HTTP_ACCEPT': 'text/html',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -292,7 +283,6 @@ def authenticated_testapp(app):
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(app, environ)
@@ -304,7 +294,6 @@ def authenticated_es_testapp(es_app):
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(es_app, environ)
@@ -316,7 +305,6 @@ def submitter_testapp(app):
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST_SUBMITTER',
     }
     return webtest.TestApp(app, environ)
@@ -329,7 +317,6 @@ def indexer_testapp(es_app):
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'INDEXER',
     }
     return webtest.TestApp(es_app, environ)
@@ -341,7 +328,6 @@ def embed_testapp(app):
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'HTTP_HOST': TEST_HTTP_HOST,
-        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'EMBED',
     }
     return webtest.TestApp(app, environ)

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -32,7 +32,9 @@ README:
 """
 
 
-TESTING_DOMAIN_REFERRER = "mytestingwebsite.somewhere.example.com"
+TEST_HTTP_HOST = "mytestingwebsite.somewhere.example.com"
+TEST_HTTP_REFERER = "https://" + TEST_HTTP_HOST
+
 
 
 @pytest.fixture(autouse=True)
@@ -195,8 +197,8 @@ def anontestapp(app):
     """TestApp for anonymous user (i.e., no user specified), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': "application/json",
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER
     }
     return webtest.TestApp(app, environ)
 
@@ -206,8 +208,8 @@ def anonhtmltestapp(app):
     """TestApp for anonymous (not logged in) user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER
     }
     test_app = webtest.TestApp(app, environ)
     return test_app
@@ -218,8 +220,8 @@ def anon_es_testapp(es_app):
     """ TestApp simulating a bare Request entering the application (with ES enabled) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER
     }
     return webtest.TestApp(es_app, environ)
 
@@ -229,8 +231,8 @@ def anon_html_es_testapp(es_app):
     """TestApp with ES + Postgres for anonymous (not logged in) user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER
     }
     return webtest.TestApp(es_app, environ)
 
@@ -240,8 +242,8 @@ def testapp(app):
     """TestApp for username TEST, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST'
     }
     return webtest.TestApp(app, environ)
@@ -252,8 +254,8 @@ def htmltestapp(app):
     """TestApp for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST',
     }
     test_app = webtest.TestApp(app, environ)
@@ -265,8 +267,8 @@ def es_testapp(es_app):
     """ TestApp with ES + Postgres. Must be imported where it is needed. """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -277,8 +279,8 @@ def html_es_testapp(es_app):
     """TestApp with ES + Postgres for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -289,8 +291,8 @@ def authenticated_testapp(app):
     """TestApp for an authenticated, non-admin user (TEST_AUTHENTICATED), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(app, environ)
@@ -301,8 +303,8 @@ def authenticated_es_testapp(es_app):
     """ TestApp for authenticated non-admin user with ES """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(es_app, environ)
@@ -313,8 +315,8 @@ def submitter_testapp(app):
     """TestApp for a non-admin user (TEST_SUBMITTER), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'TEST_SUBMITTER',
     }
     return webtest.TestApp(app, environ)
@@ -326,8 +328,8 @@ def indexer_testapp(es_app):
         Always uses the ES app (obviously, but not so obvious previously) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'INDEXER',
     }
     return webtest.TestApp(es_app, environ)
@@ -338,8 +340,8 @@ def embed_testapp(app):
     """TestApp for user EMBED, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'HTTP_HOST': TESTING_DOMAIN_REFERRER,
-        'HTTP_REFERER': TESTING_DOMAIN_REFERRER,
+        'HTTP_HOST': TEST_HTTP_HOST,
+        'HTTP_REFERER': TEST_HTTP_REFERER,
         'REMOTE_USER': 'EMBED',
     }
     return webtest.TestApp(app, environ)

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -244,7 +244,7 @@ def htmltestapp(app):
     """TestApp for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
-        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'TEST',
     }
     test_app = webtest.TestApp(app, environ)

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -191,7 +191,8 @@ def root(registry):
 def anontestapp(app):
     """TestApp for anonymous user (i.e., no user specified), accepting JSON data."""
     environ = {
-        'HTTP_ACCEPT': 'application/json',
+        'HTTP_ACCEPT': "application/json",
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
     }
     return webtest.TestApp(app, environ)
 
@@ -200,7 +201,8 @@ def anontestapp(app):
 def anonhtmltestapp(app):
     """TestApp for anonymous (not logged in) user, accepting text/html content."""
     environ = {
-        'HTTP_ACCEPT': 'text/html'
+        'HTTP_ACCEPT': 'text/html',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
     }
     test_app = webtest.TestApp(app, environ)
     return test_app
@@ -210,7 +212,8 @@ def anonhtmltestapp(app):
 def anon_es_testapp(es_app):
     """ TestApp simulating a bare Request entering the application (with ES enabled) """
     environ = {
-        'HTTP_ACCEPT': 'application/json',
+        'HTTP_ACCEPT': 'application/json',,
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
     }
     return webtest.TestApp(es_app, environ)
 
@@ -219,7 +222,8 @@ def anon_es_testapp(es_app):
 def anon_html_es_testapp(es_app):
     """TestApp with ES + Postgres for anonymous (not logged in) user, accepting text/html content."""
     environ = {
-        'HTTP_ACCEPT': 'text/html'
+        'HTTP_ACCEPT': 'text/html',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
     }
     return webtest.TestApp(es_app, environ)
 
@@ -229,7 +233,8 @@ def testapp(app):
     """TestApp for username TEST, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
-        'REMOTE_USER': 'TEST',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
+        'REMOTE_USER': 'TEST'
     }
     return webtest.TestApp(app, environ)
 
@@ -239,6 +244,7 @@ def htmltestapp(app):
     """TestApp for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com"
         'REMOTE_USER': 'TEST',
     }
     test_app = webtest.TestApp(app, environ)
@@ -250,6 +256,7 @@ def es_testapp(es_app):
     """ TestApp with ES + Postgres. Must be imported where it is needed. """
     environ = {
         'HTTP_ACCEPT': 'application/json',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -260,6 +267,7 @@ def html_es_testapp(es_app):
     """TestApp with ES + Postgres for TEST user, accepting text/html content."""
     environ = {
         'HTTP_ACCEPT': 'text/html',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'TEST',
     }
     return webtest.TestApp(es_app, environ)
@@ -270,6 +278,7 @@ def authenticated_testapp(app):
     """TestApp for an authenticated, non-admin user (TEST_AUTHENTICATED), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(app, environ)
@@ -280,6 +289,7 @@ def authenticated_es_testapp(es_app):
     """ TestApp for authenticated non-admin user with ES """
     environ = {
         'HTTP_ACCEPT': 'application/json',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'TEST_AUTHENTICATED',
     }
     return webtest.TestApp(es_app, environ)
@@ -290,6 +300,7 @@ def submitter_testapp(app):
     """TestApp for a non-admin user (TEST_SUBMITTER), accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'TEST_SUBMITTER',
     }
     return webtest.TestApp(app, environ)
@@ -301,6 +312,7 @@ def indexer_testapp(es_app):
         Always uses the ES app (obviously, but not so obvious previously) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'INDEXER',
     }
     return webtest.TestApp(es_app, environ)
@@ -311,6 +323,7 @@ def embed_testapp(app):
     """TestApp for user EMBED, accepting JSON data."""
     environ = {
         'HTTP_ACCEPT': 'application/json',
+        'HTTP_HOST': "mytestingwebsite.somewhere.example.com",
         'REMOTE_USER': 'EMBED',
     }
     return webtest.TestApp(app, environ)


### PR DESCRIPTION
Has been tested on fourfront-cgaptest

Related to https://github.com/4dn-dcic/fourfront/pull/1486

For ordinary page requests from browser (non-AJAX), `request.referrer` is not present and hostname/`request_domain` is "None". When no explicit domain supplied upon ~~logout~~ session/token expiration (nor overwrite=True), the cookie is duplicated for sometimes-different domain (maybe prepends ".", making cookie applicable for subdomains of current domain) and doesn't log out user correctly.

On top of ensuring we passing in request.domain as cookie domain to overwrite/unset in renderer.py (primary edit), we also check now that request.referrer (or referer *) domain is present and matches request.domain for login requests (as an extra check, though not entirely necessary probably).