### PR TITLE
Improve gene list submission messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.10"
+version = "7.7.11"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.11"
+version = "7.7.12"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submit_genelist.py
+++ b/src/encoded/submit_genelist.py
@@ -212,8 +212,8 @@ class GeneListSubmission:
         else:
             title = None
             self.errors.append(
-                "No title was found in the gene list. Please check the "
-                "formatting of the submitted document."
+                "No title was found in the gene list. Please check the"
+                " formatting of the submitted document."
             )
         case_atids = self._create_case_atids(cases)
         genelist = [x for x in genelist if x != ""]
@@ -226,19 +226,19 @@ class GeneListSubmission:
                 non_ascii_genes.append(gene)
         if genes_with_spaces:
             self.errors.append(
-                "Gene symbols/IDs should not contain spaces. Please reformat "
-                "the following gene entries: %s." % ", ".join(genes_with_spaces)
+                "Gene symbols/IDs should not contain spaces. Please reformat"
+                " the following gene entries: %s." % ", ".join(genes_with_spaces)
             )
         if non_ascii_genes:
             self.errors.append(
-                "The following gene(s) contain non-ASCII characters: %s. "
-                "Please re-enter the genes using only ASCII characters."
+                "The following gene(s) contain non-ASCII characters: %s."
+                " Please re-enter the genes using only ASCII characters."
                 % ", ".join(non_ascii_genes)
             )
         if not genelist and not genes_with_spaces and not non_ascii_genes:
             self.errors.append(
-                "No genes were found in the gene list. Please check the "
-                "formatting of the submitted document."
+                "No genes were found in the gene list. Please check the"
+                " formatting of the submitted document."
             )
         genelist = list(set(genelist))
         return genelist, title, case_atids
@@ -342,11 +342,11 @@ class GeneListSubmission:
                                 break
         if non_ensgids:
             self.errors.append(
-                "The following gene(s) could not be found in our database: %s. "
-                "Consider replacement with an alias name or an Ensembl ID."
-                "As a reminder, only coding genes exist in our database, so "
-                "pseudogenes, non-coding genes, etc. will cause a gene list submission "
-                "to fail."
+                "The following gene(s) could not be found in our database: %s."
+                " Consider replacement with an alias name or an Ensembl ID."
+                " As a reminder, only coding genes exist in our database, so"
+                " pseudogenes, non-coding genes, etc. will cause a gene list submission"
+                " to fail."
                 % ", ".join(non_ensgids)
             )
         sorted_gene_names = sorted(gene_ids)
@@ -591,8 +591,8 @@ class GeneListSubmission:
             validate_display.append("%s: %s" % (key, validate_result[key]))
         if genelist_uuid:
             validate_display.append(
-                "Existing gene list with the same title was found and will be "
-                "overwritten."
+                "Existing gene list with the same title was found and will be"
+                " overwritten."
             )
         validate_result = validate_display
         return (
@@ -693,13 +693,15 @@ class GeneListSubmission:
         ).json
         if submission_response["success"]:
             self.post_output.append(
-                "Variants should begin updating shortly but may take a few "
-                "hours depending on server load."
+                "Variants should begin updating shortly but may take up to a few hours"
+                " depending on server load. To ensure all variants on a case are"
+                " appropriately updated, please do not use the gene list for filtering"
+                " immediately."
             )
         else:
             self.post_output.append(
-                "Variants were not queued for updating. Please reach out "
-                "to the CGAP team and alert them of this issue."
+                "Variants were not queued for updating. Please reach out"
+                " to the CGAP team and alert them of this issue."
             )
         return
 


### PR DESCRIPTION
This PR implements a few small changes to gene list submission error messages based on recent open hours feedback. 

- When submitted gene not found, adds a reminder that only coding genes are in CGAP database
- When submitted gene not found, drops search on that gene to provide suggestions for possible alternatives
- When any error has occurred in processing, adds an explicit message that gene list was not created in the system

Remainder of feedback is front-end related and will come in separately.