### PR TITLE
Add Paired End Property to FASTQ on Submission

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 
 `PR 671: FASTQ submission paired end <https://github.com/dbmi-bgm/cgap-portal/pull/671>`_
 
-* Place paired-end property on abstract File item so available on all child classes
+* Add FASTQ paired-end property during file submission
 
 
 11.3.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ cgap-portal
 Change Log
 ----------
 
+11.3.2
+======
+
+`PR 671: FASTQ submission paired end <https://github.com/dbmi-bgm/cgap-portal/pull/671>`_
+
+* Place paired-end property on abstract File item so available on all child classes
+
+
 11.3.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "11.3.1"
+version = "11.3.2"
 description = "Clinical Genomics Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submit.py
+++ b/src/encoded/submit.py
@@ -1178,6 +1178,9 @@ class SubmittedFilesParser:
     STANDARD_FILE_EXTENSION = "standard_file_extension"
     OTHER_ALLOWED_EXTENSIONS = "other_allowed_extensions"
     GENOME_ASSEMBLY = "genome_assembly"
+    PAIRED_END = "paired_end"
+    PAIRED_END_1 = "1"
+    PAIRED_END_2 = "2"
     AT_ID = "@id"
 
     # Spreadsheet constants
@@ -1776,8 +1779,10 @@ class SubmittedFilesParser:
         for file_name, file_item in fastq_files.items():
             paired_end = self.get_paired_end_from_name(file_name)
             if paired_end == 1:
+                file_item[self.PAIRED_END] = self.PAIRED_END_1
                 fastq_paired_end_1[file_name] = file_item
             elif paired_end == 2:
+                file_item[self.PAIRED_END] = self.PAIRED_END_2
                 fastq_paired_end_2[file_name] = file_item
             else:
                 fastq_unknown_paired_end.append(file_name)

--- a/src/encoded/tests/test_submit.py
+++ b/src/encoded/tests/test_submit.py
@@ -105,11 +105,13 @@ FASTQ_FILE_ITEMS_NO_ERRORS = [
         "related_files": [
             {"relationship_type": "paired with", "file": FASTQ_FILE_NAME_1_R2_ALIAS},
         ],
+        "paired_end": "1",
     },
     {
         "aliases": [FASTQ_FILE_NAME_1_R2_ALIAS],
         "file_format": FILE_FORMAT_FASTQ,
         "filename": FASTQ_FILE_NAME_1_R2,
+        "paired_end": "2",
     },
 ]
 FASTQ_ALIASES_NO_ERRORS = [FASTQ_FILE_NAME_1_R1_ALIAS, FASTQ_FILE_NAME_1_R2_ALIAS]
@@ -118,6 +120,7 @@ FASTQ_FILE_ITEMS_ERRORS = FASTQ_FILE_ITEMS_NO_ERRORS + [
         "aliases": [FASTQ_FILE_NAME_UNMATCHED_ALIAS],
         "file_format": FILE_FORMAT_FASTQ,
         "filename": FASTQ_FILE_NAME_UNMATCHED,
+        "paired_end": "1",
     },
     {
         "aliases": [FASTQ_FILE_NAME_BAD_FORMAT_ALIAS],
@@ -2074,13 +2077,27 @@ class TestSubmittedFilesParser:
         return result
 
     @pytest.mark.parametrize(
-        "fastqs,expected_unknown_paired_end,expected_unpaired_fastqs",
+        (
+            "fastqs,expected_paired_ends,expected_unknown_paired_end,"
+            "expected_unpaired_fastqs"
+        ),
         [
-            (make_file_dicts_for_names(["foo.fastq.gz"]), ["foo.fastq.gz"], []),
-            (make_file_dicts_for_names(["foo_R1.fastq.gz"]), [], ["foo_R1.fastq.gz"]),
-            (make_file_dicts_for_names(["foo_R1.fastq.gz", "foo_R2.fastq.gz"]), [], []),
+            (make_file_dicts_for_names(["foo.fastq.gz"]), [None], ["foo.fastq.gz"], []),
+            (
+                make_file_dicts_for_names(["foo_R1.fastq.gz"]),
+                ["1"],
+                [],
+                ["foo_R1.fastq.gz"],
+            ),
+            (
+                make_file_dicts_for_names(["foo_R1.fastq.gz", "foo_R2.fastq.gz"]),
+                ["1", "2"],
+                [],
+                [],
+            ),
             (
                 make_file_dicts_for_names(["foo_R1.fastq.gz", "foo_r2.fastq.gz"]),
+                ["1", "2"],
                 [],
                 ["foo_R1.fastq.gz", "foo_r2.fastq.gz"],
             ),
@@ -2088,13 +2105,19 @@ class TestSubmittedFilesParser:
                 make_file_dicts_for_names(
                     ["foo_R1.fastq.gz", "bar_R1.fastq.gz", "foo_R2.fastq.gz"]
                 ),
+                ["1", "1", "2"],
                 [],
                 ["bar_R1.fastq.gz"],
             ),
         ],
     )
     def test_validate_and_pair_fastqs(
-        self, file_parser, fastqs, expected_unknown_paired_end, expected_unpaired_fastqs
+        self,
+        file_parser,
+        fastqs,
+        expected_paired_ends,
+        expected_unknown_paired_end,
+        expected_unpaired_fastqs,
     ):
         """Test paired-end identification and subsequent file pairing
         of FASTQs.
@@ -2105,6 +2128,9 @@ class TestSubmittedFilesParser:
         ) = file_parser.validate_and_pair_fastqs(fastqs)
         assert result_unknown_paired_end == expected_unknown_paired_end
         assert result_unpaired_fastqs == expected_unpaired_fastqs
+        assert len(fastqs) == len(expected_paired_ends)
+        for idx, file_item in enumerate(fastqs.values()):
+            assert file_item.get("paired_end") == expected_paired_ends[idx]
 
     @pytest.mark.parametrize(
         "file_name,expected",


### PR DESCRIPTION
Here, we update `submit.py` to add the `paired_end` property to submitted FASTQs. Determination of the paired end was included in a previous refactor of parsing submitted files, but this property addition was dropped accidentally at that time.