### PR TITLE
Discovery enum change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.3.1"
+version = "6.3.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/note_discovery.json
+++ b/src/encoded/schemas/note_discovery.json
@@ -51,18 +51,10 @@
             "description": "Candidacy level for Gene Discovery",
             "type": "string",
             "enum": [
-                "Tier 1 - Novel gene and phenotype",
-                "Tier 1 - Novel gene for known phenotype",
-                "Tier 1 - Phenotype expansion",
-                "Tier 1 - Phenotype not delineated",
-                "Tier 1 - Novel mode of inheritance",
-                "Tier 1 - Known gene, new phenotype",
-                "Tier 2 - Novel gene and phenotype",
-                "Tier 2 - Novel gene for known phenotype",
-                "Tier 2 - Phenotype expansion",
-                "Tier 2 - Phenotype not delineated",
-                "Tier 2 - Known gene, new phenotype",
-                "Known gene for phenotype"
+                "Strong candidate",
+                "Moderate candidate",
+                "Weak candidate",
+                "Not a candidate"
             ]
         },
         "variant_candidacy": {

--- a/src/encoded/schemas/note_interpretation.json
+++ b/src/encoded/schemas/note_interpretation.json
@@ -51,11 +51,11 @@
             "description": "Significance classification indicated by this note",
             "type": "string",
             "enum": [
-                "benign",
-                "likely benign",
+                "Benign",
+                "Likely Benign",
                 "VUS",
-                "likely pathogenic",
-                "pathogenic"
+                "Likely Pathogenic",
+                "Pathogenic"
             ]
         },
         "acmg_guidelines": {

--- a/src/encoded/schemas/note_interpretation.json
+++ b/src/encoded/schemas/note_interpretation.json
@@ -52,9 +52,9 @@
             "type": "string",
             "enum": [
                 "Benign",
-                "Likely Benign",
-                "VUS",
-                "Likely Pathogenic",
+                "Likely benign",
+                "Uncertain significance",
+                "Likely pathogenic",
                 "Pathogenic"
             ]
         },

--- a/src/encoded/tests/data/workbook-inserts/note_interpretation.json
+++ b/src/encoded/tests/data/workbook-inserts/note_interpretation.json
@@ -6,7 +6,7 @@
     "note_text": "This variant has been reported in the ClinVar database as Unknown Significance.",
     "conclusion": "For this reason, the variant has been classified as VUS.",
     "status": "in review",
-    "classification": "VUS",
+    "classification": "Uncertain significance",
     "version": 2,
     "previous_note": "de5e1c12-4c88-4a3e-a306-d37a12defa6b"
   },
@@ -17,6 +17,6 @@
     "note_text": "This variant has not been reported in the ClinVar database.",
     "conclusion": "For this reason, the variant has been classified as VUS.",
     "status": "in review",
-    "classification": "VUS"
+    "classification": "Uncertain significance"
   }
 ]

--- a/src/encoded/tests/test_types_note.py
+++ b/src/encoded/tests/test_types_note.py
@@ -13,7 +13,7 @@ def new_interpretation():
         "institution": "hms-dbmi",
         "note_text": "This variant is reported in the ClinVar database as associated with Syndrome X.",
         "conclusion": "For this reason, the variant has been classified as likely pathogenic.",
-        "classification": "Likely Pathogenic"
+        "classification": "Likely pathogenic"
     }
 
 

--- a/src/encoded/tests/test_types_note.py
+++ b/src/encoded/tests/test_types_note.py
@@ -77,7 +77,7 @@ def test_add_note_interpretation_success(workbook, es_testapp, new_interpretatio
 
 def test_add_note_interpretation_fail(workbook, es_testapp, new_interpretation):
     """ test NoteInterpretation item fails to post when schema isn't followed """
-    new_interpretation['classification'] = 'Likely Pathogenic'  # wrong case for enum
+    new_interpretation['classification'] = 'likely pathogenic'  # wrong case for enum
     post_note(es_testapp, new_interpretation, expected_status=422)
 
 def test_patch_note_interpretation_success(workbook, es_testapp, new_interpretation):

--- a/src/encoded/tests/test_types_note.py
+++ b/src/encoded/tests/test_types_note.py
@@ -13,7 +13,7 @@ def new_interpretation():
         "institution": "hms-dbmi",
         "note_text": "This variant is reported in the ClinVar database as associated with Syndrome X.",
         "conclusion": "For this reason, the variant has been classified as likely pathogenic.",
-        "classification": "likely pathogenic"
+        "classification": "Likely Pathogenic"
     }
 
 


### PR DESCRIPTION
In this PR:
- `gene_candidacy` enum in NoteDiscovery schema changed from Tier system to just strong, moderate, weak, not
- ACMG classification enum in NoteInterpretation schema changed to be capitalized
- relevant unit tests edited