### PR TITLE
Remove Departed Admins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "8.9.1"
+version = "8.9.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/data/demo_inserts/variant_sample.json
+++ b/src/encoded/tests/data/demo_inserts/variant_sample.json
@@ -25,12 +25,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:38.131568+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:599f476b-712c-4162-aa13-ff83075a6b64:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:12.582405+00:00"
-        },
         "uuid": "482e1383-9004-4e1f-a2fb-f13b3bf18933"
     },
     {
@@ -59,12 +54,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:37.712302+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:f5ca02a2-9278-4f49-9106-5997e8ec6d12:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:13.072951+00:00"
-        },
         "uuid": "cd016d00-0ab4-40bd-bc81-91d9524af21d"
     },
     {
@@ -93,12 +83,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:37.265852+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:44dee9e5-8e0d-45dc-9603-3b399be8ce46:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:13.571311+00:00"
-        },
         "uuid": "f1381006-6688-490b-b0a7-63ec38dd360f"
     },
     {
@@ -127,12 +112,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:36.740037+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:af0ed65b-5315-4c0c-a12c-7d436610d14b:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:14.027065+00:00"
-        },
         "uuid": "30159f03-3b3b-45a5-95b3-c89a3a990984"
     },
     {
@@ -161,12 +141,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:36.364120+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:1027d4f2-afc7-4647-9931-7050d5103148:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:14.541482+00:00"
-        },
         "uuid": "84220bc8-3e81-4393-a2b4-aa02bc50b65e"
     },
     {
@@ -195,12 +170,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:36.014463+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:4a0e1d9f-9b21-4705-aba1-dd2b30ad75a1:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:15.110893+00:00"
-        },
         "uuid": "57caa0ac-6c9c-4e9a-840e-99560efb6308"
     },
     {
@@ -229,12 +199,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:34.212723+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:b8e72016-d556-40bf-ba9e-54aa00e5eb37:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:15.643684+00:00"
-        },
         "uuid": "9c8c9b45-d131-4051-a2bc-3443815ed386"
     },
     {
@@ -263,12 +228,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:33.774111+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:2d662ba6-4bf3-4e71-90b5-e4911470f3ec:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:16.127597+00:00"
-        },
         "uuid": "ac22d1ce-66e6-4207-b236-c6e0a83ab3f3"
     },
     {
@@ -297,12 +257,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:31.884778+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:02d6cd06-1c5f-41dd-a606-fad39c64dcd2:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:16.652675+00:00"
-        },
         "uuid": "5b13da90-cc55-4cae-b482-e1d2174fe0dd"
     },
     {
@@ -331,12 +286,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:31.448014+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:8a62962d-a7ba-400c-a47d-5841f54f95fc:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:17.129137+00:00"
-        },
         "uuid": "ab05a28a-5f30-4c37-8e73-e99060113cb2"
     },
     {
@@ -365,12 +315,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:30.998266+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:60964e18-4243-414c-b680-2340fdcf4569:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:17.584057+00:00"
-        },
         "uuid": "bd1b083c-93bc-4026-a97c-a8a45f3d7b51"
     },
     {
@@ -399,12 +344,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:30.567588+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:86bc4c32-2ad5-4951-b521-16130d7b0237:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:18.100496+00:00"
-        },
         "uuid": "56de3653-097b-40ef-8321-366882af857f"
     },
     {
@@ -433,12 +373,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:29.906884+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:9fb07c67-4469-431a-b27a-09254b673e3d:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:18.615931+00:00"
-        },
         "uuid": "a2e164a0-7a31-41c1-8f16-d76c50d9f6f0"
     },
     {
@@ -467,12 +402,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:29.483568+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:c6087bf1-7e85-4442-92e8-0ffe8f7040af:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:19.119217+00:00"
-        },
         "uuid": "ef23a0f3-2a3d-4d96-b53b-b15913774555"
     },
     {
@@ -501,12 +431,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:28.890177+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:fa06439e-5cb4-49fb-9de2-6c3944de0203:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:19.593411+00:00"
-        },
         "uuid": "a9bf193d-206f-4b43-8c6f-7050a6f5e757"
     },
     {
@@ -535,12 +460,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:28.484188+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:788173b6-45dc-4e2f-8b09-e42d07b6eacd:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:20.155055+00:00"
-        },
         "uuid": "59fa1f35-9023-4808-b84b-be30186b1085"
     },
     {
@@ -569,12 +489,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:28.089325+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:86bab7ec-05bd-4b77-9de2-40c5e98a2bf4:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:20.841809+00:00"
-        },
         "uuid": "00ccc380-c8f4-4cb3-9bb7-9da8ff083ec0"
     },
     {
@@ -603,12 +518,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:27.649315+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:fe2debb1-8417-4021-93d9-f349a6dcdc9a:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:21.332474+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -647,12 +557,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:26.604796+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:cec425cd-ce90-4649-8a4a-98a7c31ee723:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:21.838627+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -691,12 +596,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:25.370608+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:f861d4a0-95a9-413e-aa86-0df0d9f398c9:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:22.365367+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -735,12 +635,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:24.241518+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:db1c11a5-7804-4808-866c-1825df3817a9:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:22.897826+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -779,12 +674,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:23.221189+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:50c84bcf-6b31-404a-8b77-1cf177f1f899:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:23.417887+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -823,12 +713,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:22.523105+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:f8789a98-d987-425d-aeb7-90d9fd76fb2b:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:23.936959+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -867,12 +752,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:21.909522+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:9553a7a8-b5b3-45a3-bebe-9e025d051b88:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:24.475710+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -911,12 +791,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:21.130818+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:f373e87c-c887-4197-84af-bccf69d1ebe8:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:24.990019+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -955,12 +830,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:20.094146+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:8b7d6cc7-777d-4019-b4b2-57beba8a1c99:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:25.551684+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -999,12 +869,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:19.287632+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:10410bd1-03e7-48b4-9c0b-33577b165623:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:25.975183+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1043,12 +908,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:18.822315+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:5f274294-9256-423a-a422-8c50e374e16f:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:26.513939+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1087,12 +947,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:18.187281+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:bb73e849-2222-4509-8c3a-782c85835c96:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:27.029108+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1131,12 +986,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:17.772881+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:f8c888bc-1a71-4e68-afeb-ae44d4b420bf:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:27.541874+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1175,12 +1025,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:17.274750+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:d935e116-2fd3-4793-a1c7-48f18fa109dd:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:28.070686+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1219,12 +1064,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:15.459870+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:403aa4de-bd6f-4a9d-9449-2a0eaf3d57de:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:28.624492+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1263,12 +1103,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:14.999755+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:89c0d893-c25d-4c17-8efb-2eebbf1fdeb0:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:29.137328+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1307,12 +1142,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:14.167200+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:10b1e199-1505-4e74-906f-35b766201b41:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:29.602246+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1351,12 +1181,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:13.599581+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:f6b53d24-a8e1-4c44-a5fe-5d2fb967582c:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:30.206572+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1395,12 +1220,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:13.087831+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:20b2b73c-67b3-4e22-b5db-14766ac2886e:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:30.807811+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1461,12 +1281,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:12.046758+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:e6b1c72c-ea8f-44a7-a4a7-9f52f5d7f9f0:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:31.366183+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1532,12 +1347,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:11.633636+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:6756826d-a23e-4c4c-9ef0-7eb411b0a57a:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:31.883548+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1603,12 +1413,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:11.176488+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:4deee0dd-3d83-4004-9f16-767b81f4897b:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:32.370599+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1649,12 +1454,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:10.766975+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:48fddb06-feb9-4691-9327-5ef298e5ca5e:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:32.894699+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1693,12 +1493,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:10.126953+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:ecc3af46-7b74-4267-8763-64bc1a739f16:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:33.397194+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1737,12 +1532,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:09.604467+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:f60ed4cf-3b4a-4ffc-8080-276747cbc1f9:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:34.016963+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1781,12 +1571,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:09.163832+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:d6f6b80c-1929-432f-bbb1-536f53c1dabd:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:34.785703+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1825,12 +1610,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:08.561649+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:01e4f07e-5749-4cff-891c-7ead7d641e03:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:35.333146+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1869,12 +1649,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:07.621303+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:6c55d3af-28ea-478f-8310-f6d347c55a6e:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:35.935286+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1913,12 +1688,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:07.130805+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:6daabdbb-c377-4734-9cfa-034f5b66d455:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:36.539892+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -1957,12 +1727,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:06.161021+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:5dc1fb8b-3e7f-4ee8-b24c-c21ef62d9bdd:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:37.147892+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -2001,12 +1766,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:05.575174+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:b2cd5f66-90de-4c62-863c-5e4e705ef693:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:37.692262+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -2045,12 +1805,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:05.019816+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:b0b155a5-34a7-4b88-b018-431bd9855ca2:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:38.294946+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",
@@ -2089,12 +1844,7 @@
         ],
         "institution": "59024e8e-eaea-477c-8f9b-df0bd722cfcb",
         "date_created": "2021-09-27T16:47:04.513334+00:00",
-        "submitted_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
         "annotation_id": "PROCA196-DNA1-WGS-v25:d1e9f126-b79c-41f7-9902-2fc0560761d8:GAPFI61XL3WE",
-        "last_modified": {
-            "modified_by": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-            "date_modified": "2021-11-07T19:15:38.813779+00:00"
-        },
         "genotype_labels": [
             {
                 "role": "proband",

--- a/src/encoded/tests/data/master-inserts/user.json
+++ b/src/encoded/tests/data/master-inserts/user.json
@@ -319,23 +319,6 @@
         "user_institution": "828cd4fe-ebb0-4b36-a94a-d2e3a36cc989"
     },
     {
-        "email": "sarah_reiff@hms.harvard.edu",
-        "first_name": "Sarah",
-        "last_name": "Reiff",
-        "uuid": "834559db-a3f6-462c-81a4-f5d7e5e65707",
-        "groups": [
-            "admin"
-        ],
-        "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
-        "project_roles": [
-            {
-                "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
-                "role": "developer"
-            }
-        ],
-        "user_institution": "828cd4fe-ebb0-4b36-a94a-d2e3a36cc989"
-    },
-    {
         "email": "peter_park@hms.harvard.edu",
         "first_name": "Peter",
         "last_name": "Park",
@@ -370,10 +353,10 @@
         "user_institution": "828cd4fe-ebb0-4b36-a94a-d2e3a36cc989"
     },
     {
-        "email": "phil_grayson@hms.harvard.edu",
-        "first_name": "Phil",
-        "last_name": "Grayson",
-        "uuid": "3846c019-f2c7-4612-b9b1-9c1375e0c2c4",
+        "email": "shannon_ehmsen@hms.harvard.edu",
+        "first_name": "Shannon",
+        "last_name": "Ehmsen",
+        "uuid": "c58ac2fe-fccb-4d21-992d-62a078c2dbc0",
         "groups": [
             "admin"
         ],
@@ -384,17 +367,6 @@
                 "role": "developer"
             }
         ],
-        "user_institution": "828cd4fe-ebb0-4b36-a94a-d2e3a36cc989"
-    },
-    {
-        "email": "shannon_ehmsen@hms.harvard.edu",
-        "first_name": "Shannon",
-        "last_name": "Ehmsen",
-        "uuid": "c58ac2fe-fccb-4d21-992d-62a078c2dbc0",
-        "groups": ["admin"],
-        "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
-        "project_roles": [{"project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
-                           "role": "developer"}],
         "user_institution": "828cd4fe-ebb0-4b36-a94a-d2e3a36cc989"
     },
     {


### PR DESCRIPTION
Remove departed CGAP members from inserts. Members have had their User items set to `status: deleted` on all deployed environments.