### PR TITLE
Proband inheritance facet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.8.6"
+version = "6.8.7"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.8.7"
+version = "6.8.8"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
@@ -1,6 +1,6 @@
 
 
-<h5>Inheritance mode values are candidate labels based on novocaller, comhet caller, or GATK genotype assignments.</h5>
+<h5>Inheritance mode values are candidate labels based on novocaller, Cmp-Het caller, or GATK genotype assignments.</h5>
 
 
 <p><b>de novo calls:</b></p>

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
@@ -27,8 +27,8 @@
 <p><b>Compound Heterozygous calls</b>:</p>
 <ul>
 <li> Two heterozygous variants are classified as Compound Heterozygous candidates if they are on the same gene.
-<li>  Phasing: Two variants are classified as <b>Phased</b> if the pair of variants are confirmed to be coming from the two parents. (Mother: 0/1, Father: 0/0, Child 0/1) and (Mother: 0/0, Father: 0/1, Child 0/1). Other Compound Heterozygous candidates are classified as <b>Unphased</b>.
-<li> <b>Variant severity</b>: A variant is considered severe if it has a SpliceAI Delta Score >0.8 (S), or has a Clinvar interpretation of Pathogenic or Likely Pathogenic (C), or it has a HIGH or MODERATE Impact rating (Splice acceptor variant, Splice donor variant, Stop gained, Frameshift variant, Stop lost, Start lost, Transcript amplification, Inframe insertion, Inframe deletion, Missense, variant, Protein altering variant).
+<li>  Phasing: Two variants are classified as <b>Phased</b> if the pair of variants are confirmed to be coming from the two parents ([Mother: 0/1, Father: 0/0, Child 0/1] and [Mother: 0/0, Father: 0/1, Child 0/1]). Other Compound Heterozygous candidates are classified as <b>Unphased</b>.
+<li> <b>Variant severity</b>: A variant is considered severe if it has a SpliceAI Delta Score >0.8 (S); a Clinvar interpretation of Pathogenic or Likely Pathogenic (C); or a HIGH or MODERATE Impact rating (Splice acceptor variant, Splice donor variant, Stop gained, Frameshift variant, Stop lost, Start lost, Transcript amplification, Inframe insertion, Inframe deletion, Missense variant, Protein altering variant).
 <li> Pair strength: Compound Heterozygous pairs are classified based on the severity of the two variants (HIGH, MODERATE, S, or C).
 <ul>
 <li> <b>strong pair</b>: both variants are one of (HIGH, MODERATE, S, or C).
@@ -40,6 +40,6 @@
 
 <p><b>Low relevance</b>: </p>
 <ul>
-<li> Variants on multiallelic sites (e.g, G, T, A in different individuals) are not assigned inheritance mode values, except possibly compound heterozygous.
+<li> Variants on multiallelic sites (e.g. G, T, A in different individuals) are not assigned inheritance mode values, except possibly compound heterozygous.
 <li> Variants with missing calls (./.) or calls that mismatch the sex (0/1 on chrX for a male) are not assigned inheritance mode values.
 <li> Variants with genotypes that do not meet any of the high relevant criteria above are not assigned GATK-based labels.

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
@@ -1,0 +1,32 @@
+
+
+<h5>Inheritance mode values are candidate labels based on novocaller, comhet caller, or GATK genotype assignments.</h5>
+
+<p>This case is labeled as proband-only. Since no other family members are in the analysis, most of the traditional inheritance modes can not be assigned. <b>Inheritance modes that can NOT be assigned on this case include:</b></p>
+<ul><li> de novo calls
+<li> Dominant (Maternal) vs Dominant (Paternal) vs Recessive
+<li> Loss of Heterozygosity
+<li> Phased Compound Heterozygous calls
+</ul>
+
+<p>Variants on the X or Y chromosome are still classified <b>X-linked</b> or <b>Y-linked</b>, even though they can't be called as dominant or recessive or de novo.</p>
+
+<p><b>Compound Heterozygous calls</b>:</p>
+<ul>
+<li> Two heterozygous variants are classified as Compound Heterozygous candidates if they are on the same gene.
+<li> Phasing: This case will only have <b>Unphased</b> Compound Heterozygous candidates, as mother and father genotypes are required to classify a variant as <b>Phased</b> (Mother: 0/1, Father: 0/0, Child 0/1) and (Mother: 0/0, Father: 0/1, Child 0/1). 
+<li> <b>Variant severity</b>: A variant is considered severe if it has a SpliceAI Delta Score >0.8 (S), or has a Clinvar interpretation of Pathogenic or Likely Pathogenic (C), or it has a HIGH or MODERATE Impact rating (Splice acceptor variant, Splice donor variant, Stop gained, Frameshift variant, Stop lost, Start lost, Transcript amplification, Inframe insertion, Inframe deletion, Missense, variant, Protein altering variant).
+<li> Pair strength: Compound Heterozygous pairs are classified based on the severity of the two variants (HIGH, MODERATE, S, or C).
+<ul>
+<li> <b>strong pair</b>: both variants are one of (HIGH, MODERATE, S, or C).
+<li> <b>medium pair</b>: one of the variants are one of (HIGH, MODERATE, S, or C).
+<li> <b>weak pair</b>: neither of the variants are (HIGH, MODERATE, S, or C).
+</ul>
+<li> See Documentation for Details.
+</ul>
+
+<p><b>Low relevance</b>: </p>
+<ul>
+<li> Variants on multiallelic sites (e.g, G, T, A in different individuals) are not assigned inheritance mode values, except possibly compound heterozygous.
+<li> Variants with missing calls (./.) or calls that mismatch the sex (0/1 on chrX for a male) are not assigned inheritance mode values.
+<li> Variants with genotypes that do not meet any of the high relevant criteria above are not assigned GATK-based labels.

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
@@ -9,13 +9,13 @@
 <li> Phased Compound Heterozygous calls
 </ul>
 
-<p>Variants on the X or Y chromosome are still classified <b>X-linked</b> or <b>Y-linked</b>, even though they can't be called as dominant or recessive or de novo.</p>
+<p>Variants on the X or Y chromosome are still classified <b>X-linked</b> or <b>Y-linked</b>, even though they can't be called as dominant, recessive, or de novo.</p>
 
 <p><b>Compound Heterozygous calls</b>:</p>
 <ul>
 <li> Two heterozygous variants are classified as Compound Heterozygous candidates if they are on the same gene.
-<li> Phasing: This case will only have <b>Unphased</b> Compound Heterozygous candidates, as mother and father genotypes are required to classify a variant as <b>Phased</b> (Mother: 0/1, Father: 0/0, Child 0/1) and (Mother: 0/0, Father: 0/1, Child 0/1).
-<li> <b>Variant severity</b>: A variant is considered severe if it has a SpliceAI Delta Score >0.8 (S), or has a Clinvar interpretation of Pathogenic or Likely Pathogenic (C), or it has a HIGH or MODERATE Impact rating (Splice acceptor variant, Splice donor variant, Stop gained, Frameshift variant, Stop lost, Start lost, Transcript amplification, Inframe insertion, Inframe deletion, Missense, variant, Protein altering variant).
+<li> Phasing: This case will only have <b>Unphased</b> Compound Heterozygous candidates, as mother and father genotypes are required to classify a variant as <b>Phased</b> ([Mother: 0/1, Father: 0/0, Child 0/1] and [Mother: 0/0, Father: 0/1, Child 0/1] for the pair).
+<li> <b>Variant severity</b>: A variant is considered severe if it has a SpliceAI Delta Score >0.8 (S); a Clinvar interpretation of Pathogenic or Likely Pathogenic (C); or a HIGH or MODERATE Impact rating (Splice acceptor variant, Splice donor variant, Stop gained, Frameshift variant, Stop lost, Start lost, Transcript amplification, Inframe insertion, Inframe deletion, Missense variant, Protein altering variant).
 <li> Pair strength: Compound Heterozygous pairs are classified based on the severity of the two variants (HIGH, MODERATE, S, or C).
 <ul>
 <li> <b>strong pair</b>: both variants are one of (HIGH, MODERATE, S, or C).
@@ -27,6 +27,6 @@
 
 <p><b>Low relevance</b>: </p>
 <ul>
-<li> Variants on multiallelic sites (e.g, G, T, A in different individuals) are not assigned inheritance mode values, except possibly compound heterozygous.
+<li> Variants on multiallelic sites (e.g. G, T, A in different individuals) are not assigned inheritance mode values, except possibly compound heterozygous.
 <li> Variants with missing calls (./.) or calls that mismatch the sex (0/1 on chrX for a male) are not assigned inheritance mode values.
 <li> Variants with genotypes that do not meet any of the high relevant criteria above are not assigned GATK-based labels.

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
@@ -1,6 +1,6 @@
 
 
-<h5>Inheritance mode values are candidate labels based on novocaller, comhet caller, or GATK genotype assignments.</h5>
+<h5>Inheritance mode values are candidate labels based on novocaller, Cmp-Het caller, or GATK genotype assignments.</h5>
 
 <p>This case is labeled as proband-only. Since no other family members are in the analysis, most of the traditional inheritance modes can not be assigned. <b>Inheritance modes that can NOT be assigned on this case include:</b></p>
 <ul><li> de novo calls
@@ -14,7 +14,7 @@
 <p><b>Compound Heterozygous calls</b>:</p>
 <ul>
 <li> Two heterozygous variants are classified as Compound Heterozygous candidates if they are on the same gene.
-<li> Phasing: This case will only have <b>Unphased</b> Compound Heterozygous candidates, as mother and father genotypes are required to classify a variant as <b>Phased</b> (Mother: 0/1, Father: 0/0, Child 0/1) and (Mother: 0/0, Father: 0/1, Child 0/1). 
+<li> Phasing: This case will only have <b>Unphased</b> Compound Heterozygous candidates, as mother and father genotypes are required to classify a variant as <b>Phased</b> (Mother: 0/1, Father: 0/0, Child 0/1) and (Mother: 0/0, Father: 0/1, Child 0/1).
 <li> <b>Variant severity</b>: A variant is considered severe if it has a SpliceAI Delta Score >0.8 (S), or has a Clinvar interpretation of Pathogenic or Likely Pathogenic (C), or it has a HIGH or MODERATE Impact rating (Splice acceptor variant, Splice donor variant, Stop gained, Frameshift variant, Stop lost, Start lost, Transcript amplification, Inframe insertion, Inframe deletion, Missense, variant, Protein altering variant).
 <li> Pair strength: Compound Heterozygous pairs are classified based on the severity of the two variants (HIGH, MODERATE, S, or C).
 <ul>

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -1236,6 +1236,7 @@
             "extended_description": "src/encoded/docs/extended_description_VariantSample_inheritance_mode.html",
             "order": 15,
             "grouping": "Inheritance",
+            "default_hidden": true,
             "rescue_terms": [
                 "de novo (strong)",
                 "de novo (medium)",
@@ -1261,6 +1262,20 @@
                 "Low relevance, missing call(s) in family",
                 "Low relevance, mismatching chrXY genotype(s)",
                 "Low relevance, other"
+            ]
+        },
+        "proband_only_inheritance_modes": {
+            "title": "Inheritance Modes",
+            "extended_description": "src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html",
+            "order": 15,
+            "grouping": "Inheritance",
+            "default_hidden": true,
+            "rescue_terms": [
+                "Compound Het (Unphased/strong_pair)",
+                "Compound Het (Unphased/medium_pair)",
+                "Compound Het (Unphased/weak_pair)",
+                "X-linked",
+                "Y-linked"
             ]
         },
         "novoPP": {

--- a/src/encoded/tests/test_types_case.py
+++ b/src/encoded/tests/test_types_case.py
@@ -121,13 +121,13 @@ def new_case(testapp, project, institution, fam, new_sample_processing):
     return data
 
 
-@pytest.mark.parametrize('num_samples, analysis_type', [
-    (1, 'WGS'),  # proband only
-    (2, 'WGS-Group'),  # proband and father
-    (3, 'WES-Trio'),  # proband, father, mother
-    (4, 'WES-Group')])  # proband, father, mother, brother
+@pytest.mark.parametrize('num_samples, analysis_type, proband_only', [
+    (1, 'WGS', True),  # proband only
+    (2, 'WGS-Group', False),  # proband and father
+    (3, 'WES-Trio', False),  # proband, father, mother
+    (4, 'WES-Group', False)])  # proband, father, mother, brother
 def test_case_additional_facets(testapp, project, institution, new_case,
-                                new_sample_processing, num_samples, analysis_type):
+                                new_sample_processing, num_samples, analysis_type, proband_only):
     """
     tests that additional facets are added to initial_search_href_filter_addon calc prop as appropriate:
     none for proband only, mother and father genotype labels for trio, mother/father/sibling
@@ -149,6 +149,12 @@ def test_case_additional_facets(testapp, project, institution, new_case,
             # genotype labels for this relation should NOT be an additional facet in this prop
             assert (f'associated_genotype_labels.{relation}_genotype_label'
                     not in case['additional_variant_sample_facets'])
+    if proband_only:
+        assert 'proband_only_inheritance_modes' in case['additional_variant_sample_facets']
+        assert 'inheritance_modes' not in case['additional_variant_sample_facets']
+    else:
+        assert 'proband_only_inheritance_modes' not in case['additional_variant_sample_facets']
+        assert 'inheritance_modes' in case['additional_variant_sample_facets']
 
 
 def test_case_proband_case(testapp, proband_case, mother_case):

--- a/src/encoded/types/case.py
+++ b/src/encoded/types/case.py
@@ -441,16 +441,20 @@ class Case(Item):
         fields = [facet for facet in extra_variant_sample_facets]
         sp_item = get_item_or_none(request, sample_processing, 'sample_processing')
         analysis_type = sp_item.get('analysis_type')
-        if analysis_type and (analysis_type.endswith('-Trio') or analysis_type.endswith('-Group')):
-            included_relations = [item.get('relationship') for item in sp_item.get('samples_pedigree', [{}])]
-            for relation in ['mother', 'father', 'sister', 'brother', 'co-parent',
-                            'daughter', 'son', 'daughter II', 'son II',
-                            'daughter III', 'son III', 'sister II',
-                            'sister III', 'sister IV', 'brother II',
-                            'brother III', 'brother IV']:
-                if relation in included_relations:
-                    relation = relation.replace(' ', '_').replace('-', '_')
-                    fields.append(f'associated_genotype_labels.{relation}_genotype_label')
+        if analysis_type:
+            if (analysis_type.endswith('-Trio') or analysis_type.endswith('-Group')):
+                fields.append('inheritance_modes')
+                included_relations = [item.get('relationship') for item in sp_item.get('samples_pedigree', [{}])]
+                for relation in ['mother', 'father', 'sister', 'brother', 'co-parent',
+                                'daughter', 'son', 'daughter II', 'son II',
+                                'daughter III', 'son III', 'sister II',
+                                'sister III', 'sister IV', 'brother II',
+                                'brother III', 'brother IV']:
+                    if relation in included_relations:
+                        relation = relation.replace(' ', '_').replace('-', '_')
+                        fields.append(f'associated_genotype_labels.{relation}_genotype_label')
+            else:
+                fields.append('proband_only_inheritance_modes')
         return fields
 
     @calculated_property(schema={

--- a/src/encoded/types/case.py
+++ b/src/encoded/types/case.py
@@ -453,7 +453,7 @@ class Case(Item):
                     if relation in included_relations:
                         relation = relation.replace(' ', '_').replace('-', '_')
                         fields.append(f'associated_genotype_labels.{relation}_genotype_label')
-            else:
+            elif analysis_type in ['WGS', 'WES']:  # proband-only analysis types 
                 fields.append('proband_only_inheritance_modes')
         return fields
 

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -270,15 +270,20 @@ class VariantSample(Item):
             InheritanceMode.INHMODE_LABEL_X_LINKED_RECESSIVE_MOTHER: 15,  # X-linked recessive (Maternal)
             InheritanceMode.INHMODE_LABEL_X_LINKED_DOMINANT_MOTHER: 16,  # X-linked dominant (Maternal)
             InheritanceMode.INHMODE_LABEL_X_LINKED_DOMINANT_FATHER: 17,  # X-linked dominant (Paternal)
-            'X-linked': 17,
             InheritanceMode.INHMODE_LABEL_Y_LINKED: 18,  # Y-linked dominant
-            'Y-linked': 18,
             InheritanceMode.INHMODE_LABEL_NONE_HOMOZYGOUS_PARENT: 19,  # Low relevance, homozygous in a parent
             InheritanceMode.INHMODE_LABEL_NONE_MN: 20,  # Low relevance, multiallelic site family
             InheritanceMode.INHMODE_LABEL_NONE_BOTH_PARENTS: 21,  # Low relevance, present in both parent(s)
             InheritanceMode.INHMODE_LABEL_NONE_DOT: 22,  # Low relevance, missing call(s) in family
             InheritanceMode.INHMODE_LABEL_NONE_SEX_INCONSISTENT: 23,  # Low relevance, mismatching chrXY genotype(s)
             '_default': 1000  # arbitrary large number
+        },
+        'proband_only_inheritance_modes': {
+            'Compound Het (Unphased/strong_pair)': 1,
+            'Compound Het (Unphased/medium_pair)': 2,
+            'Compound Het (Unphased/weak_pair)': 3,
+            'X-linked': 4,
+            'Y-linked': 5
         }
     }
 

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -24,6 +24,14 @@ log = structlog.getLogger(__name__)
 ANNOTATION_ID = 'annotation_id'
 ANNOTATION_ID_SEP = '_'
 
+# Compound Het constants
+CMPHET_PHASED_STRONG = 'Compound Het (Phased/strong_pair)'
+CMPHET_PHASED_MED = 'Compound Het (Phased/medium_pair)'
+CMPHET_PHASED_WEAK = 'Compound Het (Phased/weak_pair)'
+CMPHET_UNPHASED_STRONG = 'Compound Het (Unphased/strong_pair)'
+CMPHET_UNPHASED_MED = 'Compound Het (Unphased/medium_pair)'
+CMPHET_UNPHASED_WEAK = 'Compound Het (Unphased/weak_pair)'
+
 
 def extend_embedded_list(embedded_list, fd, typ, prefix=None):
     """ Extends the given embedded list with embeds from fd. Helper method for
@@ -258,12 +266,12 @@ class VariantSample(Item):
             InheritanceMode.INHMODE_LABEL_DE_NOVO_WEAK: 3,  # de novo (weak)
             InheritanceMode.INHMODE_LABEL_DE_NOVO_CHRXY: 4,  # de novo (chrXY) XXX: no GATK?
             InheritanceMode.INHMODE_LABEL_RECESSIVE: 5,  # Recessive
-            'Compound Het (Phased/strong_pair)': 6,  # cmphet all auto-generated, see compute_cmphet_inheritance_modes
-            'Compound Het (Phased/medium_pair)': 7,
-            'Compound Het (Phased/weak_pair)': 8,
-            'Compound Het (Unphased/strong_pair)': 9,
-            'Compound Het (Unphased/medium_pair)': 10,
-            'Compound Het (Unphased/weak_pair)': 11,
+            CMPHET_PHASED_STRONG: 6,  # cmphet all auto-generated, see compute_cmphet_inheritance_modes
+            CMPHET_PHASED_MED: 7,
+            CMPHET_PHASED_WEAK: 8,
+            CMPHET_UNPHASED_STRONG: 9,
+            CMPHET_UNPHASED_MED: 10,
+            CMPHET_UNPHASED_WEAK: 11,
             InheritanceMode.INHMODE_LABEL_LOH: 12,  # Loss of Heterozygousity
             InheritanceMode.INHMODE_DOMINANT_MOTHER: 13,  # Dominant (maternal)
             InheritanceMode.INHMODE_DOMINANT_FATHER: 14,  # Dominant (paternal)
@@ -279,9 +287,9 @@ class VariantSample(Item):
             '_default': 1000  # arbitrary large number
         },
         'proband_only_inheritance_modes': {
-            'Compound Het (Unphased/strong_pair)': 1,
-            'Compound Het (Unphased/medium_pair)': 2,
-            'Compound Het (Unphased/weak_pair)': 3,
+            CMPHET_UNPHASED_STRONG: 1,
+            CMPHET_UNPHASED_MED: 2,
+            CMPHET_UNPHASED_WEAK: 3,
             'X-linked': 4,
             'Y-linked': 5
         }
@@ -370,7 +378,7 @@ class VariantSample(Item):
         return 0.0
 
     @calculated_property(schema={
-        "title": "proband_only_inheritance_modes",
+        "title": "Inheritance Modes",
         "description": "Inheritance Modes (only including those relevant to a proband-only analysis)",
         "type": "array",
         "items": {
@@ -378,11 +386,7 @@ class VariantSample(Item):
         }
     })
     def proband_only_inheritance_modes(self, request, variant, inheritance_modes=[]):
-        proband_mode_options = [
-            'Compound Het (Unphased/strong_pair)',
-            'Compound Het (Unphased/medium_pair)',
-            'Compound Het (Unphased/weak_pair)'
-        ]
+        proband_mode_options = [CMPHET_UNPHASED_STRONG, CMPHET_UNPHASED_MED, CMPHET_UNPHASED_WEAK]
         proband_modes = [item for item in inheritance_modes if item in proband_mode_options]
         variant = get_item_or_none(request, variant, 'Variant', frame='raw')
         if variant['CHROM'] in ['X', 'Y']:
@@ -392,7 +396,7 @@ class VariantSample(Item):
         return None
 
     @calculated_property(schema={
-        "title": "bam_snapshot",
+        "title": "BAM Snapshot",
         "description": "Link to Genome Snapshot Image",
         "type": "string"
     })

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -270,7 +270,9 @@ class VariantSample(Item):
             InheritanceMode.INHMODE_LABEL_X_LINKED_RECESSIVE_MOTHER: 15,  # X-linked recessive (Maternal)
             InheritanceMode.INHMODE_LABEL_X_LINKED_DOMINANT_MOTHER: 16,  # X-linked dominant (Maternal)
             InheritanceMode.INHMODE_LABEL_X_LINKED_DOMINANT_FATHER: 17,  # X-linked dominant (Paternal)
+            'X-linked': 17,
             InheritanceMode.INHMODE_LABEL_Y_LINKED: 18,  # Y-linked dominant
+            'Y-linked': 18,
             InheritanceMode.INHMODE_LABEL_NONE_HOMOZYGOUS_PARENT: 19,  # Low relevance, homozygous in a parent
             InheritanceMode.INHMODE_LABEL_NONE_MN: 20,  # Low relevance, multiallelic site family
             InheritanceMode.INHMODE_LABEL_NONE_BOTH_PARENTS: 21,  # Low relevance, present in both parent(s)
@@ -361,6 +363,28 @@ class VariantSample(Item):
                 return 0.0
             return round(int(alt) / (int(ref) + int(alt)), 3)  # round to 3 digits
         return 0.0
+
+    @calculated_property(schema={
+        "title": "proband_only_inheritance_modes",
+        "description": "Inheritance Modes (only including those relevant to a proband-only analysis)",
+        "type": "array",
+        "items": {
+            "type": "string"
+        }
+    })
+    def proband_only_inheritance_modes(self, request, variant, inheritance_modes=[]):
+        proband_mode_options = [
+            'Compound Het (Unphased/strong_pair)',
+            'Compound Het (Unphased/medium_pair)',
+            'Compound Het (Unphased/weak_pair)'
+        ]
+        proband_modes = [item for item in inheritance_modes if item in proband_mode_options]
+        variant = get_item_or_none(request, variant, 'Variant', frame='raw')
+        if variant['CHROM'] in ['X', 'Y']:
+            proband_modes.append(f"{variant['CHROM']}-linked")
+        if proband_modes:
+            return proband_modes
+        return None
 
     @calculated_property(schema={
         "title": "bam_snapshot",


### PR DESCRIPTION
Most of our current inheritance modes are designed for trio analyses. This PR introduces another inheritance mode facet that is designed for proband-only cases, when most inheritance modes can't be called due to lack of family members in the analysis. 

In this PR:
- new calc prop for proband_only_inheritance_modes
- inheritance_modes and proband_only_inheritance_modes now default_hidden in schema, and get unhidden by the additional_variant_sample_facets in case.py
- proband_only_inheritance_modes has its own tooltip from a new html doc, modeled after the one for inheritance_modes