### PR TITLE
Hide inactive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.4"
+version = "7.7.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.5"
+version = "7.7.6"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.3"
+version = "7.7.4"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/case.json
+++ b/src/encoded/schemas/case.json
@@ -138,17 +138,25 @@
     },
     "facets": {
         "project.display_title": {
-            "title": "Project"
+            "title": "Project",
+            "order": 1
+        },
+        "proband_case": {
+            "title": "Proband Case",
+            "order": 2
         },
         "vcf_file.file_ingestion_status": {
-            "title": "Final VCF Status"
+            "title": "Final VCF Status",
+            "order": 3
         },
         "individual.sex": {
             "title": "Sex",
-            "grouping": "Individual"
+            "grouping": "Individual",
+            "order": 4
         },
         "status": {
-            "title": "Status"
+            "title": "Status",
+            "order": 5
         }
     },
     "columns": {

--- a/src/encoded/schemas/case.json
+++ b/src/encoded/schemas/case.json
@@ -146,6 +146,9 @@
         "individual.sex": {
             "title": "Sex",
             "grouping": "Individual"
+        },
+        "status": {
+            "title": "Status"
         }
     },
     "columns": {

--- a/src/encoded/static/components/static-pages/HomePage/UserDashboard.js
+++ b/src/encoded/static/components/static-pages/HomePage/UserDashboard.js
@@ -53,6 +53,7 @@ const RecentCasesTable = React.memo(function RecentCasesTable({ windowHeight, wi
         "/search/?type=Case"
         + "&report.uuid!=No+value"
         + "&proband_case=true"
+        + "&status!=inactive"
         + "&sort=-last_modified.date_modified"
     );
     const maxHeight = typeof windowHeight === "number" ?


### PR DESCRIPTION
This PR is for hiding "inactive" status Cases from the main user dashboard.

- `&status!=inactive` added to Case search query on user dashboard
- status added as facet on Case search page, so that a user can click "Cases" and see all their cases, and can choose to hide inactive ones or not
- order numbers added to case facets