### PR TITLE
Add failed_jobs to MetaWorkflowRun schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.7.10"
+version = "7.7.11"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/meta_workflow_run.json
+++ b/src/encoded/schemas/meta_workflow_run.json
@@ -230,6 +230,16 @@
                 "inactive"
             ]
         },
+        "failed_jobs": {
+            "title": "Failed Jobs",
+            "description": "List of failed Tibanna job ids for this meta workflow run",
+            "type": "array",
+            "items": {
+                "title": "Failed Job Id",
+                "description": "Failed Tibanna job in this meta workflow run",
+                "type": "string"
+            }
+        },
         "common_fields": {
             "title": "Common Fields",
             "description": "Common fields that go into all workflow_run, processed_files and qc items",


### PR DESCRIPTION
We want to keep track of failed jobs to accurately compute costs of a MetaWorkflowRun. This PR adds the field `failed_jobs` to the scheme for this purpose.