### PR TITLE
reorganize user inserts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.13.1"
+version = "7.13.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/data/demo_inserts/project.json
+++ b/src/encoded/tests/data/demo_inserts/project.json
@@ -23,5 +23,23 @@
         "aliases": [
             "hms-dbmi:standards"
         ]
+    },
+    {
+        "title": "Brigham Genomic Medicine",
+        "uuid": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
+        "pi": "986b362f-4eb6-4a9c-8173-3acba722bba1",
+        "name": "brigham-genomic-medicine",
+        "status": "shared",
+        "aliases": ["hms-dbmi:BGM"],
+        "date_created": "2020-07-21T17:19:17.058289+00:00"
+    },
+    {
+        "name": "multiple-system-atrophy",
+        "title": "Multiple System Atrophy",
+        "aliases": ["hms-dbmi:msa"],
+        "status": "shared",
+        "description": "Project for the Multiple System Atrophy Coalition's cases",
+        "date_created": "2020-10-27T20:08:55.654261+00:00",
+        "uuid": "a97a4781-75aa-436d-baca-829335263cdf"
     }
 ]

--- a/src/encoded/tests/data/inserts/institution.json
+++ b/src/encoded/tests/data/inserts/institution.json
@@ -1,0 +1,48 @@
+[
+    {
+        "address2": "75 Francis Street",
+        "address1": "Brigham and Women's Hospital",
+        "city": "Boston",
+        "country": "USA",
+        "fax": "000-000-0000",
+        "name": "bwh",
+        "status": "shared",
+        "phone1": "000-000-0000",
+        "phone2": "000-000-0000",
+        "pi": "jkrier@bwh.harvard.edu",
+        "postal_code": "02115",
+        "state": "MA",
+        "title": "BWH",
+        "uuid": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca234",
+        "contact_persons" : [
+            "jkrier@bwh.harvard.edu"
+        ]
+    },
+    {
+        "address2": "300 Longwood Avenue",
+        "address1": "Boston Children's Hospital",
+        "city": "Boston",
+        "country": "USA",
+        "fax": "000-000-0000",
+        "name": "bch",
+        "status": "shared",
+        "phone1": "000-000-0000",
+        "phone2": "000-000-0000",
+        "pi": "dvuzman@research.bwh.harvard.edu",
+        "postal_code": "02115",
+        "state": "MA",
+        "title": "BCH",
+        "uuid": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca765",
+        "contact_persons": [
+            "dvuzman@research.bwh.harvard.edu"
+        ]
+    },
+    {
+        "name": "msa-coalition",
+        "title": "Multiple System Atrophy Coalition",
+        "aliases": ["msa:msa-institution"],
+        "status": "shared",
+        "date_created": "2020-11-03T22:19:15.807261+00:00",
+        "uuid": "232539d0-41aa-4cdc-835d-7f164f1462ea"
+    }
+]

--- a/src/encoded/tests/data/inserts/project.json
+++ b/src/encoded/tests/data/inserts/project.json
@@ -1,0 +1,20 @@
+[
+    {
+        "title": "Brigham Genomic Medicine",
+        "uuid": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
+        "pi": "986b362f-4eb6-4a9c-8173-3acba722bba1",
+        "name": "brigham-genomic-medicine",
+        "status": "shared",
+        "aliases": ["hms-dbmi:BGM"],
+        "date_created": "2020-07-21T17:19:17.058289+00:00"
+    },
+    {
+        "name": "multiple-system-atrophy",
+        "title": "Multiple System Atrophy",
+        "aliases": ["hms-dbmi:msa"],
+        "status": "shared",
+        "description": "Project for the Multiple System Atrophy Coalition's cases",
+        "date_created": "2020-10-27T20:08:55.654261+00:00",
+        "uuid": "a97a4781-75aa-436d-baca-829335263cdf"
+    }
+]

--- a/src/encoded/tests/data/inserts/user.json
+++ b/src/encoded/tests/data/inserts/user.json
@@ -1,0 +1,33 @@
+[
+    {
+        "email": "jkrier@bwh.harvard.edu",
+        "first_name": "Joel",
+        "last_name": "Krier",
+        "uuid": "986b362f-4eb6-4a9c-8173-3acba722bba1",
+        "project": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
+        "project_roles": [
+            {
+                "project": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
+                "role": "clinician"
+            }
+        ],
+        "user_institution": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca234"
+    },
+    {
+        "email": "aghazani@bwh.harvard.edu",
+        "first_name": "Arezou",
+        "last_name": "Ghazani",
+        "uuid": "f9524d43-01b5-4b71-94c6-32d2d09c3343",
+        "groups": [
+            "admin"
+        ],
+        "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
+        "project_roles": [
+            {
+                "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
+                "role": "developer"
+            }
+        ],
+        "user_institution": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca234"
+    }
+]

--- a/src/encoded/tests/data/master-inserts/institution.json
+++ b/src/encoded/tests/data/master-inserts/institution.json
@@ -29,51 +29,5 @@
         "title": "CGAP Backend Team",
         "status": "shared",
         "uuid": "87199845-51b5-4352-bdea-583edae4bb6a"
-    },
-    {
-        "address2": "75 Francis Street",
-        "address1": "Brigham and Women's Hospital",
-        "city": "Boston",
-        "country": "USA",
-        "fax": "000-000-0000",
-        "name": "bwh",
-        "status": "shared",
-        "phone1": "000-000-0000",
-        "phone2": "000-000-0000",
-        "pi": "jkrier@bwh.harvard.edu",
-        "postal_code": "02115",
-        "state": "MA",
-        "title": "BWH",
-        "uuid": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca234",
-        "contact_persons" : [
-            "jkrier@bwh.harvard.edu"
-        ]
-    },
-    {
-        "address2": "300 Longwood Avenue",
-        "address1": "Boston Children's Hospital",
-        "city": "Boston",
-        "country": "USA",
-        "fax": "000-000-0000",
-        "name": "bch",
-        "status": "shared",
-        "phone1": "000-000-0000",
-        "phone2": "000-000-0000",
-        "pi": "dvuzman@research.bwh.harvard.edu",
-        "postal_code": "02115",
-        "state": "MA",
-        "title": "BCH",
-        "uuid": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca765",
-        "contact_persons": [
-            "dvuzman@research.bwh.harvard.edu"
-        ]
-    },
-    {
-        "name": "msa-coalition",
-        "title": "Multiple System Atrophy Coalition",
-        "aliases": ["msa:msa-institution"],
-        "status": "shared",
-        "date_created": "2020-11-03T22:19:15.807261+00:00",
-        "uuid": "232539d0-41aa-4cdc-835d-7f164f1462ea"
     }
 ]

--- a/src/encoded/tests/data/master-inserts/project.json
+++ b/src/encoded/tests/data/master-inserts/project.json
@@ -22,23 +22,5 @@
         "name": "cgap-backend-testing",
         "status": "shared",
         "date_created": "2020-11-24T20:46:00.000000+00:00"
-    },
-    {
-        "title": "Brigham Genomic Medicine",
-        "uuid": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
-        "pi": "986b362f-4eb6-4a9c-8173-3acba722bba1",
-        "name": "brigham-genomic-medicine",
-        "status": "shared",
-        "aliases": ["hms-dbmi:BGM"],
-        "date_created": "2020-07-21T17:19:17.058289+00:00"
-    },
-    {
-        "name": "multiple-system-atrophy",
-        "title": "Multiple System Atrophy",
-        "aliases": ["hms-dbmi:msa"],
-        "status": "shared",
-        "description": "Project for the Multiple System Atrophy Coalition's cases",
-        "date_created": "2020-10-27T20:08:55.654261+00:00",
-        "uuid": "a97a4781-75aa-436d-baca-829335263cdf"
     }
 ]

--- a/src/encoded/tests/data/master-inserts/user.json
+++ b/src/encoded/tests/data/master-inserts/user.json
@@ -210,20 +210,6 @@
         "date_created": "2021-05-04T22:05:01.596462+00:00"
     },
     {
-        "email": "jkrier@bwh.harvard.edu",
-        "first_name": "Joel",
-        "last_name": "Krier",
-        "uuid": "986b362f-4eb6-4a9c-8173-3acba722bba1",
-        "project": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
-        "project_roles": [
-            {
-                "project": "c2f37035-f7df-4e00-aca7-6bfbe2d5f936",
-                "role": "clinician"
-            }
-        ],
-        "user_institution": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca234"
-    },
-    {
         "email": "andrew_schroeder@hms.harvard.edu",
         "first_name": "Andy",
         "last_name": "Schroeder",
@@ -331,23 +317,6 @@
             }
         ],
         "user_institution": "828cd4fe-ebb0-4b36-a94a-d2e3a36cc989"
-    },
-    {
-        "email": "aghazani@bwh.harvard.edu",
-        "first_name": "Arezou",
-        "last_name": "Ghazani",
-        "uuid": "f9524d43-01b5-4b71-94c6-32d2d09c3343",
-        "groups": [
-            "admin"
-        ],
-        "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
-        "project_roles": [
-            {
-                "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
-                "role": "developer"
-            }
-        ],
-        "user_institution": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca234"
     },
     {
         "email": "sarah_reiff@hms.harvard.edu",


### PR DESCRIPTION
We don't want certain users with inserts, like Joel and Arezou, to be added to every CGAP deployment (like MSA). I have moved them to the "inserts" directory out of "master-inserts" for now, so the inserts are still available if we need them.