### PR TITLE
Allow Mixed Sequencing Submissions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "9.4.2"
+version = "9.4.3"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -1048,7 +1048,7 @@ class TestAccessionMetadata:
     def test_get_analysis_types(
         self, testapp, example_rows_obj, example_rows, project, institution
     ):
-        """analysis type should be none if workup types in samples don't match"""
+        """Test analysis type string calculation for cases."""
         a_types = example_rows_obj.analysis_types
         assert a_types["1111"] == "WGS-Trio"
         assert a_types["2222"] == "WGS"
@@ -1058,7 +1058,23 @@ class TestAccessionMetadata:
             testapp, example_rows, project, institution, TEST_INGESTION_ID1
         )
         new_a_types = new_obj.analysis_types
-        assert new_a_types["1111"] is None
+        assert new_a_types["1111"] == "WES/WGS-Trio"
+
+    @pytest.mark.parametrize(
+        "relations,expected",
+        [
+            (["proband"], ""),
+            (["proband", "mother", "father"], "-Trio"),
+            (["mother", "proband", "father"], "-Trio"),
+            (["proband", "mother"], "-Group"),
+            (["foo"], "-Group"),
+            ([], "-Group"),
+        ]
+    )
+    def test_get_analysis_type_add_on(self, example_rows_obj, relations, expected):
+        """Test analysis label based on relations."""
+        result = example_rows_obj.get_analysis_type_add_on(relations)
+        assert result == expected
 
     def test_add_metadata_single_item(
         self, testapp, example_rows, project, institution

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -1057,8 +1057,15 @@ class TestAccessionMetadata:
         new_obj = AccessionMetadata(
             testapp, example_rows, project, institution, TEST_INGESTION_ID1
         )
+        assert not new_obj.errors
         new_a_types = new_obj.analysis_types
         assert new_a_types["1111"] == "WES/WGS-Trio"
+        del example_rows[1][0]["workup type"]
+        example_rows[1][0]["test requested"] = ""
+        new_obj = AccessionMetadata(
+            testapp, example_rows, project, institution, TEST_INGESTION_ID1
+        )
+        assert new_obj.errors
 
     @pytest.mark.parametrize(
         "relations,expected",


### PR DESCRIPTION
In this PR, we refactor `submit.py` to allow case submissions with samples containing different sequencing types.