### PR TITLE
Fix in submit.py for new error message from snovault.schema_validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ cgap-portal
 Change Log
 ----------
 
+14.2.1
+======
+
+* Fix in ``parse_exception`` in ``submit.py`` to catch/ignore additional/new
+  error message from ``normalize_links`` in ``snovault/schema_validation.py``;
+  manifested as error from ``submit-metadata``.
+
+
 14.2.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "14.2.0"
+version = "14.2.0.1b1"  # TODO: To become 14.2.1
 description = "Computational Genome Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Fix in parse_exception in submit.py to catch/ignore additional/new error message from normalize_links in snovault/schema_validation.py; manifested as error from submit-metadata.
