### PR TITLE
show submission help links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.4.0"
+version = "6.4.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/forms/ExcelSubmissionView.js
+++ b/src/encoded/static/components/forms/ExcelSubmissionView.js
@@ -555,9 +555,11 @@ class PanelTwo extends React.PureComponent {
                     <h4 className="text-300 mt-2">
                         Attach a file to this IngestionSubmission
                     </h4>
-                    {/* <div className="mt-1">
-                        Click <a href="/help/uploading_cohort" target="_blank" rel="noreferrer">here</a> for more on how to format your document.
-                    </div> */}
+                    <div className="mt-1">
+                        { ingestionType === "genelist" ?
+                            <>Click <a href="/help/submission/gene-lists" target="_blank" rel="noreferrer">here</a> for more on how to format your genelist submission document.</>
+                            : <>Click <a href="/help/submission/accessioning" target="_blank" rel="noreferrer">here</a> for more on how to format your accession submission document.</>}
+                    </div>
                     <hr className="mb-1"/>
                     <div className="field-section mt-2">
                         <label className="d-block mb-05">


### PR DESCRIPTION
Changelog:
- Re-added link to help documents to IngestionSubmission wizard. If "accessioning" was selected in the first panel, links to the accessioning doc. If "gene list", links to the gene list doc.

Notes: Since this is a really small PR and Alex is out for a few days, figure you two can approve it.

Short demo (sorry I have a billion tabs open/slow loading)
![alt text](https://i.gyazo.com/6c0acfc85149a188b7e809ffa1380392.gif)