### PR TITLE
Adjustments to changelog handling

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,6 +1,6 @@
 # PyPi publish for dcicsnovault
 
-name: Syntactic Checks
+name: Static Checks
 
 # Controls when the action will run.
 on:
@@ -17,6 +17,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: Static checks of source code (PEP8 and our custom checks)
     # The type of runner that the job will run on
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -33,6 +33,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+      - name: Install/Link Postgres
+        if: ${{ matrix.test_type == 'NPM' || matrix.test_type == 'UNIT' }}
+        run: |
+          sudo apt-get install curl ca-certificates gnupg
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update
+          sudo apt-get install postgresql-11 postgresql-client-11
+          echo "/usr/lib/postgresql/11/bin" >> $GITHUB_PATH
+          sudo ln -s /usr/lib/postgresql/11/bin/initdb /usr/local/bin/initdb
       - name: Python Package Setup
         run: |
           make configure

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -27,7 +27,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: Setup
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Python Package Setup
         run: |
           make configure
           poetry install

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -33,6 +33,8 @@ jobs:
           poetry install
       - name: Static Checks
         env:
+          # This variable should not get used, but it's here for separation "just in case"
+          TEST_JOB_ID: cgap-static-test-${{ github.run_number }}-
           GLOBAL_ENV_BUCKET: ${{ secrets.GLOBAL_ENV_BUCKET }}
           ACCOUNT_NUMBER: $ {{ secrets.ACCOUNT_NUMBER }}
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -34,7 +34,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Install/Link Postgres
-        if: ${{ matrix.test_type == 'NPM' || matrix.test_type == 'UNIT' }}
         run: |
           sudo apt-get install curl ca-certificates gnupg
           curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,37 @@
+# PyPi publish for dcicsnovault
+
+name: Syntactic Checks
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Setup
+        run: |
+          make configure
+          poetry install
+      - name: Static Checks
+        run: |
+          make test-static
+          make lint

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -33,6 +33,7 @@ jobs:
           poetry install
       - name: Static Checks
         env:
+          S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
           # This variable should not get used, but it's here for separation "just in case"
           TEST_JOB_ID: cgap-static-test-${{ github.run_number }}-
           GLOBAL_ENV_BUCKET: ${{ secrets.GLOBAL_ENV_BUCKET }}

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -32,6 +32,9 @@ jobs:
           make configure
           poetry install
       - name: Static Checks
+        env:
+          GLOBAL_ENV_BUCKET: ${{ secrets.GLOBAL_ENV_BUCKET }}
+          ACCOUNT_NUMBER: $ {{ secrets.ACCOUNT_NUMBER }}
         run: |
           make test-static
           make lint

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Change Log
 ----------
 
 
+10.3.5
+======
+
+* Raise an error if change log inconsistent.
+
+
 10.3.4
 ======
 

--- a/Makefile
+++ b/Makefile
@@ -162,29 +162,32 @@ retest:
 	poetry run python -m pytest -vv -r w --last-failed
 
 test-any:
-	poetry run python -m pytest -vv -r w --timeout=200
+	poetry run python -m pytest -xvv -r w --timeout=200
 
 test-npm:
-	poetry run python -m pytest -vv -r w --timeout=300 -m "not manual and not integratedx and not performance and not broken and not sloppy and not indexing"
+	poetry run python -m pytest -xvv -r w --durations=25 --timeout=600 -m "not static and not manual and not integratedx and not performance and not broken and not sloppy and not indexing"
 
 test-unit:
-	poetry run python -m pytest -vv -r w --timeout=200 -m "not manual and not integratedx and not performance and not broken and not sloppy and indexing"
+	poetry run python -m pytest -xvv -r w --durations=25 --timeout=200 -m "not static and not manual and not integratedx and not performance and not broken and not sloppy and indexing"
 
 test-performance:
-	poetry run python -m pytest -vv -r w --timeout=200 -m "not manual and not integratedx and performance and not broken and not sloppy"
+	poetry run python -m pytest -xvv -r w --timeout=200 -m "not static and not manual and not integratedx and performance and not broken and not sloppy"
 
 test-integrated:
-	poetry run python -m pytest -vv -r w --timeout=200 -m "not manual and (integrated or integratedx) and not performance and not broken and not sloppy"
+	poetry run python -m pytest -xvv -r w --timeout=200 -m "not static and not manual and (integrated or integratedx) and not performance and not broken and not sloppy"
+
+test-static:
+	poetry run python -m pytest -m static
 
 remote-test:  # Actually, we don't normally use this. Instead the GA workflow sets up two parallel tests.
 	make remote-test-unit
 	make remote-test-npm
 
 remote-test-npm:  # Note this only does the 'not indexing' tests
-	poetry run python -m pytest -vv -r w --instafail --force-flaky --max-runs=2 --timeout=600 -m "not manual and not integratedx and not performance and not broken and not broken_remotely and not sloppy and not indexing" --aws-auth --durations=20 --cov src/encoded --es search-cgap-unit-testing-6-8-2p5zrlkmxif4bayh5y6kxzlvx4.us-east-1.es.amazonaws.com:443
+	poetry run python -m pytest -xvv -r w --instafail --force-flaky --max-runs=2 --timeout=600 -m "not static and not manual and not integratedx and not performance and not broken and not broken_remotely and not sloppy and not indexing" --aws-auth --durations=20 --cov src/encoded --es search-cgap-unit-testing-6-8-2p5zrlkmxif4bayh5y6kxzlvx4.us-east-1.es.amazonaws.com:443
 
 remote-test-unit:  # Note this does the 'indexing' tests
-	poetry run python -m pytest -vv -r w --timeout=300 -m "not manual and not integratedx and not performance and not broken and not broken_remotely and not sloppy and indexing" --aws-auth --es search-cgap-unit-testing-6-8-2p5zrlkmxif4bayh5y6kxzlvx4.us-east-1.es.amazonaws.com:443
+	poetry run python -m pytest -xvv -r w --timeout=300 -m "not static and not manual and not integratedx and not performance and not broken and not broken_remotely and not sloppy and indexing" --aws-auth --es search-cgap-unit-testing-6-8-2p5zrlkmxif4bayh5y6kxzlvx4.us-east-1.es.amazonaws.com:443
 
 update:  # updates dependencies
 	poetry update
@@ -244,6 +247,9 @@ tag-and-push-docker-production:
 	date
 	docker push ${AWS_ACCOUNT}.dkr.ecr.us-east-1.amazonaws.com/${ENV_NAME}:latest
 	date
+
+lint:
+	@echo "simulated flake8 for now. we're not ready for a real one"
 
 help:
 	@make info

--- a/poetry.lock
+++ b/poetry.lock
@@ -626,7 +626,7 @@ python-versions = "*"
 
 [[package]]
 name = "dcicsnovault"
-version = "6.0.6"
+version = "6.0.7"
 description = "Storage support for 4DN Data Portals."
 category = "main"
 optional = false
@@ -637,7 +637,7 @@ aws_requests_auth = ">=0.4.1,<0.5.0"
 "backports.statistics" = "0.1.0"
 boto3 = ">=1.24.36"
 botocore = ">=1.27.36"
-dcicutils = ">=4.0.0,<5.0.0"
+dcicutils = ">=5.1.0,<6.0.0"
 elasticsearch = "6.8.1"
 elasticsearch_dsl = ">=6.4.0,<7.0.0"
 future = ">=0.15.2,<1"
@@ -679,11 +679,11 @@ xlrd = ">=1.0.0,<2.0.0"
 
 [[package]]
 name = "dcicutils"
-version = "4.4.0"
+version = "5.1.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 category = "main"
 optional = false
-python-versions = ">=3.6.1,<3.10"
+python-versions = ">=3.7,<3.10"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -2238,7 +2238,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.9"
-content-hash = "9f2ea82220a038a686b33a70dc62c6831a3eb8fc7707c3e7ada82f1fef29a4d6"
+content-hash = "482fe06ef6c083d46d0d0329dcd3d8faaba37958d76a2d09eaa87eacf3e0bb54"
 
 [metadata.files]
 apipkg = [
@@ -2538,12 +2538,12 @@ dcicpyvcf = [
     {file = "dcicpyvcf-1.0.0.tar.gz", hash = "sha256:c5bf8d585002ab3b95d13a47803376b456b931865e4189c38a18cca47b108449"},
 ]
 dcicsnovault = [
-    {file = "dcicsnovault-6.0.6-py3-none-any.whl", hash = "sha256:8d5c7e3b6db96257983e3c3e2687e62f1bf57a548cba93be8b5bb037ae7dcbec"},
-    {file = "dcicsnovault-6.0.6.tar.gz", hash = "sha256:e1c2d84264834315b0738aeb4fc3266ed39186b8c2794f50031b6ab661b3f9f2"},
+    {file = "dcicsnovault-6.0.7-py3-none-any.whl", hash = "sha256:a43d8a9c88e2cea9cb34629f9a94dfe5a8b8470374f6ac89de0c92f79efef050"},
+    {file = "dcicsnovault-6.0.7.tar.gz", hash = "sha256:244f6aefbe28dcfe7eabad60d32f8a7f8cdc6dcc53075a55de0d64fb3743af39"},
 ]
 dcicutils = [
-    {file = "dcicutils-4.4.0-py3-none-any.whl", hash = "sha256:995a7b0fb68cc2fd3cf886b56e48d9699346d14a212f632f22588b2e1662811d"},
-    {file = "dcicutils-4.4.0.tar.gz", hash = "sha256:bc198aceb9894d9809d12703374cd1e64a10f55ed84fba5555195c6b450c7e9c"},
+    {file = "dcicutils-5.1.0-py3-none-any.whl", hash = "sha256:3cc227cc507f0b7c6cd69d554c583992b99606cd4578e3d7c13185145b1dac27"},
+    {file = "dcicutils-5.1.0.tar.gz", hash = "sha256:978d0a5089cdf43557ed5ade305e3291227d8834e717628a08f3382d3110c6be"},
 ]
 docker = [
     {file = "docker-4.4.4-py2.py3-none-any.whl", hash = "sha256:f3607d5695be025fa405a12aca2e5df702a57db63790c73b927eb6a94aac60af"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "10.3.4"
+version = "10.3.5"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -45,8 +45,8 @@ chardet = "3.0.4"
 codeguru-profiler-agent = "^1.2.4"
 colorama = "0.3.3"
 dcicpyvcf = "1.0.0"
-dcicsnovault = "^6.0.6"
-dcicutils = "^4.2.0"
+dcicsnovault = "^6.0.7"
+dcicutils = "^5.1.0"
 elasticsearch = "6.8.1"
 execnet = "1.4.1"
 future = ">=0.18.2,<1"

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,8 @@ addopts =
    -p snovault.tests.serverfixtures
    -p encoded.tests.personas
     --instafail
+filterwarnings =
+    ignore::DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
 markers =
     broken: mark as a test that is broken everywhere.
     es: mark a test as an elastic search test (deselect with '-m "not es"')
@@ -20,6 +22,7 @@ markers =
     sloppy: mark a test as using poor data hygiene (leaving garbage behind that may adversely affect other tests)
     slow: mark a test as slow (deselect with '-m "not slow"')
     storage: mark a test as about storage (deselect with '-m "not storage"')
+    static: mark as a test that is testing the static form of code, not its runtime functionality
     triage: mark a test as something that needs working/broken triage.
     unit: a proper unit test
     workbook: mark a test as using the 'workbook' fixture (so tests can split 'workbook' from 'not workbook')

--- a/src/encoded/tests/test_misc.py
+++ b/src/encoded/tests/test_misc.py
@@ -1,9 +1,11 @@
 import os
+import pytest
 
 from dcicutils.qa_utils import ChangeLogChecker
 from .conftest_settings import REPOSITORY_ROOT_DIR
 
 
+@pytest.mark.static
 def test_changelog_consistency():
 
     class MyAppChangeLogChecker(ChangeLogChecker):

--- a/src/encoded/tests/test_misc.py
+++ b/src/encoded/tests/test_misc.py
@@ -1,13 +1,13 @@
 import os
 
-from dcicutils.qa_utils import VersionChecker
+from dcicutils.qa_utils import ChangeLogChecker
 from .conftest_settings import REPOSITORY_ROOT_DIR
 
 
-def test_version_and_changelog():
+def test_changelog_consistency():
 
-    class MyAppVersionChecker(VersionChecker):
+    class MyAppChangeLogChecker(ChangeLogChecker):
         PYPROJECT = os.path.join(REPOSITORY_ROOT_DIR, "pyproject.toml")
         CHANGELOG = os.path.join(REPOSITORY_ROOT_DIR, "CHANGELOG.rst")
 
-    MyAppVersionChecker.check_version()
+    MyAppChangeLogChecker.check_version()


### PR DESCRIPTION
* Uses `dcicutils ^5.1.0` (and updated `snovault ^6.0.7` that's compatible with that)
* Raises error on changelog inconsistency.
* Adds a workflow to check static things like changelog.

Note: The new workflow shouldn't need database setup, but that's because we have server fixtures that span the whole set of tests that do database setup/cleanup. We might want to make an env variable that can suppress that so that we don't have to wait for a db install. It's not hugely slow, at least.
