### PR TITLE
April Cypress fixes

### DIFF
--- a/.github/workflows/cypress-tests-production.yml
+++ b/.github/workflows/cypress-tests-production.yml
@@ -42,5 +42,5 @@ jobs:
           Auth0Client: ${{ secrets.Auth0Client }}
           Auth0Secret: ${{ secrets.Auth0Secret }}
         run: |
-         $(npm bin)/cypress run --record --key $CYPRESS_KEY --env Auth0Client=$Auth0Client,Auth0Secret=$Auth0Secret --project ./deploy/post_deploy_testing --browser chrome --config baseUrl=https://cgap.hms.harvard.edu/ --parallel
+         $(npm bin)/cypress run --record --key $CYPRESS_KEY --env Auth0Client=$Auth0Client,Auth0Secret=$Auth0Secret --project ./deploy/post_deploy_testing --browser chrome --config baseUrl=https://cgap-mgb.hms.harvard.edu/ --parallel
 

--- a/deploy/post_deploy_testing/cypress.json
+++ b/deploy/post_deploy_testing/cypress.json
@@ -1,5 +1,5 @@
 {
-    "baseUrl" : "https://cgap.hms.harvard.edu",
+    "baseUrl" : "https://cgap-mgb.hms.harvard.edu/",
     "projectId": "9hf9k3",
     "defaultCommandTimeout" : 60000,
     "pageLoadTimeout" : 120000,


### PR DESCRIPTION
Cypress tests broke due to URL switch; this just points the baseURLs for Cypress to new training account