### PR TITLE
SNV Coding Effect to Consequence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "7.17.5"
+version = "7.17.6"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/variant_sample.json
+++ b/src/encoded/schemas/variant_sample.json
@@ -559,8 +559,8 @@
             "title": "Location",
             "order": 25
         },
-        "variant.genes.genes_most_severe_consequence.coding_effect": {
-            "title": "Coding Effect",
+        "variant.genes.genes_most_severe_consequence.display_title": {
+            "title": "Consequence",
             "order": 30
         },
         "GT": {

--- a/src/encoded/static/components/item-pages/VariantSampleView/VariantSampleInfoHeader.js
+++ b/src/encoded/static/components/item-pages/VariantSampleView/VariantSampleInfoHeader.js
@@ -184,7 +184,7 @@ function TranscriptSelectionSectionBody({ schemas, currentTranscript }){
         return getTranscriptLocation(currentTranscript, mostSevereConsequence);
     }, [ currentTranscript, mostSevereConsequence ]);
 
-    const { coding_effect: consequenceCodingEffect = fallbackElem } = mostSevereConsequence || {};
+    const { display_title: consequenceTitle = fallbackElem } = mostSevereConsequence || {};
 
     return (
         <div className="row">
@@ -206,13 +206,13 @@ function TranscriptSelectionSectionBody({ schemas, currentTranscript }){
 
                 <div className="row mb-03">
                     <div className="col-12 col-lg-5 col-xl-6">
-                        <label htmlFor="variant.transcript.csq_consequence.coding_effect" className="mb-0"
-                            data-tip={getTipForField("transcript.csq_consequence.coding_effect")}>
-                            Coding Effect:
+                        <label htmlFor="variant.transcript.csq_consequence" className="mb-0"
+                            data-tip={getTipForField("transcript.csq_consequence")}>
+                            Consequence:
                         </label>
                     </div>
-                    <div className="col-12 col-lg-auto" id="variant.transcript.csq_consequence.coding_effect">
-                        { consequenceCodingEffect }
+                    <div className="col-12 col-lg-auto" id="variant.transcript.csq_consequence">
+                        { consequenceTitle }
                     </div>
                 </div>
 

--- a/src/encoded/tests/test_types_variant_consequence.py
+++ b/src/encoded/tests/test_types_variant_consequence.py
@@ -1,18 +1,26 @@
 import pytest
+
 pytestmark = [pytest.mark.working, pytest.mark.schema]
 
 
 def test_calculated_variant_consequence_display_title(testapp, project, institution):
     var_conseq_info = {
-        'SO:0001893': ['transcript_ablation', 'Transcript ablation'],
-        'SO:0001626': ['incomplete_terminal_codon_variant', 'Incomplete terminal codon variant'],
+        "SO:0001893": ["transcript_ablation", "Transcript ablation"],
+        "SO:0001626": [
+            "incomplete_terminal_codon_variant",
+            "Incomplete terminal codon variant",
+        ],
+        "SO:0001624": ["3_prime_UTR_variant", "3 prime UTR variant"],
+        "SO:0001892": ["TFBS_amplification", "TFBS amplification"],
     }
     for vcid, vcnames in var_conseq_info.items():
         vc = {
-            'project': project['@id'],
-            'institution': institution['@id'],
-            'var_conseq_id': vcid,
-            'var_conseq_name': vcnames[0]
+            "project": project["@id"],
+            "institution": institution["@id"],
+            "var_conseq_id": vcid,
+            "var_conseq_name": vcnames[0],
         }
-        res = testapp.post_json('/variant_consequence', vc, status=201).json['@graph'][0]
-        assert res.get('display_title') == vcnames[1]
+        res = testapp.post_json(
+            "/variant_consequence", vc, status=201
+        ).json["@graph"][0]
+        assert res.get("display_title") == vcnames[1]

--- a/src/encoded/types/variant_consequence.py
+++ b/src/encoded/types/variant_consequence.py
@@ -31,5 +31,7 @@ class VariantConsequence(Item):
         "type": "string"
     })
     def display_title(self, request, var_conseq_name):
-        ''' var_conseq_name is a required property '''
-        return var_conseq_name.capitalize().replace('_', ' ')
+        """Create consequence title."""
+        result = var_conseq_name.replace("_", " ")
+        result = result[0].upper() + result[1:]  # Retain existing capital letters
+        return result


### PR DESCRIPTION
In this small PR, we swap the display of VariantSamples' most severe consequence's coding effect to their most severe consequence display title, which is more informative for non-coding variants.

Also, we fix the VariantConsequence display title calculated property to retain capitalized words as well as capitalize the first letter.