### PR TITLE
Update embeds for SV bioinformatics workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.1.0"
+version = "7.1.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -78,6 +78,7 @@
                 "intermediate file",
                 "raw VCF",
                 "gVCF",
+                "Higlass SV VCF",
                 "full annotated VCF"
             ]
         },

--- a/src/encoded/tests/data/inserts/file_processed.json
+++ b/src/encoded/tests/data/inserts/file_processed.json
@@ -58,5 +58,15 @@
         "institution": "hms-dbmi",
         "file_type": "full annotated VCF",
         "variant_type": "SV"
+    },
+    {
+        "status": "shared",
+        "uuid": "5593ddd6-13d1-4bf3-b412-bb0a01dfc922",
+        "file_format": "0cd4e777-a596-4927-95c8-b07716121aa5",
+        "accession": "GAPFIFYGNO4B",
+        "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
+        "institution": "hms-dbmi",
+        "file_type": "Higlass SV VCF",
+        "variant_type": "SV"
     }
 ]

--- a/src/encoded/tests/data/inserts/sample_processing.json
+++ b/src/encoded/tests/data/inserts/sample_processing.json
@@ -4,22 +4,27 @@
         "institution": "hms-dbmi",
         "status": "shared",
         "uuid": "4fdb481a-fbdb-4c0f-a68d-aac87f847a67",
-        "samples":
-        [
+        "samples": [
             "4fdb481a-fbdb-4c0f-a68d-aac87f847bec",
             "283f6047-61cd-4ddb-8881-ec1c87082569"
         ],
         "sample_processed_files": [
             {
                 "sample": "4fdb481a-fbdb-4c0f-a68d-aac87f847bec",
-                "processed_files": ["10002377-49e5-4c33-afab-9ec90d65faa2"]
+                "processed_files": [
+                    "10002377-49e5-4c33-afab-9ec90d65faa2"
+                ]
             },
             {
                 "sample": "283f6047-61cd-4ddb-8881-ec1c87082569",
-                "processed_files": ["10002377-49e5-4c33-afab-9ec90d65faa3"]
+                "processed_files": [
+                    "10002377-49e5-4c33-afab-9ec90d65faa3"
+                ]
             }
-         ],
-        "processed_files": ["10002377-49e5-4c33-afab-9ec90d65faa1"]
+        ],
+        "processed_files": [
+            "10002377-49e5-4c33-afab-9ec90d65faa1"
+        ]
     },
     {
         "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
@@ -27,17 +32,21 @@
         "status": "shared",
         "uuid": "33dcd73c-f48e-475b-84bb-7a4514750657",
         "analysis_type": "WGS",
-        "samples":
-        [
+        "samples": [
             "4fdb481a-fbdb-4c0f-a68d-aac87f847bec"
         ],
         "sample_processed_files": [
             {
                 "sample": "4fdb481a-fbdb-4c0f-a68d-aac87f847bec",
-                "processed_files": ["10002377-49e5-4c33-afab-9ec90d65faf3"]
+                "processed_files": [
+                    "10002377-49e5-4c33-afab-9ec90d65faf3"
+                ]
             }
-         ],
-        "processed_files": ["6b113e31-d4dd-465a-99b2-16fb0c3928fb"],
+        ],
+        "processed_files": [
+            "6b113e31-d4dd-465a-99b2-16fb0c3928fb",
+            "5593ddd6-13d1-4bf3-b412-bb0a01dfc922"
+        ],
         "families": [
             "415fa8aa-8482-43d0-a90a-540c0ee9c1e0"
         ]

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -393,7 +393,8 @@ class TestInvalidationScopeViewCGAP:
             DEFAULT_SCOPE + ['hpo_id', 'phenotype_name']
          ),
         ('FileProcessed', 'Case',
-            DEFAULT_SCOPE + ['accession', 'quality_metric', 'file_ingestion_status']
+            DEFAULT_SCOPE + ['accession', 'quality_metric', 'file_ingestion_status',
+                             'file_type', 'variant_type']
          ),
         ('Report', 'Case',
             DEFAULT_SCOPE + ['accession']

--- a/src/encoded/types/case.py
+++ b/src/encoded/types/case.py
@@ -260,6 +260,9 @@ def _build_case_embedded_list():
         # File linkTo
         "sample_processing.processed_files.file_format.file_format",
         "sample_processing.processed_files.accession",
+        "sample_processing.processed_files.variant_type",
+        "sample_processing.processed_files.file_type",
+        "sample_processing.processed_files.upload_key",
 
         # File linkTo
         "sample_processing.sample_processed_files.processed_files.accession",

--- a/src/encoded/types/sample.py
+++ b/src/encoded/types/sample.py
@@ -10,19 +10,9 @@ from .base import (
 from .family import Family
 
 
-@collection(
-    name='samples',
-    unique_key='accession',
-    properties={
-        'title': 'Samples',
-        'description': 'Listing of Samples',
-    })
-class Sample(Item):
-    item_type = 'sample'
-    name_key = 'accession'
-    schema = load_schema('encoded:schemas/sample.json')
-    rev = {'indiv': ('Individual', 'samples')}
-    embedded_list = [
+def _build_sample_embedded_list():
+    """Helper function to create embedded list for sample."""
+    return [
         # File linkTo
         "files.status",
         "files.file_format.file_format",
@@ -38,6 +28,21 @@ class Sample(Item):
         "processed_files.file_format.file_format",
         "processed_files.workflow_run_outputs"
     ]
+
+
+@collection(
+    name='samples',
+    unique_key='accession',
+    properties={
+        'title': 'Samples',
+        'description': 'Listing of Samples',
+    })
+class Sample(Item):
+    item_type = 'sample'
+    name_key = 'accession'
+    schema = load_schema('encoded:schemas/sample.json')
+    rev = {'indiv': ('Individual', 'samples')}
+    embedded_list = _build_sample_embedded_list()
 
     @calculated_property(schema={
         "title": "Individual",
@@ -72,6 +77,20 @@ class Sample(Item):
             return False
 
 
+def _build_sample_processing_embedded_list():
+    """Helper function to build embedded list for sample_processing."""
+    return [
+        # File linkTo
+        "processed_files.accession",  # used to locate this file from annotated VCF via search
+        "processed_files.variant_type",
+        "processed_files.file_type",
+
+        # Sample linkTo
+        "samples.completed_processes",
+        "samples.processed_files.uuid",
+    ]
+
+
 @collection(
     name='sample-processings',
     properties={
@@ -81,11 +100,7 @@ class Sample(Item):
 class SampleProcessing(Item):
     item_type = 'sample_processing'
     schema = load_schema('encoded:schemas/sample_processing.json')
-    embedded_list = [
-        'processed_files.accession',  # used to locate this file from annotated VCF via search
-        'samples.completed_processes',
-        "samples.processed_files.uuid",
-    ]
+    embedded_list = _build_sample_processing_embedded_list()
     rev = {'case': ('Case', 'sample_processing')}
 
     @calculated_property(schema={

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -611,6 +611,9 @@ class VariantSampleList(Item):
         'variant_samples.variant_sample_item.associated_genotype_labels.mother_genotype_label',
         'variant_samples.variant_sample_item.associated_genotype_labels.father_genotype_label',
         'structural_variant_samples.structural_variant_sample_item.structural_variant.display_title',
+        'structural_variant_samples.structural_variant_sample_item.interpretation.classification',
+        'structural_variant_samples.structural_variant_sample_item.discovery_interpretation.gene_candidacy',
+        'structural_variant_samples.structural_variant_sample_item.discovery_interpretation.variant_candidacy',
     ]
 
 


### PR DESCRIPTION
Update embeds for Case and SampleProcessing `files_processed` to include `variant_type` and `file_type` to better differentiate VCF files for Foursight and development, as well as `upload_key` for Case to facilitate Higlass identification of SV VCF to be used instead of BAM files. 

Also, add suggested `file_type` of "Higlass SV VCF" to be used for the above VCFs and new insert that can be used to test Higlass file identification.