### PR TITLE
ACMG strength

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "6.8.10"
+version = "6.8.11"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/note_interpretation.json
+++ b/src/encoded/schemas/note_interpretation.json
@@ -58,8 +58,65 @@
                 "Pathogenic"
             ]
         },
+        "acmg_rules_invoked": {
+            "title": "ACMG Rules Invoked",
+            "type": "array",
+            "items": {
+                "title": "ACMG Rule Invoked",
+                "type": "object",
+                "required": ["acmg_rule_name"],
+                "properties": {
+                    "acmg_rule_name": {
+                        "title": "ACMG Rule Name",
+                        "type": "string",
+                        "enum": [
+                            "PVS1",
+                            "PS1",
+                            "PS2",
+                            "PS3",
+                            "PS4",
+                            "PM1",
+                            "PM2",
+                            "PM3",
+                            "PM4",
+                            "PM5",
+                            "PM6",
+                            "PP1",
+                            "PP2",
+                            "PP3",
+                            "PP4",
+                            "PP5",
+                            "BA1",
+                            "BS1",
+                            "BS2",
+                            "BS3",
+                            "BS4",
+                            "BP1",
+                            "BP2",
+                            "BP3",
+                            "BP4",
+                            "BP5",
+                            "BP6",
+                            "BP7"
+                        ]
+                    },
+                    "rule_strength": {
+                        "title": "Rule Strength",
+                        "type": "string",
+                        "enum": [
+                            "Default",
+                            "Supporting",
+                            "Moderate",
+                            "Strong",
+                            "Very Strong"
+                        ]
+                    }
+                }
+            }
+        },
         "acmg_guidelines": {
             "title": "ACMG Guidelines Invoked",
+            "comment": "This property is being deprecated, use acmg_rules_invoked instead",
             "type": "array",
             "items": {
                 "title": "ACMG Guideline",

--- a/src/encoded/types/note.py
+++ b/src/encoded/types/note.py
@@ -85,6 +85,22 @@ class NoteInterpretation(Note):
             properties = self.upgrade_properties()
             return properties.get('uuid', None)
 
+    @calculated_property(schema={
+        "title": "ACMG Rule",
+        "description": "ACMG Rule with Strength Modifier",
+        "type": "string"
+    })
+    def acmg_rules_with_modifier(self, acmg_rules_invoked=None):
+        if not acmg_rules_invoked:
+            return
+        rules_display = []
+        for rule in acmg_rules_invoked:
+            rule_string = rule['acmg_rule_name']
+            if rule.get('rule_strength') and rule['rule_strength'] != 'Default':
+                rule_string += '_' + rule['rule_strength']
+            rules_display.append(rule_string)
+        return rules_display
+
 
 @collection(
     name='notes-discovery',

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -64,7 +64,7 @@ def build_variant_embedded_list():
     """
     embedded_list = [
         "interpretations.classification",
-        "interpretations.acmg_rules_invoked",
+        "interpretations.acmg_rules_invoked.*",
         "interpretations.acmg_rules_with_modifier",
         "interpretations.conclusion",
         "interpretations.note_text",

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -56,7 +56,8 @@ def build_variant_embedded_list():
     """
     embedded_list = [
         "interpretations.classification",
-        "interpretations.acmg_guidelines",
+        "interpretations.acmg_rules_invoked",
+        "interpretations.acmg_rules_with_modifier",
         "interpretations.conclusion",
         "interpretations.note_text",
         "interpretations.version",


### PR DESCRIPTION
This incorporates data model changes that will allow modifying the strength or evidence level of ACMG rules during Interpretation.

In this PR:
- acmg_rules_invoked property added, which is an array of sub-embedded object containing the rule name and the strength
- acmg_guidelines, the old array of string property, is left in to avoid validation errors etc. should be removed in the future.
- acmg_rules_with_modifier calc prop added, which adds the strength to the rule name and returns one string
- unit test for calc prop added
- acmg_guidelines embed replaced with acmg_rules_invoked and acmg_rules_with_modifier