### PR TITLE
Superceded prop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.7"
+version = "7.7.8"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.8"
+version = "7.7.9"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/case.json
+++ b/src/encoded/schemas/case.json
@@ -134,6 +134,14 @@
             "description": "SV Meta-workflow-run associated with this case",
             "type": "string",
             "linkTo": "MetaWorkflowRun"
+        },
+        "superceded_by": {
+            "title": "Superceded By",
+            "description": "The new case whose updated analysis will supercede this case",
+            "type": "string",
+            "format": "accession",
+            "permission": "restricted_fields",
+            "exclude_from": ["FFedit-create"]
         }
     },
     "facets": {

--- a/src/encoded/schemas/case.json
+++ b/src/encoded/schemas/case.json
@@ -135,9 +135,9 @@
             "type": "string",
             "linkTo": "MetaWorkflowRun"
         },
-        "superceded_by": {
-            "title": "Superceded By",
-            "description": "The new case whose updated analysis will supercede this case",
+        "superseded_by": {
+            "title": "Superseded By",
+            "description": "The new case whose updated analysis will supersede this case",
             "type": "string",
             "format": "accession",
             "permission": "restricted_fields",


### PR DESCRIPTION
Added `superceded_by` prop on case to indicate whether a case has been cloned, which contains the accession of the new case. I didn't want to make this a linkTo, primarily for indexing reasons. Additionally I didn't want to do a formal replacement as in 4DN because we don't necessarily want to make the original case inactive until the analysis is finished on the new case and variants are ingested. 