### PR TITLE
Open child tabs, convert links to buttons.

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -1149,7 +1149,7 @@ export default class App extends React.PureComponent {
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com  https://unpkg.com",
             "font-src 'self' https://fonts.gstatic.com",
             "worker-src 'self' blob:",
-            "connect-src 'self' https://cgap-higlass.com https://*.s3.amazonaws.com https://rest.ensembl.org https://eutils.ncbi.nlm.nih.gov https://cgap-higlass.s3.amazonaws.com"
+            "connect-src 'self' https://cgap-higlass.com https://*.s3.amazonaws.com https://rest.ensembl.org https://eutils.ncbi.nlm.nih.gov"
         ].join("; ");
 
         // `lastBuildTime` is used for both CSS and JS because is most likely they change at the same time on production from recompiling

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -64,7 +64,7 @@ export default class App extends React.PureComponent {
      * @constant
      * @type {number}
      */
-    static SLOW_REQUEST_TIME = 750
+    static SLOW_REQUEST_TIME = 750;
 
     /**
      * Immediately scrolls browser viewport to current window hash or to top of page.
@@ -1084,7 +1084,7 @@ export default class App extends React.PureComponent {
 
     /** Renders the entire HTML of the application. */
     render() {
-        const { context, lastCSSBuildTime, href, contextRequest } = this.props;
+        const { context, lastBuildTime, href, contextRequest } = this.props;
         const { mounted = false } = this.state;
         const hrefParts = memoizedUrlParse(href);
         const routeList = hrefParts.pathname.split("/");
@@ -1149,10 +1149,10 @@ export default class App extends React.PureComponent {
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com  https://unpkg.com",
             "font-src 'self' https://fonts.gstatic.com",
             "worker-src 'self' blob:",
-            "connect-src 'self' https://cgap-higlass.com https://*.s3.amazonaws.com https://rest.ensembl.org https://eutils.ncbi.nlm.nih.gov"
+            "connect-src 'self' https://cgap-higlass.com https://*.s3.amazonaws.com https://rest.ensembl.org https://eutils.ncbi.nlm.nih.gov https://cgap-higlass.s3.amazonaws.com"
         ].join("; ");
 
-        // `lastCSSBuildTime` is used for both CSS and JS because is most likely they change at the same time on production from recompiling
+        // `lastBuildTime` is used for both CSS and JS because is most likely they change at the same time on production from recompiling
 
         return (
             <html lang="en">
@@ -1167,13 +1167,13 @@ export default class App extends React.PureComponent {
                     <script data-prop-name="user_info" type="application/json" dangerouslySetInnerHTML={mounted ? null : {
                         __html: jsonScriptEscape(JSON.stringify(JWT.getUserInfo())) /* Kept up-to-date in browser.js */
                     }}/>
-                    <script data-prop-name="lastCSSBuildTime" type="application/json" dangerouslySetInnerHTML={{ __html: lastCSSBuildTime }}/>
-                    <link rel="stylesheet" href={'/static/css/style.css?build=' + (lastCSSBuildTime || 0)} />
-                    <DeferMount><link rel="stylesheet" media="print" href={'/static/css/print.css?build=' + (lastCSSBuildTime || 0)} /></DeferMount>
+                    <script data-prop-name="lastBuildTime" type="application/json" dangerouslySetInnerHTML={{ __html: lastBuildTime }}/>
+                    <link rel="stylesheet" href={'/static/css/style.css?build=' + (lastBuildTime || 0)} />
+                    <DeferMount><link rel="stylesheet" media="print" href={'/static/css/print.css?build=' + (lastBuildTime || 0)} /></DeferMount>
                     <SEO.CurrentContext {...{ context, hrefParts, baseDomain }} />
                     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900,300i,400i,600i|Yrsa|Source+Code+Pro:300,400,500,600" rel="stylesheet"/>
                     <script defer type="application/javascript" src="//www.google-analytics.com/analytics.js" />
-                    <script defer type="application/javascript" src={"/static/build/bundle.js?build=" + (lastCSSBuildTime || 0)} charSet="utf-8" />
+                    <script defer type="application/javascript" src={"/static/build/bundle.js?build=" + (lastBuildTime || 0)} charSet="utf-8" />
                     <link rel="canonical" href={canonical} />
                     {/* <script data-prop-name="inline" type="application/javascript" charSet="utf-8" dangerouslySetInnerHTML={{__html: this.props.inline}}/> <-- SAVED FOR REFERENCE */}
                 </head>

--- a/src/encoded/static/components/browse/variantSampleColumnExtensionMap.js
+++ b/src/encoded/static/components/browse/variantSampleColumnExtensionMap.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { getInitialTranscriptIndex, getMostSevereConsequence } from '../item-pages/VariantSampleView/AnnotationSections';
-import { onClickLinkNavigateChildWindow } from './../item-pages/components/child-window-reuser';
+import { onClickLinkNavigateChildWindow } from '../item-pages/components/child-window-controls';
 
 /**
  * This gets merged into the columnExtensionMap.js.
@@ -50,14 +50,18 @@ export const variantSampleColumnExtensionMap = {
         widthMap: { 'lg' : 155, 'md' : 140, 'sm' : 130 },
         render: function(result, props) {
             const { link = null, align } = props;
-            const { "@id": atID = null, variant: { genes = [] } = {} } = result || {};
+            const { "@id": atID = null, uuid: resultUUID, variant: { genes = [] } = {} } = result || {};
             if (genes.length === 0) {
                 return null;
             }
+
+            const targetHref = link ? link : (atID ? atID + '?annotationTab=0' : "#");
+
             return (
-                <a href={link ? link : atID ? atID + '?annotationTab=0' : "#"} className="d-block mx-auto" onClick={onClickLinkNavigateChildWindow}>
+                <button type="button" onClick={onClickLinkNavigateChildWindow} data-href={targetHref}
+                    data-child-window={resultUUID} className="text-truncate btn btn-link p-0 w-100">
                     <GenesMostSevereDisplayTitle {...{ result, align }} />
-                </a>
+                </button>
             );
         }
     },
@@ -68,17 +72,20 @@ export const variantSampleColumnExtensionMap = {
         widthMap: { 'lg' : 140, 'md' : 130, 'sm' : 120 },
         render: function(result, props) {
             const { link = null, align } = props;
-            const { "@id" : atID = null, variant : { genes : [ firstGene = null ] = [] } = {} } = result;
+            const { "@id" : atID = null, uuid: resultUUID, variant : { genes : [ firstGene = null ] = [] } = {} } = result;
             const { genes_most_severe_hgvsc = null, genes_most_severe_hgvsp = null } = firstGene || {};
 
             if (!genes_most_severe_hgvsc && !genes_most_severe_hgvsp) {
                 return null;
             }
 
+            const targetHref = link ? link : (atID ? atID + '?annotationTab=1' : "#");
+
             return (
-                <a href={link ? link : (atID ? atID + '?annotationTab=1' : "#")} onClick={onClickLinkNavigateChildWindow}>
+                <button type="button" onClick={onClickLinkNavigateChildWindow} data-href={targetHref}
+                    data-child-window={resultUUID} className="text-truncate btn btn-link p-0 w-100">
                     <GenesMostSevereHGVSCColumn gene={firstGene} align={align} />
-                </a>
+                </button>
             );
         }
     },
@@ -189,14 +196,17 @@ export const structuralVariantSampleColumnExtensionMap = {
     // Gene, Transcript col
     "structural_variant.transcript": {
         render: (result, props) => {
-            const { "@id": atID, structural_variant: { transcript: transcripts = [] } = {} } = result || {};
+            const { "@id": atID, uuid: resultUUID, structural_variant: { transcript: transcripts = [] } = {} } = result || {};
             const { align = "left", link } = props;
             if (transcripts.length === 0) return null;
 
+            const targetHref = link ? link : (atID ? atID + '?annotationTab=0' : "#");
+
             return (
-                <a href={link ? link : (atID ? atID + '?annotationTab=0' : "#")} onClick={onClickLinkNavigateChildWindow}>
+                <button type="button" onClick={onClickLinkNavigateChildWindow} data-href={targetHref}
+                    data-child-window={resultUUID} className="text-truncate text-left btn btn-link p-0">
                     <StructuralVariantTranscriptColumn {...{ result, align }} />
-                </a>
+                </button>
             );
         }
     }
@@ -219,24 +229,31 @@ export function StackedRowColumn(props) {
 /** An edited version of SPC's DisplayTitleColumnDefault */
 export const VariantSampleDisplayTitleColumn = React.memo(function VariantSampleDisplayTitleColumn(props) {
     const { result = null, link, onClick, className = null } = props;
-    const { variant = null } = result || {};
-    const { display_title = null, ID = null } = variant || {};
+    const {
+        "@id": atID,
+        uuid: resultUUID,
+        variant: {
+            display_title: variantTitle = null,
+            ID: variantID = null
+        } = {}
+    } = result || {};
 
     const cls = ("title-block" + (className ? " " + className : ""));
     const rows = [
         <span key={0} className="d-block text-600 text-truncate">
-            { display_title }
+            { variantTitle }
         </span>
     ];
 
-    if (ID) {
-        rows.push(<span key={1} className="font-italic">{ ID }</span>);
+    if (variantID) {
+        rows.push(<span key={1} className="font-italic">{ variantID }</span>);
     }
 
     return (
-        <a key="title" href={link || '#'} onClick={onClick} className="d-block text-truncate">
+        <button type="button" onClick={onClick} data-href={link || atID}
+            data-child-window={resultUUID} className="text-truncate text-left btn btn-link p-0">
             <StackedRowColumn className={cls} {...{ rows }}  />
-        </a>
+        </button>
     );
 });
 
@@ -245,6 +262,7 @@ export const VariantSampleDisplayTitleColumnSV = React.memo(function VariantSamp
     const { result = null, link, onClick, className = null } = props;
     const {
         "@id": atID,
+        uuid: resultUUID,
         structural_variant: {
             display_title = "",
             annotation_id = ""
@@ -264,9 +282,10 @@ export const VariantSampleDisplayTitleColumnSV = React.memo(function VariantSamp
     // (defined in SPC's basicColumnExtensionMap>DisplayTitleColumnWrapper) handle target="_blank".
 
     return (
-        <a key="title" href={link || atID} onClick={onClick} className="d-block text-truncate">
+        <button type="button" onClick={onClick} data-href={link || atID}
+            data-child-window={resultUUID} className="text-truncate text-left btn btn-link p-0">
             <StackedRowColumn className={cls} {...{ rows }}  />
-        </a>
+        </button>
     );
 });
 
@@ -437,11 +456,11 @@ export const ProbandGenotypeLabelColumn = React.memo(function ProbandGenotypeLab
 });
 
 export const BAMSnapshotColumn = React.memo(function BAMSnapshotColumn({ result }) {
-    const { "@id": resultAtID = null } = result;
+    const { "@id": resultAtID = null, uuid: resultUUID } = result;
     return (
         <div className="mx-auto text-truncate">
             <a className="btn btn-outline-dark btn-sm" onClick={onClickLinkNavigateChildWindow}
-                href={resultAtID + "@@download/"} data-child-window="bam" data-child-window-message="false"
+                href={resultAtID + "@@download/"} data-child-window={"bam-" + resultUUID} data-child-window-message="false"
                 data-html data-tip="View BAM Snapshot <i class='ml-07 icon-sm icon fas icon-external-link-alt'></i>">
                 <i className="icon icon-fw icon-image fas" />
             </a>

--- a/src/encoded/static/components/browse/variantSampleColumnExtensionMap.js
+++ b/src/encoded/static/components/browse/variantSampleColumnExtensionMap.js
@@ -459,11 +459,11 @@ export const BAMSnapshotColumn = React.memo(function BAMSnapshotColumn({ result 
     const { "@id": resultAtID = null, uuid: resultUUID } = result;
     return (
         <div className="mx-auto text-truncate">
-            <a className="btn btn-outline-dark btn-sm" onClick={onClickLinkNavigateChildWindow}
+            <button type="button" className="btn btn-outline-dark btn-sm" onClick={onClickLinkNavigateChildWindow}
                 href={resultAtID + "@@download/"} data-child-window={"bam-" + resultUUID} data-child-window-message="false"
                 data-html data-tip="View BAM Snapshot <i class='ml-07 icon-sm icon fas icon-external-link-alt'></i>">
                 <i className="icon icon-fw icon-image fas" />
-            </a>
+            </button>
         </div>
     );
 });

--- a/src/encoded/static/components/item-pages/CaseView/CaseViewEmbeddedVariantSampleSearchTable.js
+++ b/src/encoded/static/components/item-pages/CaseView/CaseViewEmbeddedVariantSampleSearchTable.js
@@ -7,7 +7,7 @@ import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
 import { console, ajax } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { DisplayTitleColumnWrapper } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
 import { EmbeddedItemSearchTable } from './../components/EmbeddedItemSearchTable';
-import { navigateChildWindow } from './../components/child-window-reuser';
+import { navigateChildWindow } from '../components/child-window-controls';
 import { VariantSampleDisplayTitleColumn, VariantSampleDisplayTitleColumnSV } from './../../browse/variantSampleColumnExtensionMap';
 import { StackedRowColumn } from '../../browse/variantSampleColumnExtensionMap';
 
@@ -39,9 +39,9 @@ export function CaseViewEmbeddedVariantSampleSearchTable(props){
                 "widthMap": { 'lg' : 250, 'md' : 220, 'sm' : 200 },
                 "minColumnWidth" : (originalColExtMap.display_title.minColumnWidth || 100) + 20,
                 "render": function(result, parentProps){
-                    const { href, context, rowNumber, detailOpen, toggleDetailOpen } = parentProps;
+                    const { context, rowNumber, detailOpen, toggleDetailOpen } = parentProps;
                     return (
-                        <VariantSampleDisplayTitleColumnWrapper {...{ result, href, context, rowNumber, detailOpen, toggleDetailOpen,
+                        <VariantSampleDisplayTitleColumnWrapper {...{ result, context, rowNumber, detailOpen, toggleDetailOpen,
                             selectedVariantSamples, onSelectVariantSample, savedVariantSampleIDMap, isLoadingVariantSampleListItem }}>
                             <VariantSampleDisplayTitleColumn />
                         </VariantSampleDisplayTitleColumnWrapper>
@@ -96,9 +96,9 @@ export function CaseViewEmbeddedVariantSampleSearchTableSV(props) {
                 "widthMap": { 'lg' : 250, 'md' : 220, 'sm' : 200 },
                 "minColumnWidth" : (originalColExtMap.display_title.minColumnWidth || 100) + 20,
                 "render": function(result, parentProps){
-                    const { href, context, rowNumber, detailOpen, toggleDetailOpen } = parentProps;
+                    const { context, rowNumber, detailOpen, toggleDetailOpen } = parentProps;
                     return (
-                        <VariantSampleDisplayTitleColumnWrapper {...{ result, href, context, rowNumber, detailOpen, toggleDetailOpen,
+                        <VariantSampleDisplayTitleColumnWrapper {...{ result, context, rowNumber, detailOpen, toggleDetailOpen,
                             selectedVariantSamples, onSelectVariantSample, savedVariantSampleIDMap, isLoadingVariantSampleListItem }}>
                             <VariantSampleDisplayTitleColumnSV />
                         </VariantSampleDisplayTitleColumnWrapper>
@@ -166,7 +166,9 @@ export function CaseViewEmbeddedVariantSampleSearchTableSV(props) {
     return <EmbeddedItemSearchTable {...passProps} {...{ columnExtensionMap }} stickyFirstColumn />;
 }
 
-/** Open Variant Sample in new window */
+/**
+ * Open Variant Sample in new window
+ */
 function VariantSampleDisplayTitleColumnWrapper (props) {
     const {
         result, href, context, rowNumber, detailOpen, toggleDetailOpen,
@@ -177,8 +179,8 @@ function VariantSampleDisplayTitleColumnWrapper (props) {
     const onClick = useCallback(function(evt){
         evt.preventDefault();
         evt.stopPropagation(); // Avoid having event bubble up and being caught by App.js onClick.
-        const { "@id": resultAtID } = result;
-        navigateChildWindow(resultAtID);
+        const { "@id": resultAtID, uuid: resultUUID } = result;
+        navigateChildWindow(resultAtID, resultUUID);
         return false;
     }, [ result ]);
 
@@ -188,7 +190,7 @@ function VariantSampleDisplayTitleColumnWrapper (props) {
     }
 
     return (
-        <DisplayTitleColumnWrapper {...{ result, href, context, rowNumber, detailOpen, toggleDetailOpen, onClick }}>
+        <DisplayTitleColumnWrapper {...{ result, context, rowNumber, detailOpen, toggleDetailOpen, onClick }} link="#">
             { checkbox }{ children }
         </DisplayTitleColumnWrapper>
     );

--- a/src/encoded/static/components/item-pages/CaseView/VariantSampleSelection.js
+++ b/src/encoded/static/components/item-pages/CaseView/VariantSampleSelection.js
@@ -412,7 +412,7 @@ export const VariantSampleSelection = React.memo(function VariantSampleSelection
                                 { snvVariantColTitle || "Variant" }
                             </label>
                             <button type="button" onClick={onClickLinkNavigateChildWindow}
-                                data-href={vsID + '?showInterpretation=True&annotationTab=0&interpretationTab=1' + (caseAccession ? '&caseSource=' + caseAccession : '')}
+                                data-href={vsID + '?showInterpretation=True&annotationTab=1&interpretationTab=1' + (caseAccession ? '&caseSource=' + caseAccession : '')}
                                 data-child-window={vsUUID} className="btn btn-link p-0">
                                 <GenesMostSevereHGVSCColumn gene={firstGene} align="left" />
                             </button>

--- a/src/encoded/static/components/item-pages/CaseView/VariantSampleSelection.js
+++ b/src/encoded/static/components/item-pages/CaseView/VariantSampleSelection.js
@@ -355,8 +355,8 @@ export const VariantSampleSelection = React.memo(function VariantSampleSelection
             <div className="card-header pr-12">
                 <div className="d-flex flex-column flex-lg-row align-items-lg-center">
 
-                    <div className="flex-auto mb-08 mb-lg-0 overflow-hidden">
-                        <h4 className="text-truncate text-600 my-0 selected-vsl-title">
+                    <div className="flex-auto mb-08 mb-lg-0">
+                        <h4 className="text-600 my-0 selected-vsl-title d-flex align-items-center">
                             { parentTabType === parentTabTypes.CASEREVIEW ?
                                 <CaseReviewTabVariantSampleTitle {...{ noSavedNotes, countNotes, countNotesInReport, countNotesInKnowledgeBase, variantDisplayTitle, searchType }} />
                                 : <InterpretationTabVariantSampleTitle {...{ noSavedNotes, anyUnsavedChanges, isDeleted, vsID, vsUUID, caseAccession, variantDisplayTitle, searchType }} />
@@ -445,7 +445,7 @@ export const VariantSampleSelection = React.memo(function VariantSampleSelection
 
             <div className="card-body border-top attribution-section py-2">
                 <div className="row align-items-center">
-                    <div className="col d-flex-align-items-center">
+                    <div className="col d-flex align-items-center">
                         <FilterBlocksUsedPopovers {...{ selection, facetDict }} />
                     </div>
                     <div className="col-auto text-small"
@@ -530,7 +530,7 @@ function InterpretationTabVariantSampleTitle(props){
                 <i className={`icon align-middle icon-fw title-prefix-icon icon-${noSavedNotes ? "pen" : "sticky-note"} fas mr-12`}
                     data-tip={noSavedNotes ? "This sample has no annotations yet" : "This sample has at least one annotation saved"}/>
                 <button type="button" onClick={onClickLinkNavigateChildWindow} data-href={targetHref}
-                    data-child-window={vsUUID} className="btn btn-link p-0 text-larger text-600">
+                    data-child-window={vsUUID} className="btn btn-link p-0 text-larger text-600 text-truncate">
                     { variantDisplayTitle }
                 </button>
             </React.Fragment>

--- a/src/encoded/static/components/item-pages/CaseView/VariantSampleSelection.js
+++ b/src/encoded/static/components/item-pages/CaseView/VariantSampleSelection.js
@@ -12,7 +12,7 @@ import { Checkbox } from '@hms-dbmi-bgm/shared-portal-components/es/components/f
 import { decorateNumberWithCommas } from '@hms-dbmi-bgm/shared-portal-components/es/components/util/value-transforms';
 
 import { buildSchemaFacetDictionary } from './../../util/Schemas';
-import { onClickLinkNavigateChildWindow, onClickOpenChildWindow } from './../components/child-window-reuser';
+import { onClickLinkNavigateChildWindow } from '../components/child-window-controls';
 
 import {
     structuralVariantSampleColumnExtensionMap,
@@ -286,6 +286,7 @@ export const VariantSampleSelection = React.memo(function VariantSampleSelection
 
     const {
         "@id": vsID,
+        uuid: vsUUID,
         variant: { display_title: snvVariantDisplayTitle, genes: [ firstGene = null ] = [] } = {},
         structural_variant: { display_title: svVariantDisplayTitle } = {},
         interpretation: clinicalInterpretationNote = null,
@@ -358,7 +359,7 @@ export const VariantSampleSelection = React.memo(function VariantSampleSelection
                         <h4 className="text-truncate text-600 my-0 selected-vsl-title">
                             { parentTabType === parentTabTypes.CASEREVIEW ?
                                 <CaseReviewTabVariantSampleTitle {...{ noSavedNotes, countNotes, countNotesInReport, countNotesInKnowledgeBase, variantDisplayTitle, searchType }} />
-                                : <InterpretationTabVariantSampleTitle {...{ noSavedNotes, anyUnsavedChanges, isDeleted, vsID, caseAccession, variantDisplayTitle, searchType }} />
+                                : <InterpretationTabVariantSampleTitle {...{ noSavedNotes, anyUnsavedChanges, isDeleted, vsID, vsUUID, caseAccession, variantDisplayTitle, searchType }} />
                             }
                         </h4>
                     </div>
@@ -395,24 +396,26 @@ export const VariantSampleSelection = React.memo(function VariantSampleSelection
                         <label className="mb-04 text-small d-block" data-tip={variantIsSNV ? snvGeneTranscriptColDescription : svGeneTranscriptColDescription}>
                             { (variantIsSNV ? snvGeneTranscriptColTitle : svGeneTranscriptColTitle) || "Gene, Transcript" }
                         </label>
-                        <a href={vsID + '?showInterpretation=True&annotationTab=0&interpretationTab=0' + (caseAccession ? '&caseSource=' + caseAccession : '')}
-                            onClick={onClickOpenChildWindow}>
+                        <button type="button" onClick={onClickLinkNavigateChildWindow}
+                            data-href={vsID + '?showInterpretation=True&annotationTab=0&interpretationTab=0' + (caseAccession ? '&caseSource=' + caseAccession : '')}
+                            data-child-window={vsUUID} className="btn btn-link p-0">
                             { variantIsSNV ?
                                 <GenesMostSevereDisplayTitle result={variantSample} align="left" />
                                 :
                                 <StructuralVariantTranscriptColumn result={variantSample} align="left" />
                             }
-                        </a>
+                        </button>
                     </div>
                     { variantIsSNV ?
                         <div className="col col-sm-4 col-lg-2 py-2">
-                            <label className="mb-04 text-small" data-tip={snvVariantColDescription}>
+                            <label className="mb-04 text-small d-block" data-tip={snvVariantColDescription}>
                                 { snvVariantColTitle || "Variant" }
                             </label>
-                            <a href={vsID + '?showInterpretation=True&annotationTab=0&interpretationTab=1' + (caseAccession ? '&caseSource=' + caseAccession : '')}
-                                onClick={onClickLinkNavigateChildWindow}>
+                            <button type="button" onClick={onClickLinkNavigateChildWindow}
+                                data-href={vsID + '?showInterpretation=True&annotationTab=0&interpretationTab=1' + (caseAccession ? '&caseSource=' + caseAccession : '')}
+                                data-child-window={vsUUID} className="btn btn-link p-0">
                                 <GenesMostSevereHGVSCColumn gene={firstGene} align="left" />
-                            </a>
+                            </button>
                         </div>
                         : null }
                     { !variantIsSNV ?
@@ -511,9 +514,7 @@ export const DiscoveryCandidacyColumn = React.memo(function DiscoveryCandidacyCo
 
 
 function InterpretationTabVariantSampleTitle(props){
-    const { noSavedNotes, anyUnsavedChanges, isDeleted, vsID, variantDisplayTitle, caseAccession } = props;
-
-    const targetHref = vsID + "?showInterpretation=True&interpretationTab=1" + (caseAccession ? '&caseSource=' + caseAccession : '');
+    const { noSavedNotes, anyUnsavedChanges, isDeleted, vsID, vsUUID, variantDisplayTitle, caseAccession } = props;
 
     if (anyUnsavedChanges) {
         return (
@@ -523,13 +524,15 @@ function InterpretationTabVariantSampleTitle(props){
             </React.Fragment>
         );
     } else {
+        const targetHref = vsID + "?showInterpretation=True&interpretationTab=1" + (caseAccession ? '&caseSource=' + caseAccession : '');
         return (
             <React.Fragment>
                 <i className={`icon align-middle icon-fw title-prefix-icon icon-${noSavedNotes ? "pen" : "sticky-note"} fas mr-12`}
                     data-tip={noSavedNotes ? "This sample has no annotations yet" : "This sample has at least one annotation saved"}/>
-                <a href={targetHref} onClick={onClickOpenChildWindow}>
+                <button type="button" onClick={onClickLinkNavigateChildWindow} data-href={targetHref}
+                    data-child-window={vsUUID} className="btn btn-link p-0 text-larger text-600">
                     { variantDisplayTitle }
-                </a>
+                </button>
             </React.Fragment>
         );
     }

--- a/src/encoded/static/components/item-pages/components/child-window-controls.js
+++ b/src/encoded/static/components/item-pages/components/child-window-controls.js
@@ -28,38 +28,43 @@ export function navigateChildWindow(targetHref, windowName = null, postMessage =
     }
 }
 
-export function onClickLinkNavigateChildWindow(e){
+
+
+function onClickCommonHandler (e) {
     e.stopPropagation();
     e.preventDefault();
     const useEvtTarget = e.currentTarget || e.target;
     const childWindowName = useEvtTarget.getAttribute("data-child-window") || null;
     const childWindowPostMessage = !(useEvtTarget.getAttribute("data-child-window-message") === "false");
-    const targetHref = useEvtTarget.href;
+    const targetHref = useEvtTarget.getAttribute("href") || useEvtTarget.getAttribute("data-href") || null;
     if (!targetHref || typeof targetHref !== "string" || targetHref === "#") {
-        return false;
+        throw new Error("Expected a target href");
     }
+    return { childWindowName, childWindowPostMessage, targetHref };
+}
+
+
+export function onClickLinkNavigateChildWindow(e){
+    const { childWindowName, childWindowPostMessage, targetHref } = onClickCommonHandler(e);
     navigateChildWindow(targetHref, childWindowName, childWindowPostMessage);
     return false;
 }
 
 
+
 let newWindowCounter = 0;
 
+/**
+ * Always opens a new child window, rather than re-using existing one.
+ */
 export function openNewChildWindow (targetHref, postMessage){
     const currentCount = newWindowCounter++;
     console.log("Openining window", currentCount);
-    return navigateChildWindow(targetHref, "nw" + currentCount, postMessage);
+    return navigateChildWindow(targetHref, "nw-" + currentCount, postMessage);
 }
 
-export function onClickOpenChildWindow(e) {
-    e.stopPropagation();
-    e.preventDefault();
-    const useEvtTarget = e.currentTarget || e.target;
-    const childWindowPostMessage = !(useEvtTarget.getAttribute("data-child-window-message") === "false");
-    const targetHref = useEvtTarget.href;
-    if (!targetHref || typeof targetHref !== "string" || targetHref === "#") {
-        return false;
-    }
+export function onClickOpenNewChildWindow(e) {
+    const { childWindowPostMessage, targetHref } = onClickCommonHandler(e);
     openNewChildWindow(targetHref, childWindowPostMessage);
     return false;
 }

--- a/src/encoded/static/components/item-pages/components/child-window-controls.js
+++ b/src/encoded/static/components/item-pages/components/child-window-controls.js
@@ -1,7 +1,15 @@
 'use strict';
-
+import _ from 'underscore';
 
 const childWindowByName = {};
+
+const cleanupChildWindowsDebounced = _.debounce(function(){
+    Object.keys(childWindowByName).forEach(function(k){
+        if (childWindowByName[k].closed) {
+            delete childWindowByName[k];
+        }
+    });
+}, 5000, false);
 
 /**
  * Reusable function that will navigate a child window if one exists already,
@@ -26,6 +34,10 @@ export function navigateChildWindow(targetHref, windowName = null, postMessage =
             // "width=1200,height=900"
         );
     }
+
+    // Cleanup references in background when possible.
+    // 'childWindowByName' is a global-scope variable/store and itself never re-instantiated.
+    cleanupChildWindowsDebounced();
 }
 
 
@@ -42,7 +54,6 @@ function onClickCommonHandler (e) {
     }
     return { childWindowName, childWindowPostMessage, targetHref };
 }
-
 
 export function onClickLinkNavigateChildWindow(e){
     const { childWindowName, childWindowPostMessage, targetHref } = onClickCommonHandler(e);

--- a/src/encoded/static/libs/react-middleware.js
+++ b/src/encoded/static/libs/react-middleware.js
@@ -9,9 +9,14 @@ import { JWT, object } from '@hms-dbmi-bgm/shared-portal-components/es/component
 import { Alerts } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts';
 import App from './../components';
 
-
-const cssFileStats = fs.statSync(__dirname + '/../css/style.css');
-const lastCSSBuildTime = Date.parse(cssFileStats.mtime.toUTCString());
+// For production, we only check CSS, since assume was built along w. JS.
+const jsFileStats = fs.statSync(__dirname + '/../build/bundle.js');
+let lastBuildTime = Date.parse(jsFileStats.mtime.toUTCString());
+if (process.env.NODE_ENV !== "production") {
+    const cssFileStats = fs.statSync(__dirname + '/../css/style.css');
+    const lastCSSBuildTime = Date.parse(cssFileStats.mtime.toUTCString());
+    lastBuildTime = lastCSSBuildTime > lastBuildTime ? lastCSSBuildTime : lastBuildTime;
+}
 
 export function appRenderFxn(body, res) {
 
@@ -21,7 +26,7 @@ export function appRenderFxn(body, res) {
     const disp_dict = {
         'context'           : context,
         'href'              : res.getHeader('X-Request-URL') || object.itemUtil.atId(context),
-        'lastCSSBuildTime'  : lastCSSBuildTime,
+        'lastBuildTime'     : lastBuildTime,
         'alerts'            : [] // Always have fresh alerts per request, else subprocess will re-use leftover global vars/vals.
     };
 

--- a/src/encoded/static/libs/react-middleware.js
+++ b/src/encoded/static/libs/react-middleware.js
@@ -9,7 +9,7 @@ import { JWT, object } from '@hms-dbmi-bgm/shared-portal-components/es/component
 import { Alerts } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts';
 import App from './../components';
 
-// For production, we only check CSS, since assume was built along w. JS.
+// For production, we only check JS, since assume CSS was built along w. JS.
 const jsFileStats = fs.statSync(__dirname + '/../build/bundle.js');
 let lastBuildTime = Date.parse(jsFileStats.mtime.toUTCString());
 if (process.env.NODE_ENV !== "production") {

--- a/src/encoded/static/store.js
+++ b/src/encoded/static/store.js
@@ -19,8 +19,8 @@ export const reducers = {
         }
     },
 
-    'lastCSSBuildTime' : function(state='', action) {
-        return (action.type && action.type.lastCSSBuildTime) || state;
+    'lastBuildTime' : function(state='', action) {
+        return (action.type && action.type.lastBuildTime) || state;
     },
 
     'slow' : function(state=false, action) {

--- a/src/encoded/types/structural_variant.py
+++ b/src/encoded/types/structural_variant.py
@@ -399,17 +399,19 @@ class StructuralVariantSample(Item):
         structural_variant = get_item_or_none(
             request, structural_variant, "StructuralVariant", frame="raw"
         )
-        start = convert_integer_to_comma_string(structural_variant["START"])
-        end = convert_integer_to_comma_string(structural_variant["END"])
-        structural_variant_display_title = build_structural_variant_display_title(
-            structural_variant["SV_TYPE"],
-            structural_variant["CHROM"],
-            start,
-            end,
-        )
+
         if structural_variant:
-            return CALL_INFO + ":" + structural_variant_display_title
-        return CALL_INFO
+            start = convert_integer_to_comma_string(structural_variant["START"])
+            end = convert_integer_to_comma_string(structural_variant["END"])
+            structural_variant_display_title = build_structural_variant_display_title(
+                structural_variant["SV_TYPE"],
+                structural_variant["CHROM"],
+                start,
+                end,
+            )
+            return structural_variant_display_title + " (" + CALL_INFO + ")" # chr1:504A>T (HG002)
+
+        return "Sample for " + CALL_INFO
 
     @calculated_property(
         schema={

--- a/src/encoded/types/structural_variant.py
+++ b/src/encoded/types/structural_variant.py
@@ -409,9 +409,9 @@ class StructuralVariantSample(Item):
                 start,
                 end,
             )
-            return structural_variant_display_title + " (" + CALL_INFO + ")" # chr1:504A>T (HG002)
+            return CALL_INFO + ":" + structural_variant_display_title # HG002:chr1:504A>T
 
-        return "Sample for " + CALL_INFO
+        return CALL_INFO
 
     @calculated_property(
         schema={

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -510,9 +510,9 @@ class VariantSample(Item):
         variant = get_item_or_none(request, variant, 'Variant', frame='raw')
         if variant:
             variant_display_title = build_variant_display_title(variant['CHROM'], variant['POS'],
-                variant['REF'], variant['ALT'])
-            return variant_display_title + " (" + CALL_INFO + ")" # chr1:504A>T (HG002)
-        return "Sample for " + CALL_INFO
+                                                            variant['REF'], variant['ALT'])
+            return CALL_INFO + ':' + variant_display_title  # HG002:chr1:504A>T
+        return CALL_INFO
 
     @calculated_property(schema={
         "title": "Variant Sample List",

--- a/src/encoded/types/variant.py
+++ b/src/encoded/types/variant.py
@@ -508,11 +508,11 @@ class VariantSample(Item):
     })
     def display_title(self, request, CALL_INFO, variant=None):
         variant = get_item_or_none(request, variant, 'Variant', frame='raw')
-        variant_display_title = build_variant_display_title(variant['CHROM'], variant['POS'],
-                                                            variant['REF'], variant['ALT'])
         if variant:
-            return CALL_INFO + ':' + variant_display_title  # HG002:chr1:504A>T
-        return CALL_INFO
+            variant_display_title = build_variant_display_title(variant['CHROM'], variant['POS'],
+                variant['REF'], variant['ALT'])
+            return variant_display_title + " (" + CALL_INFO + ")" # chr1:504A>T (HG002)
+        return "Sample for " + CALL_INFO
 
     @calculated_property(schema={
         "title": "Variant Sample List",


### PR DESCRIPTION
Links from InterpretationTab and Search Result Column are now buttons to prevent people from right-clicking "Open in new tab" and forcing UI to manage the child tabs instead (preserving window.opener/childWindow communication).

~~TODO Still: Display titles~~ done.