### PR TITLE
Remove Cypress from devDependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ COPY poetry.lock .
 RUN poetry install --no-root --no-dev
 
 # Do the front-end dependency install
+ENV NODE_ENV=production
 COPY package.json .
 COPY package-lock.json .
 RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python
@@ -82,7 +83,6 @@ RUN poetry install --no-dev -vvv && \
     make fix-dist-info
 
 # Build front-end, remove node_modules when done
-ENV NODE_ENV=production
 RUN npm run build && \
     npm run build-scss && \
     rm -rf node_modules/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,6 @@ COPY poetry.lock .
 RUN poetry install --no-root --no-dev
 
 # Do the front-end dependency install
-ENV NODE_ENV=production
 COPY package.json .
 COPY package-lock.json .
 RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python
@@ -83,9 +82,11 @@ RUN poetry install --no-dev -vvv && \
     make fix-dist-info
 
 # Build front-end, remove node_modules when done
+ENV NODE_ENV=production
 RUN npm run build && \
     npm run build-scss && \
     rm -rf node_modules/ && \
+    npm prune --production && \
     apt-get remove --purge --auto-remove -y ca-certificates
 
 # Copy config files in (down here for quick debugging)

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN poetry install --no-root --no-dev
 # Do the front-end dependency install
 COPY package.json .
 COPY package-lock.json .
-RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python
+RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python && npm cache clean --force
 
 # Copy over the rest of the code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,6 @@ ENV NODE_ENV=production
 RUN npm run build && \
     npm run build-scss && \
     rm -rf node_modules/ && \
-    npm prune --production && \
     apt-get remove --purge --auto-remove -y ca-certificates
 
 # Copy config files in (down here for quick debugging)

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "babel-loader": "^8.2.3",
         "babel-plugin-minify-dead-code-elimination": "^0.5.1",
         "bootstrap": "^4.6.1",
-        "cypress": "^10.3.0",
         "empty-module": "0.0.2",
         "eslint": "^8.10.0",
         "eslint-plugin-cypress": "^2.12.1",
@@ -1848,7 +1847,6 @@
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1857,8 +1855,8 @@
     },
     "node_modules/@cypress/request": {
       "version": "2.88.10",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -1885,24 +1883,24 @@
     },
     "node_modules/@cypress/request/node_modules/qs": {
       "version": "6.5.3",
-      "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/@cypress/request/node_modules/uuid": {
       "version": "8.3.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
@@ -1910,8 +1908,8 @@
     },
     "node_modules/@cypress/xvfb/node_modules/debug": {
       "version": "3.2.7",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -2859,13 +2857,13 @@
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -2877,7 +2875,6 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3109,7 +3106,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
@@ -3179,16 +3176,16 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -3212,7 +3209,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3273,7 +3270,6 @@
     },
     "node_modules/arch": {
       "version": "2.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3288,7 +3284,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/archy": {
       "version": "1.0.0",
@@ -3515,8 +3512,8 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -3545,8 +3542,8 @@
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3567,16 +3564,16 @@
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/async": {
       "version": "3.2.3",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/async-done": {
       "version": "1.3.2",
@@ -3614,8 +3611,8 @@
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3785,16 +3782,16 @@
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
       "version": "1.11.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/babel-cli": {
       "version": "6.26.0",
@@ -4512,8 +4509,8 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -4554,8 +4551,8 @@
     },
     "node_modules/blob-util": {
       "version": "2.0.2",
-      "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -4862,8 +4859,8 @@
     },
     "node_modules/cachedir": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -4910,8 +4907,8 @@
     },
     "node_modules/caseless": {
       "version": "0.12.0",
-      "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/center-align": {
       "version": "0.1.3",
@@ -4938,8 +4935,8 @@
     },
     "node_modules/check-more-types": {
       "version": "2.24.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -5042,8 +5039,8 @@
     },
     "node_modules/ci-info": {
       "version": "3.3.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
@@ -5141,7 +5138,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5153,8 +5150,8 @@
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -5164,8 +5161,8 @@
     },
     "node_modules/cli-table3": {
       "version": "0.6.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -5178,8 +5175,8 @@
     },
     "node_modules/cli-truncate": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
@@ -5378,8 +5375,8 @@
     },
     "node_modules/colorette": {
       "version": "2.0.16",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5393,16 +5390,16 @@
     },
     "node_modules/commander": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5585,7 +5582,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5726,9 +5723,9 @@
     },
     "node_modules/cypress": {
       "version": "10.3.0",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -5782,8 +5779,8 @@
     },
     "node_modules/cypress/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -5796,7 +5793,6 @@
     },
     "node_modules/cypress/node_modules/buffer": {
       "version": "5.7.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5812,6 +5808,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -5819,8 +5816,8 @@
     },
     "node_modules/cypress/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5834,8 +5831,8 @@
     },
     "node_modules/cypress/node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5845,8 +5842,8 @@
     },
     "node_modules/cypress/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -5856,21 +5853,21 @@
     },
     "node_modules/cypress/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cypress/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cypress/node_modules/semver": {
       "version": "7.3.7",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5883,8 +5880,8 @@
     },
     "node_modules/cypress/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6167,8 +6164,8 @@
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -6222,8 +6219,8 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.1",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6542,8 +6539,8 @@
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -6551,8 +6548,8 @@
     },
     "node_modules/ecc-jsbn/node_modules/jsbn": {
       "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -6589,8 +6586,8 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -6652,8 +6649,8 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -7319,8 +7316,8 @@
     },
     "node_modules/eventemitter2": {
       "version": "6.4.5",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/eventemitter3": {
       "version": "2.0.3",
@@ -7344,8 +7341,8 @@
     },
     "node_modules/execa": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -7366,8 +7363,8 @@
     },
     "node_modules/executable": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "pify": "^2.2.0"
       },
@@ -7554,7 +7551,7 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/extend-shallow": {
@@ -7596,8 +7593,8 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -7615,11 +7612,11 @@
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/falafel": {
       "version": "2.2.4",
@@ -7791,8 +7788,8 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -7803,8 +7800,8 @@
     },
     "node_modules/figures": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -7968,16 +7965,16 @@
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/form-data": {
       "version": "2.3.3",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -8025,8 +8022,8 @@
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -8191,8 +8188,8 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8226,16 +8223,16 @@
     },
     "node_modules/getos": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "async": "^3.2.0"
       }
     },
     "node_modules/getpass": {
       "version": "0.1.7",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -8367,8 +8364,8 @@
     },
     "node_modules/global-dirs": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ini": "2.0.0"
       },
@@ -11501,8 +11498,8 @@
     },
     "node_modules/http-signature": {
       "version": "1.3.6",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
@@ -11530,8 +11527,8 @@
     },
     "node_modules/human-signals": {
       "version": "1.1.1",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8.12.0"
       }
@@ -11613,7 +11610,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11637,8 +11634,8 @@
     },
     "node_modules/ini": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -11785,8 +11782,8 @@
     },
     "node_modules/is-ci": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ci-info": "^3.2.0"
       },
@@ -11886,8 +11883,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -11919,8 +11916,8 @@
     },
     "node_modules/is-installed-globally": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -11995,8 +11992,8 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -12069,8 +12066,8 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -12129,8 +12126,8 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
@@ -12145,8 +12142,8 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -12197,7 +12194,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ismobilejs": {
@@ -12236,8 +12233,8 @@
     },
     "node_modules/isstream": {
       "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-worker": {
       "version": "26.6.2",
@@ -12411,8 +12408,8 @@
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
-      "dev": true,
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "optional": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -12425,8 +12422,8 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -12440,8 +12437,8 @@
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -12497,11 +12494,11 @@
     },
     "node_modules/jsprim": {
       "version": "2.0.2",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -12570,8 +12567,8 @@
     },
     "node_modules/lazy-ass": {
       "version": "1.6.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "> 0.8"
       }
@@ -12648,8 +12645,8 @@
     },
     "node_modules/listr2": {
       "version": "3.14.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -12674,16 +12671,16 @@
     },
     "node_modules/listr2/node_modules/rxjs": {
       "version": "7.5.6",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/listr2/node_modules/tslib": {
       "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/load-json-file": {
       "version": "1.1.0",
@@ -12813,8 +12810,8 @@
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -12828,8 +12825,8 @@
     },
     "node_modules/log-symbols/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12842,8 +12839,8 @@
     },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12857,8 +12854,8 @@
     },
     "node_modules/log-symbols/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12868,21 +12865,21 @@
     },
     "node_modules/log-symbols/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/log-symbols/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12892,8 +12889,8 @@
     },
     "node_modules/log-update": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-escapes": "^4.3.0",
         "cli-cursor": "^3.1.0",
@@ -12909,8 +12906,8 @@
     },
     "node_modules/log-update/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12923,8 +12920,8 @@
     },
     "node_modules/log-update/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12934,13 +12931,13 @@
     },
     "node_modules/log-update/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/log-update/node_modules/slice-ansi": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -12955,8 +12952,8 @@
     },
     "node_modules/log-update/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -13144,7 +13141,7 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -13253,8 +13250,8 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -13696,8 +13693,8 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -14007,8 +14004,8 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -14082,8 +14079,8 @@
     },
     "node_modules/ospath": {
       "version": "1.2.2",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/output-file-sync": {
       "version": "1.1.2",
@@ -14126,7 +14123,7 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "aggregate-error": "^3.0.0"
@@ -14331,7 +14328,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14390,8 +14387,8 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -14414,7 +14411,7 @@
     },
     "node_modules/pify": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14618,8 +14615,8 @@
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       },
@@ -14709,8 +14706,8 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -15630,8 +15627,8 @@
     },
     "node_modules/request-progress": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "throttleit": "^1.0.0"
       }
@@ -15714,8 +15711,8 @@
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -15742,8 +15739,8 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/right-align": {
       "version": "0.1.3",
@@ -16186,7 +16183,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -16197,7 +16194,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16217,8 +16214,8 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -16264,8 +16261,8 @@
     },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -16277,8 +16274,8 @@
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -16291,8 +16288,8 @@
     },
     "node_modules/slice-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -16302,8 +16299,8 @@
     },
     "node_modules/slice-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/slugid": {
       "version": "1.1.0",
@@ -16572,8 +16569,8 @@
     },
     "node_modules/sshpk": {
       "version": "1.17.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -16596,8 +16593,8 @@
     },
     "node_modules/sshpk/node_modules/jsbn": {
       "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ssri": {
       "version": "8.0.1",
@@ -16912,8 +16909,8 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -16985,7 +16982,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -17007,8 +17004,8 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -17376,13 +17373,13 @@
     },
     "node_modules/throttleit": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/through2": {
       "version": "0.4.2",
@@ -17471,8 +17468,8 @@
     },
     "node_modules/tmp": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -17606,8 +17603,8 @@
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
-      "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -17676,8 +17673,8 @@
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -17687,8 +17684,8 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "dev": true,
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "optional": true
     },
     "node_modules/two-product": {
       "version": "1.0.2",
@@ -17715,8 +17712,8 @@
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -17955,8 +17952,8 @@
     },
     "node_modules/universalify": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -18025,8 +18022,8 @@
     },
     "node_modules/untildify": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -18157,11 +18154,11 @@
     },
     "node_modules/verror": {
       "version": "1.10.0",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -18930,7 +18927,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -19014,8 +19011,8 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -19030,8 +19027,8 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -19044,8 +19041,8 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -19055,8 +19052,8 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -19215,8 +19212,8 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -20286,12 +20283,11 @@
     },
     "@colors/colors": {
       "version": "1.5.0",
-      "dev": true,
       "optional": true
     },
     "@cypress/request": {
       "version": "2.88.10",
-      "dev": true,
+      "optional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -20315,17 +20311,17 @@
       "dependencies": {
         "qs": {
           "version": "6.5.3",
-          "dev": true
+          "optional": true
         },
         "uuid": {
           "version": "8.3.2",
-          "dev": true
+          "optional": true
         }
       }
     },
     "@cypress/xvfb": {
       "version": "1.2.4",
-      "dev": true,
+      "optional": true,
       "requires": {
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
@@ -20333,7 +20329,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -21061,11 +21057,11 @@
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
-      "dev": true
+      "optional": true
     },
     "@types/sizzle": {
       "version": "2.3.3",
-      "dev": true
+      "optional": true
     },
     "@types/tough-cookie": {
       "version": "4.0.2"
@@ -21075,7 +21071,6 @@
     },
     "@types/yauzl": {
       "version": "2.10.0",
-      "dev": true,
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -21262,7 +21257,7 @@
     },
     "aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -21307,11 +21302,11 @@
     },
     "ansi-colors": {
       "version": "4.1.3",
-      "dev": true
+      "optional": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
-      "dev": true,
+      "optional": true,
       "requires": {
         "type-fest": "^0.21.3"
       }
@@ -21325,7 +21320,7 @@
     },
     "ansi-regex": {
       "version": "5.0.1",
-      "dev": true
+      "devOptional": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -21366,7 +21361,7 @@
     },
     "arch": {
       "version": "2.2.0",
-      "dev": true
+      "optional": true
     },
     "archy": {
       "version": "1.0.0",
@@ -21508,7 +21503,7 @@
     },
     "asn1": {
       "version": "0.2.6",
-      "dev": true,
+      "optional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -21541,18 +21536,18 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "dev": true
+      "optional": true
     },
     "assign-symbols": {
       "version": "1.0.0"
     },
     "astral-regex": {
       "version": "2.0.0",
-      "dev": true
+      "optional": true
     },
     "async": {
       "version": "3.2.3",
-      "dev": true
+      "optional": true
     },
     "async-done": {
       "version": "1.3.2",
@@ -21580,7 +21575,7 @@
     },
     "at-least-node": {
       "version": "1.0.0",
-      "dev": true
+      "optional": true
     },
     "atob": {
       "version": "2.1.2"
@@ -21716,11 +21711,11 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "dev": true
+      "optional": true
     },
     "aws4": {
       "version": "1.11.0",
-      "dev": true
+      "optional": true
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -22246,7 +22241,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "dev": true,
+      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -22273,7 +22268,7 @@
     },
     "blob-util": {
       "version": "2.0.2",
-      "dev": true
+      "optional": true
     },
     "bluebird": {
       "version": "3.7.2"
@@ -22495,7 +22490,7 @@
     },
     "cachedir": {
       "version": "2.3.0",
-      "dev": true
+      "optional": true
     },
     "call-bind": {
       "version": "1.0.2",
@@ -22516,7 +22511,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "dev": true
+      "optional": true
     },
     "center-align": {
       "version": "0.1.3",
@@ -22535,7 +22530,7 @@
     },
     "check-more-types": {
       "version": "2.24.0",
-      "dev": true
+      "optional": true
     },
     "cheerio": {
       "version": "1.0.0-rc.10",
@@ -22613,7 +22608,7 @@
     },
     "ci-info": {
       "version": "3.3.0",
-      "dev": true
+      "optional": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -22683,21 +22678,21 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "dev": true
+      "devOptional": true
     },
     "clear-cut": {
       "version": "2.0.2"
     },
     "cli-cursor": {
       "version": "3.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
     },
     "cli-table3": {
       "version": "0.6.2",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
@@ -22705,7 +22700,7 @@
     },
     "cli-truncate": {
       "version": "2.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
@@ -22843,7 +22838,7 @@
     },
     "colorette": {
       "version": "2.0.16",
-      "dev": true
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -22853,11 +22848,11 @@
     },
     "commander": {
       "version": "5.1.0",
-      "dev": true
+      "optional": true
     },
     "common-tags": {
       "version": "1.8.2",
-      "dev": true
+      "optional": true
     },
     "commondir": {
       "version": "1.0.1"
@@ -23001,7 +22996,7 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -23110,7 +23105,7 @@
     },
     "cypress": {
       "version": "10.3.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -23158,14 +23153,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "buffer": {
           "version": "5.7.1",
-          "dev": true,
+          "optional": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -23173,7 +23168,7 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -23181,7 +23176,7 @@
           "dependencies": {
             "supports-color": {
               "version": "7.2.0",
-              "dev": true,
+              "optional": true,
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -23190,29 +23185,29 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "dev": true
+          "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "dev": true
+          "optional": true
         },
         "semver": {
           "version": "7.3.7",
-          "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "supports-color": {
           "version": "8.1.1",
-          "dev": true,
+          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -23446,7 +23441,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -23483,7 +23478,7 @@
     },
     "dayjs": {
       "version": "1.11.1",
-      "dev": true
+      "optional": true
     },
     "debug": {
       "version": "4.3.4",
@@ -23695,7 +23690,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "dev": true,
+      "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -23703,7 +23698,7 @@
       "dependencies": {
         "jsbn": {
           "version": "0.1.1",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -23740,7 +23735,7 @@
     },
     "emoji-regex": {
       "version": "8.0.0",
-      "dev": true
+      "optional": true
     },
     "emojis-list": {
       "version": "3.0.0"
@@ -23788,7 +23783,7 @@
     },
     "enquirer": {
       "version": "2.3.6",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -24235,7 +24230,7 @@
     },
     "eventemitter2": {
       "version": "6.4.5",
-      "dev": true
+      "optional": true
     },
     "eventemitter3": {
       "version": "2.0.3"
@@ -24254,7 +24249,7 @@
     },
     "execa": {
       "version": "4.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -24269,7 +24264,7 @@
     },
     "executable": {
       "version": "4.1.1",
-      "dev": true,
+      "optional": true,
       "requires": {
         "pify": "^2.2.0"
       }
@@ -24403,7 +24398,7 @@
     },
     "extend": {
       "version": "3.0.2",
-      "dev": true
+      "devOptional": true
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -24434,7 +24429,7 @@
     },
     "extract-zip": {
       "version": "2.0.1",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -24444,7 +24439,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "dev": true
+      "optional": true
     },
     "falafel": {
       "version": "2.2.4",
@@ -24567,7 +24562,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -24577,7 +24572,7 @@
     },
     "figures": {
       "version": "3.2.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -24687,11 +24682,11 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "dev": true
+      "optional": true
     },
     "form-data": {
       "version": "2.3.3",
-      "dev": true,
+      "optional": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -24726,7 +24721,7 @@
     },
     "fs-extra": {
       "version": "9.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -24837,7 +24832,7 @@
     },
     "get-stream": {
       "version": "5.2.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -24854,14 +24849,14 @@
     },
     "getos": {
       "version": "3.2.1",
-      "dev": true,
+      "optional": true,
       "requires": {
         "async": "^3.2.0"
       }
     },
     "getpass": {
       "version": "0.1.7",
-      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -24960,7 +24955,7 @@
     },
     "global-dirs": {
       "version": "3.0.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ini": "2.0.0"
       }
@@ -27231,7 +27226,7 @@
     },
     "http-signature": {
       "version": "1.3.6",
-      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
@@ -27252,7 +27247,7 @@
     },
     "human-signals": {
       "version": "1.1.1",
-      "dev": true
+      "optional": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -27305,7 +27300,7 @@
     },
     "indent-string": {
       "version": "4.0.0",
-      "dev": true
+      "devOptional": true
     },
     "infer-owner": {
       "version": "1.0.4"
@@ -27322,7 +27317,7 @@
     },
     "ini": {
       "version": "2.0.0",
-      "dev": true
+      "optional": true
     },
     "inline-style-parser": {
       "version": "0.1.1",
@@ -27415,7 +27410,7 @@
     },
     "is-ci": {
       "version": "3.0.1",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ci-info": "^3.2.0"
       }
@@ -27470,7 +27465,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true
+      "optional": true
     },
     "is-generator-function": {
       "version": "1.0.10",
@@ -27489,7 +27484,7 @@
     },
     "is-installed-globally": {
       "version": "0.4.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -27530,7 +27525,7 @@
     },
     "is-path-inside": {
       "version": "3.0.3",
-      "dev": true
+      "optional": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -27573,7 +27568,7 @@
     },
     "is-stream": {
       "version": "2.0.1",
-      "dev": true
+      "optional": true
     },
     "is-string": {
       "version": "1.0.7",
@@ -27605,7 +27600,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "dev": true
+      "optional": true
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -27616,7 +27611,7 @@
     },
     "is-unicode-supported": {
       "version": "0.1.0",
-      "dev": true
+      "optional": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -27643,7 +27638,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "dev": true
+      "devOptional": true
     },
     "ismobilejs": {
       "version": "1.1.1"
@@ -27672,7 +27667,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "dev": true
+      "optional": true
     },
     "jest-worker": {
       "version": "26.6.2",
@@ -27798,7 +27793,7 @@
     },
     "json-schema": {
       "version": "0.4.0",
-      "dev": true
+      "optional": true
     },
     "json-schema-traverse": {
       "version": "0.4.1"
@@ -27809,14 +27804,14 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "dev": true
+      "optional": true
     },
     "json5": {
       "version": "2.2.1"
     },
     "jsonfile": {
       "version": "6.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -27865,7 +27860,7 @@
     },
     "jsprim": {
       "version": "2.0.2",
-      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -27920,7 +27915,7 @@
     },
     "lazy-ass": {
       "version": "1.6.0",
-      "dev": true
+      "optional": true
     },
     "lazy-cache": {
       "version": "1.0.4"
@@ -27970,7 +27965,7 @@
     },
     "listr2": {
       "version": "3.14.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -27984,14 +27979,14 @@
       "dependencies": {
         "rxjs": {
           "version": "7.5.6",
-          "dev": true,
+          "optional": true,
           "requires": {
             "tslib": "^2.1.0"
           }
         },
         "tslib": {
           "version": "2.4.0",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -28099,7 +28094,7 @@
     },
     "log-symbols": {
       "version": "4.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -28107,14 +28102,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -28122,22 +28117,22 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "dev": true
+          "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "dev": true
+          "optional": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -28146,7 +28141,7 @@
     },
     "log-update": {
       "version": "4.0.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ansi-escapes": "^4.3.0",
         "cli-cursor": "^3.1.0",
@@ -28156,25 +28151,25 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "color-convert": {
           "version": "2.0.1",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "dev": true
+          "optional": true
         },
         "slice-ansi": {
           "version": "4.0.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "astral-regex": "^2.0.0",
@@ -28183,7 +28178,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -28311,7 +28306,7 @@
     },
     "merge-stream": {
       "version": "2.0.0",
-      "dev": true
+      "devOptional": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -28382,7 +28377,7 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "dev": true
+      "optional": true
     },
     "mini-signals": {
       "version": "1.2.0"
@@ -28698,7 +28693,7 @@
     },
     "npm-run-path": {
       "version": "4.0.1",
-      "dev": true,
+      "optional": true,
       "requires": {
         "path-key": "^3.0.0"
       }
@@ -28897,7 +28892,7 @@
     },
     "onetime": {
       "version": "5.1.2",
-      "dev": true,
+      "optional": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -28943,7 +28938,7 @@
     },
     "ospath": {
       "version": "1.2.2",
-      "dev": true
+      "optional": true
     },
     "output-file-sync": {
       "version": "1.1.2",
@@ -28972,7 +28967,7 @@
     },
     "p-map": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "aggregate-error": "^3.0.0"
       }
@@ -29109,7 +29104,7 @@
     },
     "path-key": {
       "version": "3.1.1",
-      "dev": true
+      "devOptional": true
     },
     "path-parse": {
       "version": "1.0.7",
@@ -29147,7 +29142,7 @@
     },
     "pend": {
       "version": "1.2.0",
-      "dev": true
+      "optional": true
     },
     "performance-now": {
       "version": "2.1.0"
@@ -29161,7 +29156,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "dev": true
+      "devOptional": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -29285,7 +29280,7 @@
     },
     "pretty-bytes": {
       "version": "5.6.0",
-      "dev": true
+      "optional": true
     },
     "pretty-hrtime": {
       "version": "1.0.3",
@@ -29342,7 +29337,7 @@
     },
     "proxy-from-env": {
       "version": "1.0.0",
-      "dev": true
+      "optional": true
     },
     "prr": {
       "version": "1.0.1"
@@ -29995,7 +29990,7 @@
     },
     "request-progress": {
       "version": "3.0.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "throttleit": "^1.0.0"
       }
@@ -30051,7 +30046,7 @@
     },
     "restore-cursor": {
       "version": "3.1.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -30066,7 +30061,7 @@
     },
     "rfdc": {
       "version": "1.3.0",
-      "dev": true
+      "optional": true
     },
     "right-align": {
       "version": "0.1.3",
@@ -30358,14 +30353,14 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "dev": true
+      "devOptional": true
     },
     "side-channel": {
       "version": "1.0.4",
@@ -30377,7 +30372,7 @@
     },
     "signal-exit": {
       "version": "3.0.7",
-      "dev": true
+      "optional": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -30411,7 +30406,7 @@
     },
     "slice-ansi": {
       "version": "3.0.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -30420,21 +30415,21 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "color-convert": {
           "version": "2.0.1",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -30633,7 +30628,7 @@
     },
     "sshpk": {
       "version": "1.17.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -30648,7 +30643,7 @@
       "dependencies": {
         "jsbn": {
           "version": "0.1.1",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -30870,7 +30865,7 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "dev": true,
+      "optional": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -30922,7 +30917,7 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -30936,7 +30931,7 @@
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "dev": true
+      "optional": true
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -31172,11 +31167,11 @@
     },
     "throttleit": {
       "version": "1.0.0",
-      "dev": true
+      "optional": true
     },
     "through": {
       "version": "2.3.8",
-      "dev": true
+      "optional": true
     },
     "through2": {
       "version": "0.4.2",
@@ -31246,7 +31241,7 @@
     },
     "tmp": {
       "version": "0.2.1",
-      "dev": true,
+      "optional": true,
       "requires": {
         "rimraf": "^3.0.0"
       }
@@ -31337,7 +31332,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -31387,14 +31382,14 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "dev": true
+      "optional": true
     },
     "two-product": {
       "version": "1.0.2"
@@ -31414,7 +31409,7 @@
     },
     "type-fest": {
       "version": "0.21.3",
-      "dev": true
+      "optional": true
     },
     "typedarray": {
       "version": "0.0.6"
@@ -31573,7 +31568,7 @@
     },
     "universalify": {
       "version": "2.0.0",
-      "dev": true
+      "optional": true
     },
     "unload": {
       "version": "2.2.0",
@@ -31619,7 +31614,7 @@
     },
     "untildify": {
       "version": "4.0.0",
-      "dev": true
+      "optional": true
     },
     "upath": {
       "version": "1.2.0",
@@ -31709,7 +31704,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -32223,7 +32218,7 @@
     },
     "which": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -32277,7 +32272,7 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -32286,21 +32281,21 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "color-convert": {
           "version": "2.0.1",
-          "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -32416,7 +32411,7 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "dev": true,
+      "optional": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "babel-loader": "^8.2.3",
     "babel-plugin-minify-dead-code-elimination": "^0.5.1",
     "bootstrap": "^4.6.1",
-    "cypress": "^10.3.0",
     "empty-module": "0.0.2",
     "eslint": "^8.10.0",
     "eslint-plugin-cypress": "^2.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "10.3.1"
+version = "10.3.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Remove duplicated entry for Cypress causing it to be packaged with Docker
- Update package-lock.json
- There is a .cache folder that npm uses and duplicates the node_modules unnecessarily, I realized it when reviewing the ECR scans and the cache paths showed vulnerabilities - removes this