### PR TITLE
Fix BAM snapshot for M variants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.9.15"
+version = "7.9.16"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/VariantSampleView/SampleTabBody.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/SampleTabBody.js
@@ -20,7 +20,8 @@ export function SampleTabBody(props){
         genotype_labels: genotypeLabels = [],
         variant = null,
         CALL_INFO = null,
-        file = null
+        file = null,
+        bam_snapshot = null
     } = context || {};
 
     const { REF: varRef = null } = variant;
@@ -35,10 +36,31 @@ export function SampleTabBody(props){
             return (schemaProperty || {}).description || null;
         };
     }, [ schemas ]);
+
+    let bamSnapSection;
+    if (bam_snapshot) {
+        bamSnapSection = (
+            <div className="col-4 col-md-3">
+                <div className="pb-2 inner-card-section h-100">
+                    <div className="info-header-title">
+                        <h4>
+                            BAM Snapshot
+                        </h4>
+                    </div>
+                    <div className="info-body text-center overflow-auto d-flex h-100 d-flex justify-content-center flex-column">
+                        <span>View BAM Snapshot</span>
+                        <a href={`/${uuid}/@@download`} className="d-block pt-2 text-center mx-auto">
+                            <i className="icon icon-fw icon-2x icon-external-link-alt fas ml-05" />
+                        </a>
+                    </div>
+                </div>
+            </div>
+        );
+    }
     return (
         <div className="variant-tab-body card-body">
             <div className="row">
-                <div className="col-8 col-md-9">
+                <div className={bam_snapshot ? "col-8 col-md-9" : "col-12 col-md-12"}>
                     <div className="pb-2 inner-card-section">
                         <div className="info-header-title">
                             <h4>
@@ -50,21 +72,7 @@ export function SampleTabBody(props){
                         </div>
                     </div>
                 </div>
-                <div className="col-4 col-md-3">
-                    <div className="pb-2 inner-card-section h-100">
-                        <div className="info-header-title">
-                            <h4>
-                                BAM Snapshot
-                            </h4>
-                        </div>
-                        <div className="info-body text-center overflow-auto d-flex h-100 d-flex justify-content-center flex-column">
-                            <span>View BAM Snapshot</span>
-                            <a href={`/${uuid}/@@download`} className="d-block pt-2" style={{ textAlign: "center", margin: "0 auto" }}>
-                                <i className="icon icon-fw icon-2x icon-external-link-alt fas ml-05" />
-                            </a>
-                        </div>
-                    </div>
-                </div>
+                {bamSnapSection}
             </div>
             <div className="row">
                 <div className="col-12 col-md-12 d-flex">

--- a/src/encoded/tests/test_types_variant_sample.py
+++ b/src/encoded/tests/test_types_variant_sample.py
@@ -101,6 +101,27 @@ def test_bam_snapshot_download(workbook, es_testapp, test_variant_sample):
     assert 'hello world' in resp.content.decode('utf-8')
 
 
+def test_bam_snapshot_presence(
+    testapp, variant, variant_sample
+):
+    """
+    Test creation of BAM snapshot calc prop on variant samples with
+    different chromosomes
+    """
+    calc_prop_name = "bam_snapshot"
+    vs_post = testapp.post_json(VARIANT_SAMPLE_URL, variant_sample, status=201)
+    vs_atid = vs_post.json["@graph"][0]["@id"]
+    chromosomes = [str(x) for x in range(1, 23)] + ["X", "Y", "M"]
+    excluded_chromosomes = ["M"]
+    for chromosome in chromosomes:
+        testapp.patch_json(variant["@id"], {"CHROM": chromosome}, status=200)
+        vs_get = testapp.get(vs_atid, status=200).json
+        if chromosome in excluded_chromosomes:
+            assert calc_prop_name not in vs_get
+        else:
+            assert calc_prop_name in vs_get
+
+
 @pytest.fixture
 def variant_sample_list1(bgm_project, institution):
     return {

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -437,12 +437,16 @@ class VariantSample(Item):
         "type": "string"
     })
     def bam_snapshot(self, request, file, variant):
+        file_path = None
+        excluded_chromosomes = ["M"]
         variant_props = get_item_or_none(request, variant, 'Variant', frame='raw')
         if variant_props is None:
             raise RuntimeError('Got none for something that definitely exists')
-        file_path = '%s/bamsnap/chr%s_%s.png' % (  # file = accession of associated VCF file
-            file, variant_props['CHROM'], variant_props['POS']
-        )
+        chromosome = variant_props.get("CHROM")
+        if chromosome not in excluded_chromosomes:
+            file_path = '%s/bamsnap/chr%s_%s.png' % (  # file = accession of associated VCF file
+                file, chromosome, variant_props['POS']
+            )
         return file_path
 
     @calculated_property(schema={


### PR DESCRIPTION
Since we're no longer generating BAM snapshots for mitochondrial variants, this PR updates the VariantSample `bam_snapshot` calculated property to remove it from mitochondrial variants. Additionally, if the property is not present on a VariantSample, the BAM Snapshot area (containing the link) within the annotation space's "Sample" tab is removed (e.g. compare this [X variant](http://fourfront-cgapdev.9wzadzju3p.us-east-1.elasticbeanstalk.com/variant-samples/253ad0f5-083f-4dfc-82de-4eb855d40376/) to this [mitochondrial one](http://fourfront-cgapdev.9wzadzju3p.us-east-1.elasticbeanstalk.com/variant-samples/2af827a0-ffda-4f21-a0f3-af55f7d2f057/#overview)).