### PR TITLE
Change 'strict'->'Lax' to auth on linked-to pages

### DIFF
--- a/src/encoded/authentication.py
+++ b/src/encoded/authentication.py
@@ -322,7 +322,9 @@ def login(context, request):
         domain=request.domain,
         path="/",
         httponly=True,
-        samesite="strict",
+        # 'Lax' is default and fine esp. with secure cookies; 'strict' prevents user-clicked links/redirects from being authenticated.
+        # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+        samesite="Lax",
         overwrite=True,
         secure=is_https
     )


### PR DESCRIPTION
We noticed that when click on a link to go to CGAP URL, then always appear as logged-out until we refresh the page. Traced the issue down to being due to 'strict' samesite cookie policy, which prevents sending of the cookie if user is navigating in from a different domain/origin (such as ..slack.com). Changed to 'Lax', which should be fine and still secure against CSRF requests... AFAICT. [More details from MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).