### PR TITLE
Family ingestion ids

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.8.7"
+version = "6.8.8"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/case.json
+++ b/src/encoded/schemas/case.json
@@ -33,6 +33,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/ingestion_ids"
+        },
+        {
             "$ref": "mixins.json#/status"
         },
         {
@@ -109,16 +112,6 @@
             "title": "Variant Sample List Identifier",
             "description": "uuid of associated VariantSampleList item",
             "type": "string"
-        },
-        "ingestion_ids": {
-            "title": "Submission IDs",
-            "description": "uuids of the IngestionSubmission items that created/edited this case",
-            "type": "array",
-            "items": {
-                "title": "Submission ID",
-                "description": "an IngestionSubmission item that created or edited this case",
-                "type": "string"
-            }
         }
     },
     "facets": {

--- a/src/encoded/schemas/family.json
+++ b/src/encoded/schemas/family.json
@@ -33,6 +33,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/ingestion_ids"
+        },
+        {
             "$ref": "mixins.json#/status"
         },
         {

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -310,6 +310,18 @@
             }
         }
     },
+    "ingestion_ids": {
+        "ingestion_ids": {
+            "title": "Submission IDs",
+            "description": "uuids of the IngestionSubmission items that created/edited this case",
+            "type": "array",
+            "items": {
+                "title": "Submission ID",
+                "description": "an IngestionSubmission item that created or edited this case",
+                "type": "string"
+            }
+        }
+    },
     "tags": {
         "tags": {
             "title": "Tags",

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -920,8 +920,10 @@ class PedigreeMetadata:
         """
         family_metadata = {}
         for alias, item in self.individuals.items():
-            family_metadata.setdefault(item['family_id'],
-                                       {'family_id': item['family_id'], 'members': []})
+            family_metadata.setdefault(
+                item['family_id'],
+                {'family_id': item['family_id'], 'members': [], 'ingestion_ids': [self.ingestion_id]}
+            )
             family_metadata[item['family_id']]['members'].append(alias)
             if item.get('proband', False):
                 if 'proband' not in family_metadata[item['family_id']]:

--- a/src/encoded/tests/data/demo_inserts/phenotype.json
+++ b/src/encoded/tests/data/demo_inserts/phenotype.json
@@ -1,0 +1,154 @@
+[
+    {
+        "hpo_id": "HP:0000545",
+        "status": "shared",
+        "dbxrefs": [
+            "UMLS:C0027092",
+            "MSH:D009216",
+            "SNOMEDCT_US:57190000"
+        ],
+        "hpo_url": "http://purl.obolibrary.org/obo/HP_0000545",
+        "synonyms": [
+            "Near sighted",
+            "Nearsightedness",
+            "Close sighted",
+            "Near sightedness"
+        ],
+        "definition": "An abnormality of refraction characterized by the ability to see objects nearby clearly, while objects in the distance appear blurry.",
+        "slim_terms": [
+            "c4c52a02-6cb0-4b86-8667-aca3666e7d65"
+        ],
+        "phenotype_name": "Myopia",
+        "alternative_ids": [
+            "HP:0008012",
+            "HP:0001110",
+            "HP:0007847"
+        ],
+        "uuid": "fcbfd8d2-58d3-4d48-8a1c-57569e53e334"
+    },
+    {
+        "hpo_id": "HP:0001149",
+        "status": "shared",
+        "dbxrefs": [
+            "MSH:D028227",
+            "UMLS:C0155127",
+            "SNOMEDCT_US:1192004",
+            "SNOMEDCT_US:361199007"
+        ],
+        "hpo_url": "http://purl.obolibrary.org/obo/HP_0001149",
+        "synonyms": [
+            "Biber haab dimmer dystrophy"
+        ],
+        "definition": "The presence of fine, branching linear opacities in Bowman's layer in the central area that may spread to the periphery in the clinical course. The deep corneal stroma may be involved but the process does not reach Descemet's membrane. Recurrent corneal erosion may occur. Histologic examination reveals amyloid deposits in the collagen fibers of the cornea.",
+        "slim_terms": [
+            "c4c52a02-6cb0-4b86-8667-aca3666e7d65"
+        ],
+        "phenotype_name": "Lattice corneal dystrophy",
+        "uuid": "9bb3f1b9-9f8e-4f17-bd4d-10011e62b873"
+    },
+    {
+        "hpo_id": "HP:0001382",
+        "status": "shared",
+        "dbxrefs": [
+            "SNOMEDCT_US:298181000",
+            "UMLS:C1844820"
+        ],
+        "hpo_url": "http://purl.obolibrary.org/obo/HP_0001382",
+        "synonyms": [
+            "Extensible joints",
+            "Hyperextensible joints",
+            "Double-Jointed",
+            "Increased mobility of joints",
+            "Flexible joints",
+            "Joint hyperextensibility"
+        ],
+        "definition": "The ability of a joint to move beyond its normal range of motion.",
+        "slim_terms": [
+            "1262c802-99bc-4d04-a2b4-910115662bdd"
+        ],
+        "phenotype_name": "Joint hypermobility",
+        "alternative_ids": [
+            "HP:0001378",
+            "HP:0005034"
+        ],
+        "uuid": "3b35f3b3-22cc-4fff-a6f2-a76e3b843774"
+    },
+    {
+        "hpo_id": "HP:0000407",
+        "status": "shared",
+        "dbxrefs": [
+            "MSH:D006319",
+            "UMLS:C0018784",
+            "SNOMEDCT_US:60700002"
+        ],
+        "hpo_url": "http://purl.obolibrary.org/obo/HP_0000407",
+        "synonyms": [
+            "Sensorineural hearing loss",
+            "Sensorineural deafness",
+            "Hearing loss, sensorineural"
+        ],
+        "definition": "A type of hearing impairment in one or both ears related to an abnormal functionality of the cochlear nerve.",
+        "slim_terms": [
+            "ac3ff33f-b57a-4054-b158-4e669afe5816"
+        ],
+        "phenotype_name": "Sensorineural hearing impairment",
+        "alternative_ids": [
+            "HP:0008576",
+            "HP:0000374",
+            "HP:0008553",
+            "HP:0001916",
+            "HP:0008614",
+            "HP:0001753",
+            "HP:0008611",
+            "HP:0008613",
+            "HP:0008538",
+            "HP:0008565"
+        ],
+        "uuid": "b4e753bb-99d5-477d-8f34-965c0fa76390"
+    },
+    {
+        "hpo_id": "HP:0000716",
+        "status": "shared",
+        "dbxrefs": [
+            "SNOMEDCT_US:35489007",
+            "SNOMEDCT_US:21061000119107",
+            "MSH:D003866",
+            "UMLS:C0011581",
+            "SNOMEDCT_US:78667006"
+        ],
+        "hpo_url": "http://purl.obolibrary.org/obo/HP_0000716",
+        "synonyms": [
+            "Depression"
+        ],
+        "definition": "Frequent feelings of being down, miserable, and/or hopeless; difficulty recovering from such moods; pessimism about the future; pervasive shame; feeling of inferior self-worth; thoughts of suicide and suicidal behavior.",
+        "slim_terms": [
+            "cfa14e52-2ef2-46bc-ac5d-cd6bbf76942c"
+        ],
+        "phenotype_name": "Depressivity",
+        "uuid": "d4f2ea98-1d4a-4dcf-b0b9-1d49f55f3d61"
+    },
+    {
+        "hpo_id": "HP:0000821",
+        "status": "shared",
+        "dbxrefs": [
+            "MSH:D007037",
+            "UMLS:C0020676",
+            "SNOMEDCT_US:40930008"
+        ],
+        "hpo_url": "http://purl.obolibrary.org/obo/HP_0000821",
+        "synonyms": [
+            "Underactive thyroid",
+            "Low T4"
+        ],
+        "definition": "Deficiency of thyroid hormone.",
+        "slim_terms": [
+            "2a0ccce5-5edf-4777-910a-cacd3c71c5f6"
+        ],
+        "phenotype_name": "Hypothyroidism",
+        "alternative_ids": [
+            "HP:0003222",
+            "HP:0008203"
+        ],
+        "uuid": "5c2fcf82-4596-432e-88f0-7bf2c4bcf62e"
+    }
+]

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -387,7 +387,7 @@ class TestInvalidationScopeViewCGAP:
                              'last_modified.modified_by', 'date_created', 'submitted_by', 'aliases',
                              'accession', 'alternate_accessions', 'schema_version', 'title', 'family_id',
                              'members', 'proband', 'pedigree_source', 'original_pedigree', 'clinic_notes',
-                             'timestamp', 'family_phenotypic_features', 'description']
+                             'timestamp', 'family_phenotypic_features', 'description', 'ingestion_ids']
          ),
         ('Phenotype', 'Case',
             DEFAULT_SCOPE + ['hpo_id', 'phenotype_name']

--- a/src/encoded/types/case.py
+++ b/src/encoded/types/case.py
@@ -181,7 +181,7 @@ def _build_case_embedded_list():
         "individual.samples.files.quality_metric.status",
 
         # Family linkTo
-        "individual.families.ingestion_ids",
+        "individual.families.uuid",
 
         # Sample linkTo
         "sample.accession",

--- a/src/encoded/types/case.py
+++ b/src/encoded/types/case.py
@@ -181,7 +181,7 @@ def _build_case_embedded_list():
         "individual.samples.files.quality_metric.status",
 
         # Family linkTo
-        "individual.families.uuid",
+        "individual.families.ingestion_ids",
 
         # Sample linkTo
         "sample.accession",


### PR DESCRIPTION
The main purpose of this PR is to put ingestion_ids on Family so that after a pedigree is submitted, a search table of the related Case(s) can be shown.

In this PR:
- ingestion_ids prop on Case moved to mixins
- ingestion_ids mixin added to Family
- Case now embeds individual.families.ingestion_ids
- submit.py edited to put ingestion_ids on family metadata
- phenotypes needed for submission of the test pedigree file have been added to demo_inserts
