### PR TITLE
Fixed up data for previous removal of Dana's user record.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ cgap-portal
 Change Log
 ----------
 
+15.1.1
+======
+* 2023-10-24
+* Change references to Dana's email address (dvuzman@research.bwh.harvard.edu) in
+  tests/data/inserts/institution.json to an existing one, since it was previously
+  removed from tests/data/master-inserts/user.json; make deploy1 fails without this.
+
+
 15.1.0
 ======
 `PR 737: Add notes for Case items <https://github.com/dbmi-bgm/cgap-portal/pull/737>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "15.1.0"
+version = "15.1.1"
 description = "Computational Genome Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/data/inserts/institution.json
+++ b/src/encoded/tests/data/inserts/institution.json
@@ -31,13 +31,13 @@
         "status": "shared",
         "phone1": "000-000-0000",
         "phone2": "000-000-0000",
-        "pi": "william_ronchetti@hms.harvard.edu",
+        "pi": "peter_park@hms.harvard.edu",
         "postal_code": "02115",
         "state": "MA",
         "title": "BCH",
         "uuid": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca765",
         "contact_persons": [
-            "william_ronchetti@hms.harvard.edu"
+            "peter_park@hms.harvard.edu"
         ]
     },
     {

--- a/src/encoded/tests/data/inserts/institution.json
+++ b/src/encoded/tests/data/inserts/institution.json
@@ -31,13 +31,13 @@
         "status": "shared",
         "phone1": "000-000-0000",
         "phone2": "000-000-0000",
-        "pi": "dvuzman@research.bwh.harvard.edu",
+        "pi": "william_ronchetti@hms.harvard.edu",
         "postal_code": "02115",
         "state": "MA",
         "title": "BCH",
         "uuid": "828cd4fe-ebb0-4b36-ccbb-d2e3a36ca765",
         "contact_persons": [
-            "dvuzman@research.bwh.harvard.edu"
+            "william_ronchetti@hms.harvard.edu"
         ]
     },
     {


### PR DESCRIPTION
Someone removed Dana's user record from master inserts, but there was still a reference to it in another data file; without this fix make deploy1 fails on inserts.