### PR TITLE
Uppercase cram

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.8.3"
+version = "6.8.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -431,7 +431,7 @@ class AccessionRow:
         valid_extensions = {
             '.fastq.gz': ('fastq', 'reads'),
             '.fq.gz': ('fastq', 'reads'),
-            '.cram': ('cram', 'alignments'),
+            '.cram': ('CRAM', 'alignments'),
             '.vcf.gz': ('vcf_gz', 'raw VCF')
         }
         files = {'file_fastq': {}, 'file_processed': {}, 'errors': []}
@@ -468,7 +468,7 @@ class AccessionRow:
                         ]
                 self.files_fastq.append(MetadataItem(file_info, self.row, 'file_fastq'))
             else:
-                if fmt == 'cram':
+                if fmt == 'CRAM':
                     self.sample.metadata.setdefault('cram_files', []).append(file_alias)
                 else:
                     self.sample.metadata.setdefault('processed_files', []).append(file_alias)


### PR DESCRIPTION
Changes references to the `.cram` file format in `submit.py` from `cram` to `CRAM` to match the FileFormat item on prod.

Note that `CRAM` is the only uppercased FileFormat item - I don't think this is terribly consistent, but this PR can be merged if changing lines in Foursight or workflows etc is too much of a pain.