### PR TITLE
Include s3_encrypt_key_id among upload_credentials

### DIFF
--- a/deploy/docker/local/docker_development.ini.template
+++ b/deploy/docker/local/docker_development.ini.template
@@ -32,6 +32,7 @@ encoded_version = 100.200.300
 snovault_version = 200.300.400
 utils_version = 300.400.500
 eb_app_version = app-v-development-simulation
+s3_encrypt_key_id = ${S3_ENCRYPT_KEY_ID}
 
 [pipeline:debug]
 pipeline =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.12.1"
+version = "7.13.0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/prepare_docker.py
+++ b/src/encoded/commands/prepare_docker.py
@@ -36,11 +36,12 @@ def template_creator(extra_environment_variables):
     return create_from_template
 
 
-def prepare_docker(data_set=DEFAULT_DATA_SET, load_inserts=False, run_tests=False):
+def prepare_docker(data_set=DEFAULT_DATA_SET, load_inserts=False, run_tests=False, s3_encrypt_key_id=""):
     extra_vars = {
         "DATA_SET": data_set,
         "LOAD_INSERTS": "true" if load_inserts else "",
         "RUN_TESTS": "true" if run_tests else "",
+        "S3_ENCRYPT_KEY_ID": s3_encrypt_key_id,
     }
     prepare_from_template = template_creator(extra_vars)
     prepare_from_template(DOCKER_COMPOSE_FILE, expect_change=True)
@@ -58,9 +59,15 @@ def main():
                         help="if supplied, causes inserts to be loaded (default: not loaded)")
     parser.add_argument("--run-tests", default=False, action="store_true",
                         help="if supplied, causes tests to be run in container (default: not tested)")
+    parser.add_argument('--s3-encrypt-key-id', default="",
+                        help="an encrypt key id (default: the empty string)")
+
     args = parser.parse_args()
     logging.basicConfig()
-    prepare_docker(data_set=args.data_set, load_inserts=args.load_inserts, run_tests=args.run_tests)
+    prepare_docker(data_set=args.data_set,
+                   load_inserts=args.load_inserts,
+                   run_tests=args.run_tests,
+                   s3_encrypt_key_id=args.s3_encrypt_key_id)
 
 
 if __name__ == '__main__':

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -150,6 +150,7 @@ def external_creds(bucket, key, name=None, profile_name=None):
             'upload_url': f's3://{bucket}/{key}',
             'federated_user_arn': token.get('FederatedUser').get('Arn'),
             'federated_user_id': token.get('FederatedUser').get('FederatedUserId'),
+            's3_encrypt_key_id': s3_encrypt_key_id,
             'request_id': token.get('ResponseMetadata').get('RequestId'),
             'key': key
         })


### PR DESCRIPTION
* Include `s3_encrypt_key_id` among `upload_credentials` for data files.
* Change `prepare-docker` to accept an `--s3-encrypt-key-id` argument.
