### PR TITLE
New gene link-outs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.15.2"
+version = "7.16.0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/gene.json
+++ b/src/encoded/schemas/gene.json
@@ -563,6 +563,12 @@
             "schema_title": "Marrvel",
             "link": "http://v1.marrvel.org/search/gene/<ID>"
         },
+        "medline_plus": {
+            "title": "MedlinePlus",
+            "type": "string",
+            "description": "Formerly Genetics Home Reference, a resource from the National Library of Medicine for features and inheritance of genetic conditions.",
+            "link": "https://medlineplus.gov/genetics/gene/<ID>/"
+        },
         "mgd_id": {
             "title": "MGI",
             "type": "array",

--- a/src/encoded/schemas/gene.json
+++ b/src/encoded/schemas/gene.json
@@ -398,6 +398,12 @@
             "description": "gene damage prediction (low/medium/high) by GDI for all diseases",
             "schema_title": "Gene damage prediction (all disease-causing genes)"
         },
+        "gencc": {
+            "title": "GenCC",
+            "description": "GenCC provides information pertaining to the validity of gene-disease relationships, with a current focus on Mendelian diseases.",
+            "type": "string",
+            "link": "https://search.thegencc.org/genes/<ID>"
+        },
         "gene_biotype": {
             "title": "Gene biotype",
             "field_name": "gene_biotype",

--- a/src/encoded/schemas/variant_sample_list.json
+++ b/src/encoded/schemas/variant_sample_list.json
@@ -107,12 +107,13 @@
                         "type": "string",
                         "description": "Stringified JSON representing the compound filter block request made when this Structural Variant Sample was selected"
                     },
-                    "userid": {
-                        "title": "User ID",
+                    "selected_by": {
+                        "title": "Selector",
                         "type": "string",
-                        "description": "User ID of person who made this selection",
+                        "description": "Person who made this selection",
                         "serverDefault": "userid",
-                        "format": "uuid"
+                        "linkTo": "User",
+                        "permission": "restricted_fields"
                     },
                     "date_selected": {
                         "title": "Date Selected",

--- a/src/encoded/static/components/item-pages/VariantSampleView/AnnotationSections.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/AnnotationSections.js
@@ -35,6 +35,7 @@ export const ExternalDatabasesSection = React.memo(function ExternalDatabasesSec
         externalDatabaseFieldnames = [
             "genecards",
             "medline_plus",
+            "gencc",
             "ensgid",
             "entrez_id",
             "hgnc_id",

--- a/src/encoded/static/components/item-pages/VariantSampleView/AnnotationSections.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/AnnotationSections.js
@@ -34,6 +34,7 @@ export const ExternalDatabasesSection = React.memo(function ExternalDatabasesSec
 
         externalDatabaseFieldnames = [
             "genecards",
+            "medline_plus",
             "ensgid",
             "entrez_id",
             "hgnc_id",


### PR DESCRIPTION
We update the schema for genes to allow for two new gene link-outs, to be manually patched after deployment. Gene inserts are also updated with the corresponding fields for new environments.

Additionally, we rename a sub-embedded property on VariantSampleLists to harmonize property names for both SNV and SV variant samples.