### PR TITLE
Show cases without reports by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "9.1.1"
+version = "9.1.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/static-pages/HomePage/UserDashboard.js
+++ b/src/encoded/static/components/static-pages/HomePage/UserDashboard.js
@@ -54,7 +54,6 @@ export const UserDashboard = React.memo(function UserDashboard({ windowHeight, w
 const RecentCasesTable = React.memo(function RecentCasesTable({ windowHeight, windowWidth }){
     const searchHref = (
         "/search/?type=Case"
-        + "&report.uuid!=No+value"
         + "&proband_case=true"
         + "&status!=inactive"
         + "&sort=-last_modified.date_modified"

--- a/src/encoded/types/image.py
+++ b/src/encoded/types/image.py
@@ -33,6 +33,7 @@ class Image(ItemWithAttachment, Item):
     def unique_keys(self, properties):
         """smth."""
         keys = super(Image, self).unique_keys(properties)
-        value = properties['attachment']['download']
-        keys.setdefault('image:filename', []).append(value)
+        value = properties.get("attachment", {}).get("download")
+        if value:
+            keys.setdefault('image:filename', []).append(value)
         return keys


### PR DESCRIPTION
Here, we make a small change to the homepage case display such that cases without reports are included by default. Users can click the button to show only those with reports. We make this change since many of our users are accessioning cases without reports since they don't require the item.

Also, we fix a calcprop on Image items.