### PR TITLE
Fix variant_update endpoint's search limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.4.2"
+version = "6.4.3"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.4.0"
+version = "6.4.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.4.1"
+version = "6.4.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submit_genelist.py
+++ b/src/encoded/submit_genelist.py
@@ -768,7 +768,7 @@ class CommonUtils:
         fields=[],
     ):
         """
-        Performs get requests in batches to decrease the number of
+        Performs search requests in batches to decrease the number of
         API calls and capture all search results (as default behavior
         of vapp.get("/search/") is to return only first 25 items).
 

--- a/src/encoded/submit_genelist.py
+++ b/src/encoded/submit_genelist.py
@@ -721,6 +721,7 @@ class VariantUpdateSubmission:
             self.vapp,
             item_type="VariantSample",
             project=self.project,
+            batch_size=3,
         )
         for variant_sample_response in variant_sample_search:
             variant_samples_to_invalidate.append(

--- a/src/encoded/submit_genelist.py
+++ b/src/encoded/submit_genelist.py
@@ -68,9 +68,7 @@ class GeneListSubmission:
     Class to handle processing of submitted gene list.
     """
 
-    def __init__(
-        self, filename, project, institution, vapp, validate_only=False
-    ):
+    def __init__(self, filename, project, institution, vapp, validate_only=False):
         self.filename = filename
         self.project = project
         self.institution = institution
@@ -110,9 +108,7 @@ class GeneListSubmission:
                 title_line = line
                 title_idx = title_line.lower().index("title")
                 title_line = title_line[title_idx + 5:]
-                title_line = title_line.translate(
-                    {ord(i): None for i in ':;"\n"'}
-                )
+                title_line = title_line.translate({ord(i): None for i in ':;"\n"'})
                 title = title_line.strip()
                 if title == "":
                     title = None
@@ -239,14 +235,10 @@ class GeneListSubmission:
             for response in ensgid_search:
                 if response["gene_symbol"] in gene_ids:
                     gene_ids[response["gene_symbol"]].append(response["uuid"])
-                    gene_ensgids[response["gene_symbol"]].append(
-                        response["ensgid"]
-                    )
+                    gene_ensgids[response["gene_symbol"]].append(response["ensgid"])
                 else:
                     gene_ids[response["gene_symbol"]] = [response["uuid"]]
-                    gene_ensgids[response["gene_symbol"]] = [
-                        response["ensgid"]
-                    ]
+                    gene_ensgids[response["gene_symbol"]] = [response["ensgid"]]
                 ensgids.remove(response["ensgid"])
             if ensgids:
                 unmatched_genes_without_options += ensgids
@@ -264,20 +256,18 @@ class GeneListSubmission:
                 if not non_ensgids:
                     break
                 search = CommonUtils.batch_search(
-                    self.vapp, non_ensgids, search_type, batch_size=10,
+                    self.vapp,
+                    non_ensgids,
+                    search_type,
+                    batch_size=10,
                 )
                 for response in search:
                     if (
                         response["gene_symbol"] in gene_ids
-                        and response["uuid"]
-                        not in gene_ids[response["gene_symbol"]]
+                        and response["uuid"] not in gene_ids[response["gene_symbol"]]
                     ):
-                        gene_ids[response["gene_symbol"]].append(
-                            response["uuid"]
-                        )
-                        gene_ensgids[response["gene_symbol"]].append(
-                            response["ensgid"]
-                        )
+                        gene_ids[response["gene_symbol"]].append(response["uuid"])
+                        gene_ensgids[response["gene_symbol"]].append(response["ensgid"])
                         responsible_gene = response[search_type]
                         if type(response[search_type]) is list:
                             for item in response[search_type]:
@@ -285,14 +275,11 @@ class GeneListSubmission:
                                     responsible_gene = item
                                     break
                         self.notes.append(
-                            "Note: gene %s refers to multiple genes "
-                            "in our database, including genes with "
-                            "the following Ensembl IDs: %s. If you "
-                            "would prefer to "
-                            "only include one of these genes in this "
-                            "gene list, please resubmit and replace "
-                            "the gene %s with one of "
-                            "the Ensembl IDs above."
+                            "Note: gene %s refers to multiple genes in our database,"
+                            " including genes with the following Ensembl IDs: %s."
+                            " If you would prefer to only include one of these genes"
+                            " in this gene list, please resubmit and replace the"
+                            " gene %s with one of the Ensembl IDs above."
                             % (
                                 responsible_gene,
                                 ", ".join(gene_ensgids[responsible_gene]),
@@ -302,9 +289,7 @@ class GeneListSubmission:
                         continue
                     else:
                         gene_ids[response["gene_symbol"]] = [response["uuid"]]
-                        gene_ensgids[response["gene_symbol"]] = [
-                            response["ensgid"]
-                        ]
+                        gene_ensgids[response["gene_symbol"]] = [response["ensgid"]]
                     if type(response[search_type]) is str:
                         non_ensgids.remove(response[search_type])
                     elif type(response[search_type]) is list:
@@ -315,9 +300,9 @@ class GeneListSubmission:
         if non_ensgids:
             for gene in non_ensgids:
                 try:
-                    response = self.vapp.get(
-                        "/search/?type=Gene&q=" + gene
-                    ).json["@graph"]
+                    response = self.vapp.get("/search/?type=Gene&q=" + gene).json[
+                        "@graph"
+                    ]
                     options = [option["gene_symbol"] for option in response]
                     self.errors.append(
                         "No perfect match found for gene %s. "
@@ -343,8 +328,8 @@ class GeneListSubmission:
         Creates gene list and document bodies for posting.
 
         Returns:
-            - List of bodies to post: [document, gene list] (None if no matched
-              genes)
+            - List of bodies to post: [document, gene list]
+              (None if no matched genes)
         """
 
         if not self.gene_ids:
@@ -363,7 +348,8 @@ class GeneListSubmission:
                 "download": self.title.replace(" ", "_") + "_genelist." + extension,
                 "type": content_type,
                 "href": (
-                    "data:%s;base64,%s" % (
+                    "data:%s;base64,%s"
+                    % (
                         content_type,
                         b64encode(stream.read()).decode("ascii"),
                     )
@@ -376,7 +362,8 @@ class GeneListSubmission:
         }
         genelist_post_body = {
             "title": (
-                self.title + " (%s)" % len(self.gene_ids) if self.title
+                self.title + " (%s)" % len(self.gene_ids)
+                if self.title
                 else "Stand in title"
             ),
             "institution": self.institution,
@@ -416,7 +403,12 @@ class GeneListSubmission:
             try:
                 fields = ["title", "uuid", "genes.uuid"]
                 project_genelists = CommonUtils.batch_search(
-                    self.vapp, project_list, "project.%40id", item_type="GeneList", institution=self.institution, fields=fields
+                    self.vapp,
+                    project_list,
+                    "project.%40id",
+                    item_type="GeneList",
+                    institution=self.institution,
+                    fields=fields,
                 )
                 project_titles = [x["title"] for x in project_genelists]
                 for previous_title in project_titles:
@@ -428,9 +420,7 @@ class GeneListSubmission:
                     if self.title == previous_title:
                         genelist_idx = project_titles.index(genelist_title)
                         genelist_uuid = project_genelists[genelist_idx]["uuid"]
-                        genelist_gene_uuids = project_genelists[genelist_idx][
-                            "genes"
-                        ]
+                        genelist_gene_uuids = project_genelists[genelist_idx]["genes"]
                         previous_genelist_gene_ids += [
                             gene["uuid"] for gene in genelist_gene_uuids
                         ]
@@ -440,7 +430,12 @@ class GeneListSubmission:
         try:
             fields = ["display_title", "uuid"]
             project_documents = CommonUtils.batch_search(
-                self.vapp, project_list, "project.%40id", item_type="Document", institution=self.institution, fields=fields
+                self.vapp,
+                project_list,
+                "project.%40id",
+                item_type="Document",
+                institution=self.institution,
+                fields=fields,
             )
             project_docs = [
                 x["display_title"].replace(".txt", "").replace(".xlsx", "")
@@ -510,9 +505,7 @@ class GeneListSubmission:
                 {"attachment": document_json["attachment"]},
             ).json
         else:
-            document_post = self.vapp.post_json(
-                "/Document/", document_json
-            ).json
+            document_post = self.vapp.post_json("/Document/", document_json).json
         post_result["Document"] = (
             "posted with uuid " + document_post["@graph"][0]["uuid"]
         )
@@ -528,9 +521,7 @@ class GeneListSubmission:
                     },
                 ).json
             else:
-                genelist_post = self.vapp.post_json(
-                    "/GeneList/", genelist_json
-                ).json
+                genelist_post = self.vapp.post_json("/GeneList/", genelist_json).json
             post_result["Gene list"] = (
                 "posted with uuid " + genelist_post["@graph"][0]["uuid"]
             )
@@ -650,9 +641,7 @@ class VariantUpdateSubmission:
     list of gene uuids.
     """
 
-    def __init__(
-        self, filename, project, institution, vapp, validate_only=False
-    ):
+    def __init__(self, filename, project, institution, vapp, validate_only=False):
         self.filename = filename
         self.project = project
         self.institution = institution
@@ -666,8 +655,8 @@ class VariantUpdateSubmission:
 
     def genes_from_file(self):
         """
-        Extracts gene uuids from input file. Expects gene uuids to be separated
-        by '\n'.
+        Extracts gene uuids from input file. Expects gene uuids
+        to be separated by '\n'.
 
         Returns:
             - List of gene uuids
@@ -690,7 +679,7 @@ class VariantUpdateSubmission:
 
         Returns:
             - List of unique variant sample uuids (None if no gene
-            uuids)
+              uuids)
         """
         if not self.gene_uuids:
             return None
@@ -706,12 +695,10 @@ class VariantUpdateSubmission:
             "variant.genes.genes_most_severe_gene.uuid",
             item_type="VariantSample",
             project=project,
-            fields=["uuid"]
+            fields=["uuid"],
         )
         for variant_sample_response in variant_sample_search:
-            variant_samples_to_invalidate.append(
-                variant_sample_response["uuid"]
-            )
+            variant_samples_to_invalidate.append(variant_sample_response["uuid"])
         to_invalidate = list(set(variant_samples_to_invalidate))
         return to_invalidate
 
@@ -730,9 +717,7 @@ class VariantUpdateSubmission:
             return validate_output
         not_validated = []
         for uuid in self.variant_samples:
-            validate_response = self.vapp.patch_json(
-                "/" + uuid + "?validate_only", {}
-            )
+            validate_response = self.vapp.patch_json("/" + uuid + "?validate_only", {})
             if validate_response.json["status"] != "success":
                 not_validated.append(uuid)
         if not_validated:
@@ -780,11 +765,12 @@ class CommonUtils:
         item_type="Gene",
         project=None,
         institution=None,
-        fields=[]
+        fields=[],
     ):
         """
         Performs get requests in batches to decrease the number of
-        API calls and improve performance.
+        API calls and capture all search results (as default behavior
+        of vapp.get("/search/") is to return only first 25 items).
 
         Returns:
             - List of all items found by search
@@ -794,8 +780,6 @@ class CommonUtils:
         flat_result = []
         search_size = 100
         add_ons = ""
-        import pdb
-        pdb.set_trace()
         if project:
             add_ons += "&project.%40id=" + project.replace("/", "%2F")
         if institution:
@@ -814,7 +798,7 @@ class CommonUtils:
                 new_search = True
                 while new_search:
                     limit = str(search_size)
-                    from_index = str(search_size*count)
+                    from_index = str(search_size * count)
                     limit_add_on = "&from=" + from_index + "&limit=" + limit
                     search_string = base_search + batch_string + limit_add_on
                     try:

--- a/src/encoded/tests/data/workbook-inserts/project.json
+++ b/src/encoded/tests/data/workbook-inserts/project.json
@@ -5,5 +5,12 @@
         "description": "This is a test project",
         "status": "current",
         "name": "hms-dbmi"
+    },
+    {
+        "title": "Core Project",
+        "uuid": "98c17432-1541-eb5c-4af5-65c7ab00e621",
+        "description": "This is another test project",
+        "status": "current",
+        "name": "cgap-core"
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/variant_sample.json
+++ b/src/encoded/tests/data/workbook-inserts/variant_sample.json
@@ -6,5 +6,13 @@
         "file": "SomeFile",
         "CALL_INFO": "SomeString",
         "uuid": "11bff838-99af-4936-a0ae-4dfc63ba8bf4"
+    },
+    {
+        "project": "cgap-core",
+        "institution": "hms-dbmi",
+        "variant": "cedff838-99af-4936-a0ae-4dfc63ba8bf4",
+        "file": "AnotherFile",
+        "CALL_INFO": "SomeString",
+        "uuid": "421d9db2-b98a-4e8c-9b0f-addb6bdb0b15"
     }
 ]

--- a/src/encoded/tests/test_submit_genelist.py
+++ b/src/encoded/tests/test_submit_genelist.py
@@ -294,6 +294,6 @@ def test_batch_search(es_testapp, wb_project, wb_institution):
         project=project,
         fields=fields,
     )
-    assert len(response) > 30
+    assert len(response) > 25
     for idx in range(len(response)):
         assert response[idx]["project"]["@id"] == project

--- a/src/encoded/tests/test_submit_genelist.py
+++ b/src/encoded/tests/test_submit_genelist.py
@@ -89,7 +89,7 @@ class TestGeneListSubmission:
         identifiable in the database.
         """
         genelist = GeneListSubmission(
-            "src/encoded/tests/data/documents/gene_lists/" "test-parse_gene_list.txt",
+            "src/encoded/tests/data/documents/gene_lists/test-parse_gene_list.txt",
             wb_project["@id"],
             wb_institution["@id"],
             es_testapp,
@@ -110,7 +110,7 @@ class TestGeneListSubmission:
         Tests for detection of empty gene list and no title.
         """
         genelist = GeneListSubmission(
-            "src/encoded/tests/data/documents/gene_lists/" "test-empty_gene_list.txt",
+            "src/encoded/tests/data/documents/gene_lists/test-empty_gene_list.txt",
             wb_project["@id"],
             wb_institution["@id"],
             es_testapp,
@@ -127,7 +127,7 @@ class TestGeneListSubmission:
         given an excel gene list.
         """
         genelist = GeneListSubmission(
-            "src/encoded/tests/data/documents/gene_lists/" "test_empty_gene_list.xlsx",
+            "src/encoded/tests/data/documents/gene_lists/test_empty_gene_list.xlsx",
             wb_project["@id"],
             wb_institution["@id"],
             es_testapp,
@@ -144,7 +144,7 @@ class TestGeneListSubmission:
         different names.
         """
         genelist = GeneListSubmission(
-            "src/encoded/tests/data/documents/gene_lists/" "test-match_gene_list.txt",
+            "src/encoded/tests/data/documents/gene_lists/test-match_gene_list.txt",
             wb_project["@id"],
             wb_institution["@id"],
             es_testapp,
@@ -158,8 +158,7 @@ class TestGeneListSubmission:
         posting should occur in this scenario.
         """
         genelist = GeneListSubmission(
-            "src/encoded/tests/data/documents/gene_lists/"
-            "test-no-match_gene_list.txt",
+            "src/encoded/tests/data/documents/gene_lists/test-no-match_gene_list.txt",
             wb_project["@id"],
             wb_institution["@id"],
             es_testapp,
@@ -174,8 +173,7 @@ class TestGeneListSubmission:
         when some genes are not identified in the database.
         """
         genelist = GeneListSubmission(
-            "src/encoded/tests/data/documents/gene_lists/"
-            "test-no-match_gene_list.txt",
+            "src/encoded/tests/data/documents/gene_lists/test-no-match_gene_list.txt",
             wb_project["@id"],
             wb_institution["@id"],
             es_testapp,
@@ -204,7 +202,7 @@ class TestGeneListSubmission:
         Test for correct parsing of excel-formatted gene list.
         """
         genelist = GeneListSubmission(
-            "src/encoded/tests/data/documents/gene_lists/" "test-match_gene_list.xlsx",
+            "src/encoded/tests/data/documents/gene_lists/test-match_gene_list.xlsx",
             wb_project["@id"],
             wb_institution["@id"],
             es_testapp,
@@ -318,4 +316,5 @@ def test_batch_search(es_testapp, wb_project, wb_institution):
     )
     assert len(response) > 25
     for idx in range(len(response)):
+        assert "uuid" in response[idx]
         assert response[idx]["project"]["@id"] == project

--- a/src/encoded/tests/test_types_filter_set.py
+++ b/src/encoded/tests/test_types_filter_set.py
@@ -46,7 +46,7 @@ def test_filter_set_barebones(workbook, es_testapp, barebones_filter_set):
         ],
         'search_type': 'Project'  # NOTE: will work since we are not actually validating this
     }).json['@graph']
-    assert len(compound_search_res) == 1
+    assert len(compound_search_res) == 2
 
     # do it again, this time with a type that will return 404
     es_testapp.post_json(COMPOUND_SEARCH_URL, {
@@ -109,7 +109,7 @@ def test_filter_set_simple(workbook, es_testapp, simple_filter_set):
         ],
         'search_type': 'Project'
     }).json['@graph']
-    assert len(compound_search_res) == 1
+    assert len(compound_search_res) == 2
 
     # execute the same search using filter_blocks and flags
     compound_search_res = es_testapp.post_json(COMPOUND_SEARCH_URL, {


### PR DESCRIPTION
During Wednesday's all-hands meeting, I noticed Joel submitted a gene list but a variant sample was not updated; in fact, many variant samples were being missed in the `variant_update` ingestion submission. After a good deal of digging, this turned out to be the result of an unknown, to me at least, limitation of VirtualApp GET requests with searches such that only 25 results are returned by default. 

This PR fixes the issue by paginating the `batch_search` method in chunks of 100 items until all items have been received.

Additionally, some light refactoring of the endpoint and the `genelist` ingestion submission was done to:
-  broaden the scope of the `batch_search` method so other search requests won't be limited to 25 items
-  queue variant samples in a project-specific manner to reduce indexing load with gene list submission.