### PR TITLE
Pre may2021 demo embed fixes

### DIFF
--- a/src/encoded/static/components/item-pages/CaseView/FilteringTableFilterSetUI.js
+++ b/src/encoded/static/components/item-pages/CaseView/FilteringTableFilterSetUI.js
@@ -1060,7 +1060,7 @@ function AddToVariantSampleListButton(props){
             // patch existing
             const {
                 "@id": vslAtID,
-                variant_samples: existingVariantSampleSelections
+                variant_samples: existingVariantSampleSelections = []
             } = variantSampleListItem;
 
             const patchVSLPayload = { "variant_samples": [ ...existingVariantSampleSelections ] };

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -506,11 +506,16 @@ class VariantSampleList(Item):
     item_type = 'variant_sample_list'
     schema = load_schema('encoded:schemas/variant_sample_list.json')
     embedded_list = [
-        'variant_samples.variant_sample_item.*',
+        'variant_samples.filter_blocks_request_at_time_of_selection',
+        'variant_samples.date_selected',
+        'variant_samples.variant_sample_item.variant.display_title',
         'variant_samples.variant_sample_item.variant.genes.genes_most_severe_gene.display_title',
         'variant_samples.variant_sample_item.variant.genes.genes_most_severe_transcript',
         'variant_samples.variant_sample_item.variant.genes.genes_most_severe_hgvsc',
-        'variant_samples.variant_sample_item.variant.genes.genes_most_severe_hgvsp'
+        'variant_samples.variant_sample_item.variant.genes.genes_most_severe_hgvsp',
+        'variant_samples.variant_sample_item.associated_genotype_labels.proband_genotype_label',
+        'variant_samples.variant_sample_item.associated_genotype_labels.mother_genotype_label',
+        'variant_samples.variant_sample_item.associated_genotype_labels.father_genotype_label'
     ]
 
 

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -506,8 +506,6 @@ class VariantSampleList(Item):
     item_type = 'variant_sample_list'
     schema = load_schema('encoded:schemas/variant_sample_list.json')
     embedded_list = [
-        'variant_samples.filter_blocks_request_at_time_of_selection',
-        'variant_samples.date_selected',
         'variant_samples.variant_sample_item.variant.display_title',
         'variant_samples.variant_sample_item.variant.genes.genes_most_severe_gene.display_title',
         'variant_samples.variant_sample_item.variant.genes.genes_most_severe_transcript',


### PR DESCRIPTION
- Replaced `variant_samples.variant_sample_item.*` with more specific embeds for variant display titles and genotype labels
- Fix for broken add to selection button when `variantSampleList.variant_samples` is null/undefined