### PR TITLE
Modernize README (C4-1037)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ cgap-portal
 Change Log
 ----------
 
+14.2.3
+======
+
+* Update README.rst
+
+
 14.2.2
 ======
 `PR 741: Style updates for cgap-portal item-pages <https://github.com/dbmi-bgm/cgap-portal/pull/741>`_

--- a/README.rst
+++ b/README.rst
@@ -3,38 +3,56 @@
 ========================
 
 .. image:: https://github.com/dbmi-bgm/cgap-portal/actions/workflows/main.yml/badge.svg
+   :target: https://github.com/dbmi-bgm/cgap-portal/actions
+   :alt: Build Status
+
+.. image:: https://coveralls.io/repos/github/dbmi-bgm/cgap-portal/badge.svg
+    :target: https://coveralls.io/github/dbmi-bgm/cgap-portal
+    :alt: Coverage Percentage
 
 .. image:: https://readthedocs.org/projects/cgap-portal/badge/?version=latest
+   :target: https://cgap-portal.readthedocs.io/en/latest/
+   :alt: Documentation Status
 
 .. image:: https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiVjRJaE5DeHE3a0tjcGcwb01FaDZvSU5Id056amkwazV0UWlJM29IaEM2VWVlMm5INjhKS1dMVTRCMVAwSVl0RmFJR05zOHVHZUFrWStKdzBaV0VKZm04PSIsIml2UGFyYW1ldGVyU3BlYyI6Im1mMVFVOW10dFltQ2dLQkIiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master
+   :alt: CodeBuild Status
 
 
-Welcome to CGAP! We are a team of scientists, clinicians, and developers who aim to streamline the clinical genetics workflow. The following locations are different deployments of our data portal:
+Welcome to CGAP!
+================
 
-* `Production  <http://cgap.hms.harvard.edu/>`_ for the stable release
-* `cgapdev <http://fourfront-cgapdev.9wzadzju3p.us-east-1.elasticbeanstalk.com/>`_ for data model and back-end development
-* `cgaptest <http://fourfront-cgaptest.9wzadzju3p.us-east-1.elasticbeanstalk.com/>`_ for front-end and UX development
-* `cgapwolf <http://fourfront-cgapwolf.9wzadzju3p.us-east-1.elasticbeanstalk.com/>`_ for workflow development
+We are a team of scientists, clinicians, and developers
+who aim to streamline the clinical genetics workflow.
 
-Be warned that features are under active development and may not be stable! Visit the production deployment for the best experience. For installation and more information on getting started, see our `documentation page <https://cgap-portal.readthedocs.io/en/latest/index.html>`_.
+* For useful information about CGAP's features,
+  see `the CGAP informational site <https://cgap.hms.harvard.edu>`_.
 
-Note that at this time, CGAP is operating in hybrid model where some environments are deployed to AWS ElasticBeanstalk and others are deployed to AWS Elastic Container Service. The BS deployments are referred to as "legacy deployments" and the ECS deployments are referred to as "alpha deployments".
+* CGAP is orchestrated technology capable of being easily deployed
+  in hospital setting. Our flagship site is
+  `CGAP-MGB <https://cgap-mgb.hms.harvard.edu">`_.
 
-For information on how to run CGAP with Docker, see `here. <./docs/source/docker-local.rst>`_
+  For information on how to set your hospital up to use this technology,
+  `contact us <mailto:cgap-support@hms-dbmi.atlassian.net>`_.
 
-For information on CGAP-Docker in production, see `here. <./docs/source/docker-production.rst>`_
+* CGAP is an open source system under continuous development.
+  For documentation, see
+  `the CGAP Portal page at ReadTheDocs
+   <https://cgap-portal.readthedocs.io/en/latest/>`_.
 
-Navigating this Repository
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+* For information about governance and other policies, see
+  `the CGAP Governance repository
+  <https://github.com/dbmi-bgm/cgap-governance>`_.
 
-Important directories/files are outlined below.
+
+Repository Structure
+--------------------
+
+These are some important files and directories you might want to be aware of:
 
     * ``.github/workflows/`` contains Github Action Workflows
-    * ``.ebextensions/`` contains the Elastic Beanstalk provisioning scripts
-    * ``bin/`` contains the few remaining executables
+    * ``bin/`` contains a few legacy scripts, though most are in ``scripts/``
     * ``deploy/docker`` contains containerization related scripts/configuration
     * ``docs/ contains`` documentation
-    * ``parts/`` contains WSGI entry points for the Beanstalk setup
     * ``scripts/`` contains misc scripts
     * ``src/encoded/`` where the code is
     * ``.dockerignore`` specifies paths ignored by the Dockerfile
@@ -45,8 +63,9 @@ Important directories/files are outlined below.
     * ``pyproject.toml`` and ``poetry.lock`` specify the back-end dependencies
     * ``setup_eb.py`` performs final installation setup
 
-Navigating src/encoded/
-^^^^^^^^^^^^^^^^^^^^^^^
+
+Navigating core functionality (src/encoded/)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Top level files are modules that make up the core functionality of the back-end. Some modules differ greatly from or do
 not even exist in fourfront. Directories are outlined below.
@@ -61,3 +80,18 @@ not even exist in fourfront. Directories are outlined below.
     * ``tests/`` contains back-end unit tests and insert data
     * ``types/`` contains metadata type definitions
     * ``upgrade/`` contains collection schema version upgraders - are not functioning as intended currently
+
+
+Related Repositories
+~~~~~~~~~~~~~~~~~~~~
+
+Note that ``cgap-portal`` is bound on supporting functionality
+in numerous libaries, but importantly:
+
+    * **dcicsnovault**
+      [`pypi library <https://pypi.org/project/dcicsnovault/>`_]
+      [`source repo <https://github.com/4dn-dcic/snovault>`_]
+
+    * **dcicutils**
+      [`pypi library <https://pypi.org/project/dcicutils/>`_]
+      [`source repo <https://github.com/4dn-dcic/utils>`_]

--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,11 @@
    :target: https://cgap-portal.readthedocs.io/en/latest/
    :alt: Documentation Status
 
-.. image:: https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiMWtFYjJTeXkzcXZVYkpmbkd3VUlOQ0pSTnlLRGloVENJcitGS1g1RTV1THgxQkc3M2tDY0NFUFUxOXRBeS92dUNtbXdRZU5YWEkzbUhaMm1lUlNDZ2NZPSIsIml2UGFyYW1ldGVyU3BlYyI6Ijl6OUZkY3JvaWlyZDduUnEiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master
-   :alt: CodeBuild Status
-
 
 Welcome to CGAP!
 ================
+
+CGAP is the Computational Genome Analysis Platform.
 
 We are a team of scientists, clinicians, and developers
 who aim to streamline the clinical genetics workflow.
@@ -37,7 +36,7 @@ who aim to streamline the clinical genetics workflow.
 * CGAP is an open source system under continuous development.
   For documentation, see
   `the CGAP Portal page at ReadTheDocs
-   <https://cgap-portal.readthedocs.io/en/latest/>`_.
+  <https://cgap-portal.readthedocs.io/en/latest/>`_.
 
 * For information about governance and other policies, see
   `the CGAP Governance repository
@@ -49,19 +48,19 @@ Repository Structure
 
 These are some important files and directories you might want to be aware of:
 
-    * ``.github/workflows/`` contains Github Action Workflows
-    * ``bin/`` contains a few legacy scripts, though most are in ``scripts/``
-    * ``deploy/docker`` contains containerization related scripts/configuration
-    * ``docs/ contains`` documentation
-    * ``scripts/`` contains misc scripts
-    * ``src/encoded/`` where the code is
-    * ``.dockerignore`` specifies paths ignored by the Dockerfile
-    * ``Dockerfile`` contains the Docker build instructions for the cgap-portal - see ``docker-production.rst``
-    * ``Makefile`` contains macros for common build operations - see ``make info``
-    * ``docker-compose.yml`` builds the new local deployment - see ``docker-local.rst``
-    * ``package.json`` and ``package-lock.json`` specify the front-end dependencies
-    * ``pyproject.toml`` and ``poetry.lock`` specify the back-end dependencies
-    * ``setup_eb.py`` performs final installation setup
+* ``.dockerignore`` specifies paths ignored by the Dockerfile
+* ``.github/workflows/`` contains Github Action Workflows
+* ``bin/`` contains a few legacy scripts, though most are in ``scripts/``
+* ``deploy/docker`` contains containerization related scripts/configuration
+* ``docker-compose.yml`` builds the new local deployment (see ``docker-local.rst``)
+* ``Dockerfile`` contains the Docker build instructions for the cgap-portal (see ``docker-production.rst``)
+* ``docs/ contains`` documentation
+* ``Makefile`` contains macros for common build operations (see ``make info``)
+* ``package.json`` and ``package-lock.json`` specify the front-end dependencies
+* ``pyproject.toml`` and ``poetry.lock`` specify the back-end dependencies
+* ``scripts/`` contains misc scripts
+* ``setup_eb.py`` performs final installation setup
+* ``src/encoded/`` where the code is
 
 
 Navigating core functionality (src/encoded/)
@@ -70,16 +69,16 @@ Navigating core functionality (src/encoded/)
 Top level files are modules that make up the core functionality of the back-end. Some modules differ greatly from or do
 not even exist in fourfront. Directories are outlined below.
 
-    * ``annotations/`` contains mapping table and ingestion related metadata
-    * ``commands/`` contains Python commands that can be run on the system from the command line
-    * ``docs/`` contains ReadTheDocs documentation
-    * ``ingestion/`` contains ingestion related code, such as mapping table intake and VCF processing
-    * ``schemas/`` contains the metadata schemas
-    * ``search/`` contains the search/filter_set APIs
-    * ``static/`` contains front-end code
-    * ``tests/`` contains back-end unit tests and insert data
-    * ``types/`` contains metadata type definitions
-    * ``upgrade/`` contains collection schema version upgraders
+* ``annotations/`` contains mapping table and ingestion related metadata
+* ``commands/`` contains Python commands that can be run on the system from the command line
+* ``docs/`` contains ReadTheDocs documentation
+* ``ingestion/`` contains ingestion related code, such as mapping table intake and VCF processing
+* ``schemas/`` contains the metadata schemas
+* ``search/`` contains the search/filter_set APIs
+* ``static/`` contains front-end code
+* ``tests/`` contains back-end unit tests and insert data
+* ``types/`` contains metadata type definitions
+* ``upgrade/`` contains collection schema version upgraders
 
 
 Related Repositories
@@ -88,10 +87,10 @@ Related Repositories
 Note that ``cgap-portal`` is bound on supporting functionality
 in numerous libaries, but importantly:
 
-    * **dcicsnovault**
-      [`pypi library <https://pypi.org/project/dcicsnovault/>`_]
-      [`source repo <https://github.com/4dn-dcic/snovault>`_]
+* **dcicsnovault**
+  [`pypi library <https://pypi.org/project/dcicsnovault/>`_]
+  [`source repo <https://github.com/4dn-dcic/snovault>`_]
 
-    * **dcicutils**
-      [`pypi library <https://pypi.org/project/dcicutils/>`_]
-      [`source repo <https://github.com/4dn-dcic/utils>`_]
+* **dcicutils**
+  [`pypi library <https://pypi.org/project/dcicutils/>`_]
+  [`source repo <https://github.com/4dn-dcic/utils>`_]

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
    :target: https://cgap-portal.readthedocs.io/en/latest/
    :alt: Documentation Status
 
-.. image:: https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiVjRJaE5DeHE3a0tjcGcwb01FaDZvSU5Id056amkwazV0UWlJM29IaEM2VWVlMm5INjhKS1dMVTRCMVAwSVl0RmFJR05zOHVHZUFrWStKdzBaV0VKZm04PSIsIml2UGFyYW1ldGVyU3BlYyI6Im1mMVFVOW10dFltQ2dLQkIiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master
+.. image:: https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiMWtFYjJTeXkzcXZVYkpmbkd3VUlOQ0pSTnlLRGloVENJcitGS1g1RTV1THgxQkc3M2tDY0NFUFUxOXRBeS92dUNtbXdRZU5YWEkzbUhaMm1lUlNDZ2NZPSIsIml2UGFyYW1ldGVyU3BlYyI6Ijl6OUZkY3JvaWlyZDduUnEiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master
    :alt: CodeBuild Status
 
 
@@ -79,7 +79,7 @@ not even exist in fourfront. Directories are outlined below.
     * ``static/`` contains front-end code
     * ``tests/`` contains back-end unit tests and insert data
     * ``types/`` contains metadata type definitions
-    * ``upgrade/`` contains collection schema version upgraders - are not functioning as intended currently
+    * ``upgrade/`` contains collection schema version upgraders
 
 
 Related Repositories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "14.2.2"
+version = "14.2.3"
 description = "Computational Genome Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This overhauls the [README.rst](https://github.com/dbmi-bgm/cgap-portal/blob/kmp_update_readme/README.rst) in various ways:

* Add a reference to new `cgap-governance` repo.
* Clean up some of the structure and text.
* Remove stale references to beanstalks.
* Remove stale references to beanstalk deployment environments.

