### PR TITLE
Corrected /auth0_config endpoint to return array for allowedConnections

### DIFF
--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -137,6 +137,12 @@ def main(global_config, **local_config):
     settings['auth0.allowed_connections'] = settings.get('auth0.allowed_connections',  # comma separated string
                                                          os.environ.get('Auth0AllowedConnections',
                                                                         DEFAULT_AUTH0_ALLOWED_CONNECTIONS).split(','))
+
+    # Comma separated string (typically in GAC e.g. ENCODED_AUTH0_ALLOWED_CONNECTIONS),
+    # e.g.: google-oauth2,github,hms-it,partners (changed July 2023).
+    if isinstance(settings['auth0.allowed_connections'], str):
+        settings['auth0.allowed_connections'] = settings['auth0.allowed_connections'].split(",")
+
     settings['auth0.options'] = {
         'auth': {
             'sso': False,


### PR DESCRIPTION
This correction ensures that the 'allowedConnections' property of the /auth0_config endpoint is an array; split on a comma-separated string (typically in GAC as 'ENCODED_AUTH0_ALLOWED_CONNECTIONS').