### PR TITLE
Fix problems in development.init.template and test.ini.template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,16 @@ Change Log
 10.3.1
 ======
 
-* Fix a bug in ``prepare-local-dev`` script.
+`PR 642: Fix problems in development.init.template and test.ini.template <https://github.com/dbmi-bgm/cgap-portal/pull/642>`_
+
+* Fix a bug in ``prepare-local-dev`` script (C4-907).
 * Cosmetic changes to Dockerfile to bring in line with Fourfront.
 
 
 10.3.0
 ======
+
+`PR 637: Manage development.ini and test.ini outside of source control <https://github.com/dbmi-bgm/cgap-portal/pull/637>`_
 
 Changes made by this PR:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Change Log
 ----------
 
 
+10.3.1
+======
+
+* Fix a bug in ``prepare-local-dev`` script.
+* Cosmetic changes to Dockerfile to bring in line with Fourfront.
+
+
 10.3.0
 ======
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # CGAP-Portal (Production) Dockerfile
-# Take latest 3.8.13 Debian variant
+
+# Debian Buster with Python 3.8.13
 FROM python:3.8.13-slim-buster
 
 MAINTAINER William Ronchetti "william_ronchetti@hms.harvard.edu"
@@ -76,7 +77,7 @@ RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/b
 COPY . .
 
 # Build remaining back-end
-RUN poetry install --no-dev && \
+RUN poetry install --no-dev -vvv && \
     python setup_eb.py develop && \
     make fix-dist-info
 

--- a/development.ini.template
+++ b/development.ini.template
@@ -27,7 +27,7 @@ encoded_version = 100.200.300
 snovault_version = 200.300.400
 utils_version = 300.400.500
 eb_app_version = app-v-development-simulation
-env.name = ${PREPARED_DEV_ENV:~cgap-devlocal-${USER}}
+env.name = cgap-devlocal-${USER}
 
 [pipeline:debug]
 pipeline =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "10.3.0"
+version = "10.3.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test.ini.template
+++ b/test.ini.template
@@ -16,7 +16,7 @@ utils_version = 333.444.555
 eb_app_version = app-v-test-simulation
 create_tables = true
 load_test_data = encoded.loadxl:load_test_data
-env.name = ${PREPARED_TEST_ENV:~cgap-test-${USER}}
+env.name = cgap-test-${USER}
 
 [composite:indexer]
 use = config:base.ini#indexer


### PR DESCRIPTION
@alexkb0009 reported a problem ([C4-907](https://hms-dbmi.atlassian.net/browse/C4-907)) in the `.ini` file creation done by `prepare-local-dev`. This fixes that.

I'm also including some cosmetic changes to the `Dockerfile`.