### PR TITLE
File Paired-end Property

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ cgap-portal
 Change Log
 ----------
 
+11.3.1
+======
+
+`PR 669: File Paired-end <https://github.com/dbmi-bgm/cgap-portal/pull/669>`_
+
+* Place paired-end property on abstract File item so available on all child classes
+
 11.3.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "11.3.0"
+version = "11.3.1"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -354,6 +354,15 @@
                 "GRCh38"
             ]
         },
+        "paired_end": {
+            "title": "Paired End Identifier",
+            "description": "Which pair the file belongs to (if paired end library)",
+            "type": "string",
+            "enum": [
+                "1",
+                "2"
+            ]
+        },
         "override_lab_name": {
             "description": "The lab that did the experiment if not the attributed Lab from whence this file",
             "type": "string",

--- a/src/encoded/schemas/file_fastq.json
+++ b/src/encoded/schemas/file_fastq.json
@@ -47,9 +47,6 @@
             "$ref": "mixins.json#/static_embeds"
         },
         {
-            "$ref": "mixins.json#/paired_end"
-        },
-        {
             "$ref": "file.json#/properties"
         }
     ],

--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -47,9 +47,6 @@
             "$ref": "mixins.json#/tags"
         },
         {
-            "$ref": "mixins.json#/paired_end"
-        },
-        {
             "$ref": "file.json#/properties"
         }
     ],

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -489,17 +489,6 @@
             }
         }
     },
-    "paired_end": {
-        "paired_end": {
-            "title": "Paired End Identifier",
-            "description": "Which pair the file belongs to (if paired end library)",
-            "type": "string",
-            "enum": [
-                "1",
-                "2"
-            ]
-        }
-    },
     "meta_workflow_runs": {
         "meta_workflow_runs": {
             "title": "MetaWorkflowRuns",


### PR DESCRIPTION
Here, we move the `paired_end` property onto the abstract File item so it is available to all child items.