### PR TITLE
Submission bug fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 `PR 659: Submission bug fixes <https://github.com/dbmi-bgm/cgap-portal/pull/659>`_
 
 * Minor refactoring of case submission code to fix bugs failing submissions
+* Enforce file name conventions to match schema regex
 
 
 10.4.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Change Log
 ----------
 
 
+10.4.1
+======
+
+`PR 659: Submission bug fixes <https://github.com/dbmi-bgm/cgap-portal/pull/659>`_
+
+* Minor refactoring of case submission code to fix bugs failing submissions
+
+
 10.4.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "10.4.0"
+version = "10.4.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -326,6 +326,25 @@ def format_ontology_term_with_colon(str_value):
     return str_value.upper().replace("_", ":")
 
 
+def make_conjoined_list(list_values, conjunction="and"):
+    """Make conjoined list with more sane defaults.
+
+    :param list_values: The strings to join
+    :type list_values: list
+    :param conjunction: Conjunction for joining strings
+    :type conjunction: str
+    :returns: Joined strings
+    :rtype: str
+    """
+    if conjunction:
+        result = conjoined_list(
+            list_values, oxford_comma=True, conjunction=conjunction, nothing=" "
+        )
+    else:
+        result = conjoined_list(list_values, oxford_comma=True, nothing=" ")
+    return result
+
+
 class MetadataItem:
     """
     class for single DB-item-worth of json
@@ -670,10 +689,16 @@ class AccessionRow:
             if result is None:
                 msg = (
                     f"Row {self.row} - Invalid genome build provided:"
-                    f" {submitted_genome_build}. Consider replacing with one of the"
-                    f" following:"
-                    f" {conjoined_list(list(self.ACCEPTED_GENOME_BUILDS.keys()))}."
+                    f" {submitted_genome_build}."
                 )
+                if self.ACCEPTED_GENOME_BUILDS:
+                    accepted_genome_builds = make_conjoined_list(
+                        list(self.ACCEPTED_GENOME_BUILDS.keys()), conjunction="or",
+                    )
+                    msg += (
+                        "Consider replacing with one of the following:"
+                        f" {accepted_genome_builds}."
+                    )
                 self.errors.append(msg)
         return result
 
@@ -1232,7 +1257,7 @@ class SubmittedFilesParser:
         if multiple_file_formats:
             msg = (
                 "Could not identify a unique file format for the following file"
-                f" extensions: {conjoined_list(list(multiple_file_formats.keys()))}."
+                f" extensions: {make_conjoined_list(list(multiple_file_formats.keys()))}."
                 f" Please report this error to the CGAP team for assistance:"
                 f" {multiple_file_formats}."
             )
@@ -1306,14 +1331,14 @@ class SubmittedFilesParser:
             if invalid_fastq_names:
                 msg = (
                     f"Row {row_index} - Invalid FASTQ file name(s) found:"
-                    f" {conjoined_list(invalid_fastq_names)}. FASTQ file names"
+                    f" {make_conjoined_list(invalid_fastq_names)}. FASTQ file names"
                     f" must contain read information; see documentation for details."
                 )
                 errors.append(msg)
             if unpaired_fastqs:
                 msg = (
                     f"Row {row_index} - No matched pair-end file found for FASTQ file"
-                    f" name(s): {conjoined_list(unpaired_fastqs)}."
+                    f" name(s): {make_conjoined_list(unpaired_fastqs)}."
                     f" Matched FASTQ file names must differ only in the read number."
                 )
                 errors.append(msg)
@@ -1321,16 +1346,16 @@ class SubmittedFilesParser:
             if self.unidentified_file_format is False:
                 accepted_file_extensions = self.get_accepted_file_extensions()
                 msg = (
-                    f"Unable to identify at least 1 file extension on this submission."
+                    "Unable to identify at least 1 file extension on this submission."
                     f" The following extensions are currently accepted:"
-                    f" {conjoined_list(accepted_file_extensions)}."
+                    f" {make_conjoined_list(accepted_file_extensions)}."
                 )
                 self.errors.append(msg)
                 self.unidentified_file_format = True
             msg = (
                 f"Row {row_index} - Invalid file extensions provided for the following"
                 f" file name(s):"
-                f" {conjoined_list(list(files_without_file_format.keys()))}."
+                f" {make_conjoined_list(list(files_without_file_format.keys()))}."
             )
             errors.append(msg)
         return file_items, file_aliases, errors

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -693,7 +693,7 @@ class AccessionRow:
                 )
                 if self.ACCEPTED_GENOME_BUILDS:
                     accepted_genome_builds = make_conjoined_list(
-                        list(self.ACCEPTED_GENOME_BUILDS.keys()), conjunction="or",
+                        list(self.ACCEPTED_GENOME_BUILDS.keys()), conjunction="or"
                     )
                     msg += (
                         " Accepted genome builds include the following:"

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -696,7 +696,7 @@ class AccessionRow:
                         list(self.ACCEPTED_GENOME_BUILDS.keys()), conjunction="or",
                     )
                     msg += (
-                        "Consider replacing with one of the following:"
+                        " Accepted genome builds include the following:"
                         f" {accepted_genome_builds}."
                     )
                 self.errors.append(msg)

--- a/src/encoded/tests/data/inserts/file_format.json
+++ b/src/encoded/tests/data/inserts/file_format.json
@@ -9,7 +9,8 @@
         "uuid": "c13d06cf-218e-4f61-aaf0-91f226248b2c",
         "status": "shared",
         "valid_item_types": [
-            "FileFastq"
+            "FileFastq",
+            "FileSubmitted"
         ],
         "project": "12a92962-8265-4fc0-b2f8-cf14f05db58b",
         "institution": "hms-dbmi"

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -1125,7 +1125,7 @@ def test_format_ontology_term_with_colon(term, result):
         (["foo", "bar"], "or", "foo or bar"),
         (["foo", "bar", "fu"], None, "foo, bar, and fu"),
         (["foo", "bar", "fu"], "or", "foo, bar, or fu"),
-    ]
+    ],
 )
 def test_make_conjoined_list(items, conjunction, expected):
     """Test making readable, joined list of strings for error
@@ -1893,7 +1893,7 @@ class TestSubmittedFilesParser:
             (" foo_bar.txt", False),
             ("foo_bar.txt ", False),
             ("foo_bar_19", True),
-        ]
+        ],
     )
     def test_is_file_name_valid(self, file_parser, file_name, expected):
         """Test validation of file names with regex."""

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -1779,6 +1779,7 @@ class TestSubmittedFilesParser:
         [
             ("", None, 0, [], [], 0),
             ("foo.bar", None, 1, [], [], 1),
+            ("foo .bar", None, 1, [], [], 2),
             (VCF_FILE_PATH, None, 0, [VCF_FILE_ITEM], [VCF_FILE_ALIAS], 0),
             (
                 "foo.bar, " + VCF_FILE_PATH,
@@ -1879,6 +1880,25 @@ class TestSubmittedFilesParser:
         """Test parsing submitted file names."""
         result = file_parser.parse_file_names(submitted_file_names)
         assert result == set(expected)
+
+    @pytest.mark.parametrize(
+        "file_name,expected",
+        [
+            ("", False),
+            (" ", False),
+            ("foo-bar", True),
+            ("foo-bar.txt", True),
+            ("foo_bar", True),
+            ("foo bar", False),
+            (" foo_bar.txt", False),
+            ("foo_bar.txt ", False),
+            ("foo_bar_19", True),
+        ]
+    )
+    def test_is_file_name_valid(self, file_parser, file_name, expected):
+        """Test validation of file names with regex."""
+        result = file_parser.is_file_name_valid(file_name)
+        assert result == expected
 
     @pytest.mark.parametrize(
         "accepted_file_formats,expected",

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -20,6 +20,7 @@ from ..submit import (
     digest_xlsx,
     format_ontology_term_with_colon,
     get_column_name,
+    make_conjoined_list,
     map_fields,
     parse_exception,
     post_and_patch_all_items,
@@ -1114,6 +1115,24 @@ def test_get_column_name(row, columns, expected):
 )
 def test_format_ontology_term_with_colon(term, result):
     assert format_ontology_term_with_colon(term) == result
+
+
+@pytest.mark.parametrize(
+    "items,conjunction,expected",
+    [
+        ([], None, " "),
+        (["foo", "bar"], None, "foo and bar"),
+        (["foo", "bar"], "or", "foo or bar"),
+        (["foo", "bar", "fu"], None, "foo, bar, and fu"),
+        (["foo", "bar", "fu"], "or", "foo, bar, or fu"),
+    ]
+)
+def test_make_conjoined_list(items, conjunction, expected):
+    """Test making readable, joined list of strings for error
+    reporting.
+    """
+    result = make_conjoined_list(items, conjunction=conjunction)
+    assert result == expected
 
 
 class TestAccessionRow:


### PR DESCRIPTION
Here, we make some minor bug fixes to the submission code to remove errors around the use of `conjoined_list`. Also, we update an insert to permit FASTQ file submissions when default inserts loaded.