### PR TITLE
U sex inhmode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.9.4"
+version = "7.9.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -220,4 +220,3 @@ memlimit = "encoded.memlimit:filter_app"
 [build-system]
 requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-

--- a/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode.html
+++ b/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode.html
@@ -31,8 +31,4 @@ Note that structural variants, unlike SNVs, lack a specialized de novo variant c
 
 <p><b>Ambiguous</b>: </p>
 
-<p>
-  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
-  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
-  be marked ambiguous.
-</p>
+<p>If a sample is submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes are calculated normally but sex-linked inheritance modes and genotypes cannot be properly determined. These will be marked "Ambiguous".</p>

--- a/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode.html
+++ b/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode.html
@@ -28,3 +28,11 @@ Note that structural variants, unlike SNVs, lack a specialized de novo variant c
 <li> Variants with genotypes that do not meet any of the high relevance criteria above are not assigned inheritance mode labels.
 </ul>
 </p>
+
+<p><b>Ambiguous</b>: </p>
+
+<p>
+  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
+  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
+  be marked ambiguous.
+</p>

--- a/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode_proband_only.html
+++ b/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode_proband_only.html
@@ -28,8 +28,4 @@ Variants on the X or Y chromosome are classified <b>X-linked</b> or <b>Y-linked<
 
 <p><b>Ambiguous</b>: </p>
 
-<p>
-  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
-  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
-  be marked ambiguous.
-</p>
+<p>If a sample is submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes are calculated normally but sex-linked inheritance modes and genotypes cannot be properly determined. These will be marked "Ambiguous".</p>

--- a/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode_proband_only.html
+++ b/src/encoded/docs/extended_description_StructuralVariantSample_inheritance_mode_proband_only.html
@@ -25,3 +25,11 @@ Variants on the X or Y chromosome are classified <b>X-linked</b> or <b>Y-linked<
 <li> Variants with missing calls (./.) or calls that mismatch the sex (e.g. 0/1 on chrX for a male) are not assigned inheritance mode values.
 <li> Variants with genotypes that do not meet any of the high relevance criteria above are not assigned inheritance mode labels.
 </p>
+
+<p><b>Ambiguous</b>: </p>
+
+<p>
+  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
+  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
+  be marked ambiguous.
+</p>

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
@@ -43,3 +43,12 @@
 <li> Variants on multiallelic sites (e.g. G, T, A in different individuals) are not assigned inheritance mode values, except possibly compound heterozygous.
 <li> Variants with missing calls (./.) or calls that mismatch the sex (0/1 on chrX for a male) are not assigned inheritance mode values.
 <li> Variants with genotypes that do not meet any of the high relevant criteria above are not assigned GATK-based labels.
+</ul>
+
+<p><b>Ambiguous</b>: </p>
+
+<p>
+  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
+  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
+  be marked ambiguous.
+</p>

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode.html
@@ -47,8 +47,4 @@
 
 <p><b>Ambiguous</b>: </p>
 
-<p>
-  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
-  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
-  be marked ambiguous.
-</p>
+<p>If a sample is submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes are calculated normally but sex-linked inheritance modes and genotypes cannot be properly determined. These will be marked "Ambiguous".</p>

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
@@ -34,8 +34,4 @@
 
 <p><b>Ambiguous</b>: </p>
 
-<p>
-  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
-  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
-  be marked ambiguous.
-</p>
+<p>If a sample is submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes are calculated normally but sex-linked inheritance modes and genotypes cannot be properly determined. These will be marked "Ambiguous".</p>

--- a/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
+++ b/src/encoded/docs/extended_description_VariantSample_inheritance_mode_probandonly.html
@@ -30,3 +30,12 @@
 <li> Variants on multiallelic sites (e.g. G, T, A in different individuals) are not assigned inheritance mode values, except possibly compound heterozygous.
 <li> Variants with missing calls (./.) or calls that mismatch the sex (0/1 on chrX for a male) are not assigned inheritance mode values.
 <li> Variants with genotypes that do not meet any of the high relevant criteria above are not assigned GATK-based labels.
+</ul>
+
+<p><b>Ambiguous</b>: </p>
+
+<p>
+  If a sample was submitted to CGAP with the sex indicated as "U" or "Unknown", then autosome inheritance modes and genotypes
+  will still be calculated normally but sex chromosome inheritance mode and genotype cannot be properly determined. These will
+  be marked ambiguous.
+</p>

--- a/src/encoded/tests/test_inheritance_mode.py
+++ b/src/encoded/tests/test_inheritance_mode.py
@@ -74,6 +74,13 @@ def test_compute_genotype_label_raises_error(gt, sex, chrom):
     ('0/1', 'M', '3', InheritanceMode.GENOTYPE_LABEL_0M),
     ('1/1', 'M', '21', InheritanceMode.GENOTYPE_LABEL_MM),
     ('2/1', 'M', '9', InheritanceMode.GENOTYPE_LABEL_MN),
+    ('0/1', 'U', 'Y', InheritanceMode.GENOTYPE_LABEL_SEX_AMBIGUOUS),
+    ('0/1', 'U', 'X', InheritanceMode.GENOTYPE_LABEL_SEX_AMBIGUOUS),
+    ('1/1', 'U', 'Y', InheritanceMode.GENOTYPE_LABEL_SEX_AMBIGUOUS),
+    ('1/1', 'U', 'X', InheritanceMode.GENOTYPE_LABEL_SEX_AMBIGUOUS),
+    ('0/1', 'U', '7', InheritanceMode.GENOTYPE_LABEL_0M),
+    ('1/1', 'U', '7', InheritanceMode.GENOTYPE_LABEL_MM),
+    ('2/1', 'U', '7', InheritanceMode.GENOTYPE_LABEL_MN)
 ])
 def test_compute_genotype_label(gt, sex, chrom, expected):
     assert InheritanceMode.compute_genotype_label(gt=gt, sex=sex, chrom=chrom) == expected
@@ -205,6 +212,26 @@ def test_compute_family_genotype_labels(gts, sexes, chrom, expected_labels):
         'X',
         .8,
         [InheritanceMode.INHMODE_LABEL_DE_NOVO_MEDIUM]
+    ),
+    (  # test case 4 - proband U
+        {
+            'proband': '0/1',
+            'mother': '1/1',
+            'father': '0/0'
+        },
+        {
+            'proband': ['Ambiguous'],
+            'mother': ['Homozygous alternate'],
+            'father': ['Hemizygous reference']
+        },
+        {
+            'proband': 'U',
+            'mother': 'F',
+            'father': 'M'
+        },
+        'X',
+        .8,
+        []
     )
 ])
 def test_compute_inheritance_mode_trio(gts, gt_labels, sexes, chrom, novoPP, expected_inh):
@@ -332,7 +359,7 @@ def test_compute_inheritance_mode_trio_structural_variant(
     genotypes, sexes, chrom, result
 ):
     """
-    Test for SV-specific inheritance mode calculations. 
+    Test for SV-specific inheritance mode calculations.
     """
     genotype_labels = InheritanceMode.compute_family_genotype_labels(
         genotypes, sexes, chrom
@@ -503,9 +530,83 @@ def test_compute_inheritance_mode_trio_structural_variant(
             ],
             'inheritance_modes': []
         }
+    ),
+    (  # test case 6 - proband U, sex chromosome
+        {
+            'samplegeno': [
+                {
+                    'samplegeno_role': 'proband',
+                    'samplegeno_numgt': '1/1',
+                    'samplegeno_sex': 'U',
+                    'samplegeno_sampleid': 'sample_id_1'
+                },
+                {
+                    'samplegeno_role': 'mother',
+                    'samplegeno_numgt': '0/1',
+                    'samplegeno_sex': 'F',
+                    'samplegeno_sampleid': 'sample_id_2'
+                },
+                {
+                    'samplegeno_role': 'father',
+                    'samplegeno_numgt': '0/0',
+                    'samplegeno_sex': 'M',
+                    'samplegeno_sampleid': 'sample_id_3'
+                },
+            ],
+            'novoPP': .5,
+            'cmphet': None,
+            'variant': {
+                'CHROM': 'X'
+            }
+        },
+        {
+            'genotype_labels': [
+                {'labels': ['Ambiguous'], 'role': 'proband', 'sample_id': 'sample_id_1'},
+                {'labels': ['Heterozygous'], 'role': 'mother', 'sample_id': 'sample_id_2'},
+                {'labels': ['Hemizygous reference'], 'role': 'father', 'sample_id': 'sample_id_3'}
+            ],
+            'inheritance_modes': ['Ambiguous due to missing sex determination']
+        }
+    ),
+    (  # test case 7 - proband U, autosome 
+        {
+            'samplegeno': [
+                {
+                    'samplegeno_role': 'proband',
+                    'samplegeno_numgt': '1/1',
+                    'samplegeno_sex': 'U',
+                    'samplegeno_sampleid': 'sample_id_1'
+                },
+                {
+                    'samplegeno_role': 'mother',
+                    'samplegeno_numgt': '0/1',
+                    'samplegeno_sex': 'F',
+                    'samplegeno_sampleid': 'sample_id_2'
+                },
+                {
+                    'samplegeno_role': 'father',
+                    'samplegeno_numgt': '0/1',
+                    'samplegeno_sex': 'M',
+                    'samplegeno_sampleid': 'sample_id_3'
+                },
+            ],
+            'novoPP': .5,
+            'cmphet': None,
+            'variant': {
+                'CHROM': 1
+            }
+        },
+        {
+            'genotype_labels': [
+                {'labels': ['Homozygous alternate'], 'role': 'proband', 'sample_id': 'sample_id_1'},
+                {'labels': ['Heterozygous'], 'role': 'mother', 'sample_id': 'sample_id_2'},
+                {'labels': ['Heterozygous'], 'role': 'father', 'sample_id': 'sample_id_3'}
+            ],
+            'inheritance_modes': ['de novo (medium)']
+        }
     )
 ])
-def test_compute_inheritance_modes(variant_sample, expected_new_fields):
+def test_compute_inheritance_modes_snv(variant_sample, expected_new_fields):
     """ Tests end-to-end inheritance mode computation """
     assert InheritanceMode.compute_inheritance_modes(variant_sample) == expected_new_fields
 


### PR DESCRIPTION
The inheritance mode code needs handling for "unknown" sex. 
When sex is "U":
- genotypes/inheritance modes on autosomes stay the same
- genotypes on X or Y are labelled "ambiguous"
- inheritance modes on X or Y variants are labelled "Ambiguous due to missing sex determination"