### PR TITLE
New base image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ cgap-portal
 Change Log
 ----------
 
+16.3.0
+======
+
+* New base image
+
+
 16.2.0
 ======
 `PR 778: SN Add user <https://github.com/dbmi-bgm/cgap-portal/pull/778>`_

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # CGAP-Portal (Production) Dockerfile
 
 # Bullseye with Python 3.11.5
+# 2026-02-24: Update docker image to a Python 3.11.12 version;
 # 2023-09-28: Update docker image to a Python 3.11 version;
 # this was previously: FROM python:3.8.13-slim-buster
-FROM python:3.11.5-slim-bullseye
+FROM python:3.11.12-slim-bullseye
 
 MAINTAINER William Ronchetti "william_ronchetti@hms.harvard.edu"
 

--- a/deploy/docker/production/install_nginx_bullseye.sh
+++ b/deploy/docker/production/install_nginx_bullseye.sh
@@ -32,11 +32,11 @@ set -x \
     " \
     && case "$dpkgArch" in \
         amd64|arm64) \
-            echo "deb https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
+            echo "deb [ trusted=yes ]  https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \
             ;; \
         *) \
-            echo "deb-src https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
+            echo "deb-src [ trusted=yes ]  https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
             \
             && tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "cgap-portal".
 name = "encoded"
-version = "16.2.0"
+version = "16.3.0"
 description = "Computational Genome Analysis Platform"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Upgrade to `python:3.11.12-slim-bullseye` due to build issues of the older patch version.