### PR TITLE
Update informatics documentation

### DIFF
--- a/docs/public/help/developer_facing_docs.md
+++ b/docs/public/help/developer_facing_docs.md
@@ -2,7 +2,9 @@ You can find further information at the links below.
 
 * [CGAP Portal](https://cgap-portal.readthedocs.io/en/latest/)
 
-* [CGAP Pipeline](https://cgap-pipeline.readthedocs.io/en/latest/)
+* [CGAP SNV Pipeline](https://cgap-pipeline.readthedocs.io/en/latest/)
+
+* [CGAP SV Pipeline](https://cgap-sv-pipeline.readthedocs.io/en/latest/SV.html)
 
 * [Submit-CGAP](https://submitcgap.readthedocs.io/en/latest/)
 
@@ -11,3 +13,5 @@ You can find further information at the links below.
 * [Tibanna](https://tibanna-ff.readthedocs.io/en/latest/)
 
 * [Granite](https://granite-suite.readthedocs.io/en/latest/)
+
+* [Magma-suite](https://magma-suite.readthedocs.io/en/latest/index.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.5"
+version = "7.7.7"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/data/deploy-inserts/page.json
+++ b/src/encoded/tests/data/deploy-inserts/page.json
@@ -164,7 +164,7 @@
     },
     {
         "name": "help/developer_facing_documentation",
-        "title": "Developer-Facing Documentation",
+        "title": "Informatics Documentation",
         "status": "public",
         "aliases": [
             "hms-dbmi:developer_facing_documentation"

--- a/src/encoded/tests/data/deploy-inserts/static_section.json
+++ b/src/encoded/tests/data/deploy-inserts/static_section.json
@@ -160,7 +160,7 @@
     {
         "file": "/docs/public/help/developer_facing_docs.md",
         "name": "help.developer_facing_docs.content",
-        "title": "Informatics Documentation",
+        "title": "Links for Further Documentation",
         "status": "public",
         "aliases": [
             "hms-dbmi:developer_facing_docs.content"

--- a/src/encoded/tests/data/deploy-inserts/static_section.json
+++ b/src/encoded/tests/data/deploy-inserts/static_section.json
@@ -160,7 +160,7 @@
     {
         "file": "/docs/public/help/developer_facing_docs.md",
         "name": "help.developer_facing_docs.content",
-        "title": "Links for Further Documentation",
+        "title": "Informatics Documentation",
         "status": "public",
         "aliases": [
             "hms-dbmi:developer_facing_docs.content"


### PR DESCRIPTION
As outlined in this [Trello ticket](https://trello.com/c/tMve1Mt0/109-minor-updates-to-cgaps-help-page), this PR adds a few new links for further information and changes the title of the page to "Informatics Documentation" from "Developer-Facing Documentation."