### PR TITLE
Syntax makeover for clear-db-es-contents

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -32,4 +32,57 @@ ignore =
     # ==============================================================
     # F541: f-string is missing placeholders
     #       https://flake8.pycqa.org/en/latest/user/error-codes.html
-    F541
+    F541,
+    # ==============================================================
+    # =====  We want these complaints eventually, but not now. =====
+    # ==============================================================
+    # E111 indentation is not a multiple of 4
+    E111,
+    # E116 unexpected indentation (comment)
+    E116,
+    # E122 continuation line missing indentation or outdented
+    E122,
+    # E124 closing bracket does not match visual indentation
+    E124,
+    # E127 continuation line over-indented for visual indent
+    E127,
+    # E128 continuation line under-indented for visual indent
+    E128,
+    # E201 whitespace after '['
+    E201,
+    # E202 whitespace before '}'
+    E202,
+    # E203 whitespace before ':'
+    E203,
+    # E221 multiple spaces before operator
+    E221,
+    # E222 multiple spaces after operator
+    E222,
+    # E231 missing whitespace after ':
+    E231,
+    # E241 multiple spaces after ':'
+    E241,
+    # E251 unexpected spaces around keyword / parameter equals
+    E251,
+    # E261 at least two spaces before inline comment
+    E261,
+    # E262 inline comment should start with '# '
+    E262,
+    # E265 block comment should start with '# '
+    E265,
+    # E266 too many leading '#' for block comment
+    E266,
+    # E272 multiple spaces before keyword
+    E272,
+    # W291 trailing whitespace
+    W291,
+    # W293 blank line contains whitespace
+    W293,
+    # E302 expected 2 blank lines
+    E302,
+    # E303 too many blank lines
+    E303,
+    # W391 blank line at end of file
+    W391,
+    # E501 line too long
+    E501,

--- a/deploy/docker/local/entrypoint.sh
+++ b/deploy/docker/local/entrypoint.sh
@@ -5,7 +5,7 @@ if [  -z ${TEST+x} ]; then
     if [ ! -z ${LOAD+x} ]; then
 
         # Clear db/es since this is the local entry point
-        poetry run clear-db-es-contents development.ini --app-name app --env "$CGAP_ENV_NAME"
+        poetry run clear-db-es-contents development.ini --app-name app --only-if-env "$CGAP_ENV_NAME"
 
         # Create mapping
         poetry run create-mapping-on-deploy development.ini --app-name app --clear-queue

--- a/deploy/docker/production/entrypoint_deployment.sh
+++ b/deploy/docker/production/entrypoint_deployment.sh
@@ -9,7 +9,7 @@ poetry run python -m assume_identity
 # Clear db/es on cgap-devtest if we run an "initial" deploy
 # Do nothing on other environments
 if [ -n "${INITIAL_DEPLOYMENT}" ]; then
-  poetry run clear-db-es-contents production.ini --app-name app --env cgap-devtest
+  poetry run clear-db-es-contents production.ini --app-name app --only-if-env cgap-devtest
 fi
 
 # Create mapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "8.9.2"
+version = "8.10.0"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/clear_db_es_contents.py
+++ b/src/encoded/commands/clear_db_es_contents.py
@@ -41,8 +41,7 @@ def clear_db_tables(app):
         for table in meta.sorted_tables:
             connection.execute(table.delete())
     except Exception as e:
-        log.error('clear_db_es_contents: error on DB drop_all/create_all.'
-                  ' Error : %s' % str(e))
+        log.error(f"clear_db_es_contents: Error on DB drop_all/create_all. {type(e)}: {e}")
         transaction.abort()
     else:
         # commit all changes to DB
@@ -51,6 +50,9 @@ def clear_db_tables(app):
         transaction.commit()
         success = True
     return success
+
+
+SKIPPING_CLEAR_ATTEMPT = 'Skipping the attempt to clear DB.'
 
 
 def run_clear_db_es(app, only_envs: Optional[List[str]] = None, skip_es: bool = False) -> bool:
@@ -73,33 +75,34 @@ def run_clear_db_es(app, only_envs: Optional[List[str]] = None, skip_es: bool = 
         bool: True if DB was cleared (regardless of ES)
     """
     current_env = app.registry.settings.get('env.name', 'local')
-    skipping_clear_attempt = 'Skipping the attempt to clear DB.'
 
     if is_stg_or_prd_env(current_env):
-        log.error(f'clear_db_es_contents: This action cannot be performed on env {current_env}'
-                  f' because it is a production-class (stg or prd) environment.'
-                  f' {skipping_clear_attempt}')
+        log.error(f"clear_db_es_contents: This action cannot be performed on env {current_env}"
+                  f" because it is a production-class (stg or prd) environment."
+                  f" {SKIPPING_CLEAR_ATTEMPT}")
         return False
 
     if only_envs and current_env not in only_envs:
-        log.error(f'clear_db_es_contents: The current environment, {current_env}, is not {disjoined_list(only_envs)}.'
-                  f' {skipping_clear_attempt}')
+        log.error(f"clear_db_es_contents: The current environment, {current_env}, is not {disjoined_list(only_envs)}."
+                  f" {SKIPPING_CLEAR_ATTEMPT}")
         return False
 
     log.info('clear_db_es_contents: Clearing DB tables...')
     db_success = clear_db_tables(app)
     if not db_success:
-        log.error('clear_db_es_contents: Clearing DB failed!'
-                  ' Such failures may happen, for example, when there are external DB connections.'
-                  ' You might want to try running clear_db_es_contents again.')
+        log.error("clear_db_es_contents: Clearing DB tables failed!"
+                  " Such failures may happen, for example, when there are external DB connections."
+                  " You might want to try running clear_db_es_contents again.")
         return False
-    log.info('clear_db_es_contents: Successfully cleared DB.')
+    log.info("clear_db_es_contents: Successfully cleared DB.")
 
     # create mapping after clear DB to remove ES contents
     if not skip_es:
-        log.info('clear_db_es_contents: Clearing ES with create_mapping...')
+        log.info("clear_db_es_contents: Clearing ES with create_mapping...")
         run_create_mapping(app, purge_queue=True)
-    log.info('clear_db_es_contents: Done!')
+        log.info("clear_db_es_contents: Successfully cleared ES.")
+
+    log.info("clear_db_es_contents: All done.")
     return True
 
 
@@ -117,14 +120,20 @@ def main(simulated_args=None):
     parser.add_argument('--only-if-env', '--only-if-envs', dest='only_envs', default=None,
                         help=("A comma-separated list of envs where this action is allowed to run."
                               " If omitted, any env is OK to run."))
+    parser.add_argument("--confirm", action="store_true", dest="confirm", default=None)
+    parser.add_argument("--no-confirm", action="store_false", dest="confirm", default=None)
     parser.add_argument('--skip-es', action='store_true', default=False,
                         help='If set, do not run create_mapping after DB drop')
     args = parser.parse_args(simulated_args)
 
+    confirm = args.confirm
     app_name = args.app_name
     config_uri = args.config_uri
     only_envs = args.only_envs
     skip_es = args.skip_es
+
+    if confirm is None:
+        confirm = not only_envs  # If only_envs is supplied, we have better protection so don't need to confirm
 
     # get the pyramids app
     app = get_app(config_uri, app_name)
@@ -133,6 +142,14 @@ def main(simulated_args=None):
     configure_dbsession(app)
 
     only_envs = [x for x in (only_envs or "").split(',') if x]
+
+    if confirm:
+        env_to_confirm = app.registry.settings.get('env.name', 'local')
+        env_confirmation = input(f'This will completely clear DB contents for environment {env_to_confirm}.\n'
+                                 f' Type the env name to confirm: ')
+        if env_confirmation != env_to_confirm:
+            print(f"NOT confirmed. {SKIPPING_CLEAR_ATTEMPT}")
+            return
 
     # actually run. split this out for easy testing
     run_clear_db_es(app=app, only_envs=only_envs, skip_es=skip_es)

--- a/src/encoded/commands/clear_db_es_contents.py
+++ b/src/encoded/commands/clear_db_es_contents.py
@@ -4,10 +4,12 @@ import structlog
 import transaction
 
 from dcicutils.env_utils import is_stg_or_prd_env
+from dcicutils.lang_utils import disjoined_list
 from pyramid.paster import get_app
 from snovault import DBSESSION
 from snovault.elasticsearch.create_mapping import run as run_create_mapping
 from sqlalchemy import MetaData
+from typing import Optional, List
 from zope.sqlalchemy import mark_changed
 from .. import configure_dbsession
 
@@ -51,55 +53,57 @@ def clear_db_tables(app):
     return success
 
 
-def run_clear_db_es(app, arg_env, arg_skip_es=False):
+def run_clear_db_es(app, only_envs: Optional[List[str]] = None, skip_es: bool = False) -> bool:
     """
     This function actually clears DB/ES. Takes a Pyramid app as well as two flags. _Use with care!_
 
-    For safety, this function will return without side-effect on any production system.
-
-    Also does additional checks based on arguments supplied:
-
-    If an `arg_env` (default None) is given as a non-empty string value,
-    this function will return without side-effect if the current app environment does not match the given value.
+    For safety, this function will return without side-effect if ...
+    - The current environment is any production system.
+    - The current environment is not a member of the `only_envs` argument (list).
 
     If `arg_skip_es` (default False) is True, this function will return after DB clear
     and before running create_mapping.
 
     Args:
         app: Pyramid application
-        arg_env (str): if provided, only run if environment matches this value
-        arg_skip_es (bool): if True, do not run create_mapping after DB clear
+        only_envs (list): a list of env names that are the only envs where this action will run
+        skip_es (bool): if True, do not run create_mapping after DB clear
 
     Returns:
         bool: True if DB was cleared (regardless of ES)
     """
-    env = app.registry.settings.get('env.name', '')
-    # for now, do NOT allow clearing of production systems
-    if is_stg_or_prd_env(env):
-        log.error('clear_db_es_contents: will NOT run on env %s. Exiting...' % env)
-        return False
-    if arg_env and arg_env != env:
-        log.error('clear_db_es_contents: environment mismatch! Given --env %s '
-                  'does not match current env %s. Exiting....' % (arg_env, env))
+    current_env = app.registry.settings.get('env.name', 'local')
+    skipping_clear_attempt = 'Skipping the attempt to clear DB.'
+
+    if is_stg_or_prd_env(current_env):
+        log.error(f'clear_db_es_contents: This action cannot be performed on env {current_env}'
+                  f' because it is a production-class (stg or prd) environment.'
+                  f' {skipping_clear_attempt}')
         return False
 
-    log.info('clear_db_es_contents: clearing DB tables...')
+    if only_envs and current_env not in only_envs:
+        log.error(f'clear_db_es_contents: The current environment, {current_env}, is not {disjoined_list(only_envs)}.'
+                  f' {skipping_clear_attempt}')
+        return False
+
+    log.info('clear_db_es_contents: Clearing DB tables...')
     db_success = clear_db_tables(app)
     if not db_success:
-        log.error('clear_db_es_contents: clearing DB failed! Try to run again.'
-                  ' This command can fail if there are external DB connections')
+        log.error('clear_db_es_contents: Clearing DB failed!'
+                  ' Such failures may happen, for example, when there are external DB connections.'
+                  ' You might want to try running clear_db_es_contents again.')
         return False
-    log.info('clear_db_es_contents: successfully cleared DB')
+    log.info('clear_db_es_contents: Successfully cleared DB.')
 
     # create mapping after clear DB to remove ES contents
-    if not arg_skip_es:
-        log.info('clear_db_es_contents: clearing ES with create_mapping...')
+    if not skip_es:
+        log.info('clear_db_es_contents: Clearing ES with create_mapping...')
         run_create_mapping(app, purge_queue=True)
-    log.info('clear_db_es_contents: done!')
+    log.info('clear_db_es_contents: Done!')
     return True
 
 
-def main():
+def main(simulated_args=None):
     logging.basicConfig()
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.DEBUG)
@@ -110,28 +114,28 @@ def main():
     )
     parser.add_argument('config_uri', help='path to configfile')
     parser.add_argument('--app-name', help='Pyramid app name in configfile')
-    parser.add_argument('--env', help='If provided, only run if on given environment')
+    parser.add_argument('--only-if-env', '--only-if-envs', dest='only_envs', default=None,
+                        help=("A comma-separated list of envs where this action is allowed to run."
+                              " If omitted, any env is OK to run."))
     parser.add_argument('--skip-es', action='store_true', default=False,
                         help='If set, do not run create_mapping after DB drop')
-    args = parser.parse_args()
+    args = parser.parse_args(simulated_args)
+
+    app_name = args.app_name
+    config_uri = args.config_uri
+    only_envs = args.only_envs
+    skip_es = args.skip_es
 
     # get the pyramids app
-    app = get_app(args.config_uri, args.app_name)
+    app = get_app(config_uri, app_name)
 
     # create db schema
     configure_dbsession(app)
 
-    # confirm with user if not providing a specific env
-    if not args.env:
-        disp_env = app.registry.settings.get('env.name', 'local')
-        name = input('This will completely clear DB contents for environment %s.'
-                     ' Type the env name to confirm: ' % disp_env)
-        if str(name) != disp_env:
-            print("Could not confirm env. Exiting...")
-            return
+    only_envs = [x for x in (only_envs or "").split(',') if x]
 
     # actually run. split this out for easy testing
-    run_clear_db_es(app, args.env, args.skip_es)
+    run_clear_db_es(app=app, only_envs=only_envs, skip_es=skip_es)
 
 
 if __name__ == '__main__':

--- a/src/encoded/commands/clear_db_es_contents.py
+++ b/src/encoded/commands/clear_db_es_contents.py
@@ -120,8 +120,10 @@ def main(simulated_args=None):
     parser.add_argument('--only-if-env', '--only-if-envs', dest='only_envs', default=None,
                         help=("A comma-separated list of envs where this action is allowed to run."
                               " If omitted, any env is OK to run."))
-    parser.add_argument("--confirm", action="store_true", dest="confirm", default=None)
-    parser.add_argument("--no-confirm", action="store_false", dest="confirm", default=None)
+    parser.add_argument("--confirm", action="store_true", dest="confirm", default=None,
+                        help="Specify --confirm to require interactive confirmation.")
+    parser.add_argument("--no-confirm", action="store_false", dest="confirm", default=None,
+                        help="Specify --no-confirm to suppress interactive confirmation.")
     parser.add_argument('--skip-es', action='store_true', default=False,
                         help='If set, do not run create_mapping after DB drop')
     args = parser.parse_args(simulated_args)

--- a/src/encoded/tests/test_clear_es_db_contents.py
+++ b/src/encoded/tests/test_clear_es_db_contents.py
@@ -127,14 +127,21 @@ def test_run_clear_db_es_unit(app, testapp):
                 assert mock_clear_db_tables.call_count == expected_db_clears
                 assert mock_run_create_mapping.call_count == expected_es_clears
 
-                with local_env_name_registry_setting_for_testing(app, 'fourfront-cgap'):
-                    # should never run on this env
-                    assert clear_db_es_contents_module.is_stg_or_prd_env('fourfront-cgap') is True
-                    assert run_clear_db_es(app, only_envs=None, skip_es=True) is False
-                    expected_db_clears += 0
-                    expected_es_clears += 0
-                    assert mock_clear_db_tables.call_count == expected_db_clears
-                    assert mock_run_create_mapping.call_count == expected_es_clears
+                # Really we only care about the first of these names, but the rest are names that were at one time
+                # planned to be stg or prd names for cgap, so this tests that it's properly noticing such names
+                # and skipping in that case. -kmp 4-Jun-2022
+                for production_env in ['fourfront-cgap',
+                                       'fourfront-cgap-green', 'cgap-green',
+                                       'fourfront-cgap-blue', 'cgap-blue']:
+
+                    with local_env_name_registry_setting_for_testing(app, production_env):
+                        # should never run on this env
+                        assert clear_db_es_contents_module.is_stg_or_prd_env(production_env) is True
+                        assert run_clear_db_es(app, only_envs=None, skip_es=True) is False
+                        expected_db_clears += 0
+                        expected_es_clears += 0
+                        assert mock_clear_db_tables.call_count == expected_db_clears
+                        assert mock_run_create_mapping.call_count == expected_es_clears
 
                 with local_env_name_registry_setting_for_testing(app, 'fourfront-test-env'):
 

--- a/src/encoded/tests/test_clear_es_db_contents.py
+++ b/src/encoded/tests/test_clear_es_db_contents.py
@@ -175,6 +175,22 @@ def test_run_clear_db_es_unit(app, testapp):
                     assert mock_clear_db_tables.call_count == expected_db_clears
                     assert mock_run_create_mapping.call_count == expected_es_clears
 
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-test-env-1', 'fourfront-test-env-2'],
+                                           skip_es=False) is False
+                    expected_db_clears += 0
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-test-env-1', 'fourfront-test-env'],
+                                           skip_es=False) is True
+                    expected_db_clears += 1
+                    expected_es_clears += 1
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
 
 @pytest.mark.unit
 def test_clear_db_es_contents_main():

--- a/src/encoded/tests/test_clear_es_db_contents.py
+++ b/src/encoded/tests/test_clear_es_db_contents.py
@@ -1,8 +1,12 @@
+import contextlib
 import pytest
 
+from unittest import mock
+from ..commands import clear_db_es_contents as clear_db_es_contents_module
 from ..commands.clear_db_es_contents import (
     clear_db_tables,
-    run_clear_db_es
+    run_clear_db_es,
+    main as clear_db_es_contents_main
 )
 
 
@@ -20,28 +24,196 @@ def test_clear_db_tables(app, testapp):
     testapp.get(post_res.location, status=404)
 
 
-def test_run_clear_db_envs(app, testapp):
+@pytest.mark.integratedx
+def test_run_clear_db_es_integrated(app, testapp):
+
+    # It works positionally
     assert run_clear_db_es(app, None, True) is True
+    # It works by keyword argument
+    assert run_clear_db_es(app, only_envs=None, skip_es=True) is True
+
     prev_env = app.registry.settings.get('env.name')
 
-    post_res = testapp.post_json('/testing-post-put-patch/', {'required': 'abc'},
-                                 status=201)
-    testapp.get(post_res.location, status=200)
+    try:
 
-    # should never run on this env
-    app.registry.settings['env.name'] = 'fourfront-cgap'
-    assert run_clear_db_es(app, None, True) is False
-    testapp.get(post_res.location, status=200)
+        post_res = testapp.post_json('/testing-post-put-patch/', {'required': 'abc'}, status=201)
+        testapp.get(post_res.location, status=200)
 
-    # test if we are only running on specific envs
-    app.registry.settings['env.name'] = 'fourfront-test-env'
-    assert run_clear_db_es(app, 'fourfront-other-env', True) is False
-    testapp.get(post_res.location, status=200)
-    assert run_clear_db_es(app, 'fourfront-test-env', True) is True
-    testapp.get(post_res.location, status=404)
+        # should never run on this env
+        app.registry.settings['env.name'] = 'fourfront-cgap'
+        assert run_clear_db_es(app, only_envs=None, skip_es=True) is False
+        testapp.get(post_res.location, status=200)
 
-    # reset settings after test
-    if prev_env is None:
-        del app.registry.settings['env.name']
-    else:
-        app.registry.settings['env.name'] = prev_env
+        # test if we are only running on specific envs
+        app.registry.settings['env.name'] = 'fourfront-test-env'
+        assert run_clear_db_es(app, only_envs=['fourfront-other-env'], skip_es=True) is False
+        testapp.get(post_res.location, status=200)
+        assert run_clear_db_es(app, only_envs=['fourfront-test-env'], skip_es=True) is True
+        testapp.get(post_res.location, status=404)
+
+    finally:
+
+        # reset settings after test
+        if prev_env is None:
+            del app.registry.settings['env.name']
+        else:
+            app.registry.settings['env.name'] = prev_env
+
+
+@contextlib.contextmanager
+def local_env_name_registry_setting_for_testing(app, envname):
+    old_env = app.registry.settings.get('env.name')
+    print(f"Remembering old env.name = {old_env}")
+    try:
+        app.registry.settings['env.name'] = envname
+        print(f"Set env.name = {envname}")
+        yield
+    finally:
+        if old_env is None:
+            print(f"Removing env.name")
+            del app.registry.settings['env.name']
+        else:
+            print(f"Restoring env.name to {old_env}")
+            app.registry.settings['env.name'] = old_env
+
+
+@pytest.mark.unit
+def test_run_clear_db_es_unit(app, testapp):
+
+    def mocked_is_stg_or_prd_env(env):
+        result = env.endswith("blue") or env.endswith("green") or env.endswith("cgap")
+        print(f"Mocked is_stg_or_prd_env({env}) returning {result}.")
+        return result
+
+    with mock.patch.object(clear_db_es_contents_module, "is_stg_or_prd_env") as mock_is_stg_or_prd_env:
+        mock_is_stg_or_prd_env.side_effect = mocked_is_stg_or_prd_env
+        with mock.patch.object(clear_db_es_contents_module, "clear_db_tables") as mock_clear_db_tables:
+            with mock.patch.object(clear_db_es_contents_module, "run_create_mapping") as mock_run_create_mapping:
+
+                expected_db_clears = 0
+                expected_es_clears = 0
+
+                assert mock_clear_db_tables.call_count == expected_db_clears
+                assert mock_run_create_mapping.call_count == expected_es_clears
+
+                # It works positionally
+                assert run_clear_db_es(app, None, True) is True
+                expected_db_clears += 1
+                expected_es_clears += 0
+
+                assert mock_clear_db_tables.call_count == expected_db_clears
+                assert mock_run_create_mapping.call_count == expected_es_clears
+
+                # It works by keyword argument
+                assert run_clear_db_es(app, only_envs=None, skip_es=True) is True
+                expected_db_clears += 1
+                expected_es_clears += 0
+
+                assert mock_clear_db_tables.call_count == expected_db_clears
+                assert mock_run_create_mapping.call_count == expected_es_clears
+
+                with local_env_name_registry_setting_for_testing(app, 'fourfront-cgap'):
+                    # should never run on this env
+                    assert clear_db_es_contents_module.is_stg_or_prd_env('fourfront-cgap') is True
+                    assert run_clear_db_es(app, only_envs=None, skip_es=True) is False
+                    expected_db_clears += 0
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                with local_env_name_registry_setting_for_testing(app, 'fourfront-test-env'):
+
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-other-env'], skip_es=True) is False
+                    expected_db_clears += 0
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-other-env'], skip_es=False) is False
+                    expected_db_clears += 0
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-test-env'], skip_es=True) is True
+                    expected_db_clears += 1
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-test-env'], skip_es=False) is True
+                    expected_db_clears += 1
+                    expected_es_clears += 1
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+
+@pytest.mark.unit
+def test_clear_db_es_contents_main():
+
+    class FakeApp:
+
+        def __init__(self, config_uri, appname):
+            self.appname = appname
+            self.config_uri = config_uri
+
+        def __str__(self):
+            return f"<FakeApp {self.appname} {self.config_uri} {id(self)}>"
+
+        def __repr__(self):
+            return str(self)
+
+    class MockDBSession:
+
+        def __init__(self, app):
+            self.app = app
+
+    apps = {}
+
+    def mocked_get_app(config_uri, appname):
+        key = (config_uri, appname)
+        app = apps.get(key)
+        if not app:
+            apps[key] = app = FakeApp(config_uri, appname)
+        return app
+
+    def mocked_configure_dbsession(app):
+        return MockDBSession(app)
+
+    with mock.patch.object(clear_db_es_contents_module, "run_clear_db_es") as mock_run_clear_db_es:
+        with mock.patch.object(clear_db_es_contents_module, "get_app") as mock_get_app:
+            mock_get_app.side_effect = mocked_get_app
+            with mock.patch.object(clear_db_es_contents_module, "configure_dbsession") as mock_configure_dbsession:
+                mock_configure_dbsession.side_effect = mocked_configure_dbsession
+
+                config_uri = 'production.ini'
+                appname = "app"
+
+                clear_db_es_contents_main([config_uri])
+                mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, None),
+                                                        only_envs=[],
+                                                        skip_es=False)
+
+                clear_db_es_contents_main([config_uri, "--app-name", appname])
+                mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                        only_envs=[],
+                                                        skip_es=False)
+
+                clear_db_es_contents_main([config_uri, "--app-name", appname, '--skip-es'])
+                mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                        only_envs=[],
+                                                        skip_es=True)
+
+                clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", "cgap-devtest"])
+                mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                        only_envs=['cgap-devtest'],
+                                                        skip_es=False)
+
+                clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", "cgap-devtest,cgap-foo"])
+                mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                        only_envs=['cgap-devtest', 'cgap-foo'],
+                                                        skip_es=False)


### PR DESCRIPTION
Adjustments to clear-db-es-contents to make arguments more intelligible and error messages more clear.

Instead of `--env <envname>` this wants you to supply `--only-if-env <env>` or `--only-if-envs <env1>,<env2>,...`

A `--confirm` and `--no-confirm` controls whether you are interactively queried for confirmation. The default is not to prompt if you provide `--only-if-env` or `--only-if-envs`, and otherwise to prompt.