### PR TITLE
Correct image schema metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.8.6"
+version = "6.8.7"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/image.json
+++ b/src/encoded/schemas/image.json
@@ -1,7 +1,7 @@
 {
-    "title": "Document",
-    "description": "Additional files like pdf, doc, txt",
-    "id": "/profiles/document.json",
+    "title": "Image",
+    "description": "Image file and caption.",
+    "id": "/profiles/image.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [


### PR DESCRIPTION
Update "Image" schema's title, description, and ID to appropriate values instead of matching those of the "Document" schema. This updates the "Data Type" facet for images when searching all items from "Document" to "Image". 